### PR TITLE
feat: Add Cagan button with Cat Facts API integration

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,6 +11,9 @@ document.addEventListener("DOMContentLoaded", function () {
 
     var btn = document.createElement("button");
     btn.textContent = label;
+    if (label === "Cagan") {
+      btn.classList.add("cagan-btn");
+    }
     btn.addEventListener("click", handler);
     grid.appendChild(btn);
   }

--- a/config.js
+++ b/config.js
@@ -5,7 +5,7 @@
  * Update BUTTON_LABELS to set the text displayed on each button.
  */
 
-const NUM_BUTTONS = 5;
+const NUM_BUTTONS = 6;
 
 const BUTTON_LABELS = [
   "Button 1",
@@ -13,4 +13,5 @@ const BUTTON_LABELS = [
   "Button 3",
   "Button 4",
   "Button 5",
+  "Cagan",
 ];

--- a/handlers.js
+++ b/handlers.js
@@ -24,3 +24,21 @@ function onButton4Click() {
 function onButton5Click() {
   console.log("Button 5 clicked -- implement me!");
 }
+
+function onButton6Click() {
+  var resultBox = document.getElementById("cagan-result");
+  resultBox.style.display = "block";
+  resultBox.textContent = "Loading...";
+
+  fetch("https://catfact.ninja/fact")
+    .then(function (response) {
+      return response.json();
+    })
+    .then(function (data) {
+      resultBox.innerHTML =
+        '<strong>🐱 Cagan\'s Cat Fact:</strong><br>' + data.fact;
+    })
+    .catch(function (error) {
+      resultBox.textContent = "Error: " + error.message;
+    });
+}

--- a/index.html
+++ b/index.html
@@ -74,6 +74,29 @@
     #button-grid button:active {
       background-color: #3730a3;
     }
+
+    #button-grid button.cagan-btn {
+      background: linear-gradient(135deg, #f97316, #ef4444);
+      font-weight: 700;
+      letter-spacing: 0.5px;
+    }
+
+    #button-grid button.cagan-btn:hover {
+      background: linear-gradient(135deg, #ea580c, #dc2626);
+      box-shadow: 0 4px 12px rgba(249, 115, 22, 0.4);
+    }
+
+    #cagan-result {
+      display: none;
+      margin-top: 24px;
+      padding: 16px 20px;
+      background: #fef3c7;
+      border-left: 4px solid #f97316;
+      border-radius: 8px;
+      color: #1e293b;
+      font-size: 0.95rem;
+      line-height: 1.6;
+    }
   </style>
 </head>
 <body>
@@ -81,6 +104,7 @@
     <h1>Stub App</h1>
     <p>Click a button to trigger its handler function.</p>
     <div id="button-grid"></div>
+    <div id="cagan-result"></div>
   </div>
 
   <script src="config.js"></script>


### PR DESCRIPTION
## Summary

- Add a new **Cagan** button (6th button) to the button grid in `config.js`
- Implement `onButton6Click` handler in `handlers.js` that fetches a random cat fact from the [Cat Facts API](https://catfact.ninja/fact) on each click
- Display the fetched cat fact in a styled result box below the button grid
- Style the Cagan button with a distinctive orange-to-red gradient to set it apart from the other buttons

## Test plan

- [ ] Open `index.html` in a browser
- [ ] Verify a 6th button labeled **Cagan** appears in the grid with an orange-red gradient
- [ ] Click the Cagan button and confirm a cat fact appears in the result box below
- [ ] Click multiple times to verify a new random fact loads each time
- [ ] Confirm other buttons (1–5) are unaffected