### PR TITLE
feat(mobile): add login and register flows with validation

### DIFF
--- a/app/mobile/App.tsx
+++ b/app/mobile/App.tsx
@@ -1,12 +1,15 @@
 import { NavigationContainer } from '@react-navigation/native';
 import { StatusBar } from 'expo-status-bar';
+import { AuthProvider } from './src/context/AuthContext';
 import { PublicStackNavigator } from './src/navigation/PublicStackNavigator';
 
 export default function App() {
   return (
-    <NavigationContainer>
-      <StatusBar style="auto" />
-      <PublicStackNavigator />
-    </NavigationContainer>
+    <AuthProvider>
+      <NavigationContainer>
+        <StatusBar style="auto" />
+        <PublicStackNavigator />
+      </NavigationContainer>
+    </AuthProvider>
   );
 }

--- a/app/mobile/README.md
+++ b/app/mobile/README.md
@@ -20,3 +20,13 @@ These screens are reachable without signing in, aligned with public routes in `a
 | Story detail  | `/stories/:id`   | Mock data; linked recipe → recipe screen |
 
 Mock data lives under `src/mocks/`. Replace with `services/*` calls when the backend is wired.
+
+## Auth UI (login / register)
+
+Aligned with `app/frontend/src/pages/LoginPage.jsx` and `RegisterPage.jsx`:
+
+- **Login:** email + password; client validation (required + email format). Submit uses `src/services/mockAuthService.ts` (no real API). Success stores user + token via `AuthContext` and `AsyncStorage` (like web `localStorage`).
+- **Register:** username + email + password; same required fields as web plus password minimum length (8) and email format. Mock register; use username `taken` to simulate failure.
+- **Mock failures:** login with password `wrong` or email containing `fail@` → error message like web API errors.
+
+Swap `mockLoginRequest` / `mockRegisterRequest` for HTTP calls matching `app/frontend/src/services/authService.js` when the backend is available.

--- a/app/mobile/package-lock.json
+++ b/app/mobile/package-lock.json
@@ -1,13 +1,14 @@
 {
-  "name": "mobile",
+  "name": "group12-mobile",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "mobile",
+      "name": "group12-mobile",
       "version": "1.0.0",
       "dependencies": {
+        "@react-native-async-storage/async-storage": "1.23.1",
         "@react-navigation/native": "^7.2.2",
         "@react-navigation/native-stack": "^7.14.10",
         "expo": "~52.0.0",
@@ -3095,6 +3096,18 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "1.23.1",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.23.1.tgz",
+      "integrity": "sha512-Qd2kQ3yi6Y3+AcUlrHxSLlnBvpdCEMVGFlVBneVOjaFaPU61g1huc38g339ysXspwY1QZA2aNhrk/KlHGO+ewA==",
+      "license": "MIT",
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.60 <1.0"
       }
     },
     "node_modules/@react-native-community/cli": {
@@ -7818,6 +7831,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
@@ -8852,6 +8874,18 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
       "license": "MIT"
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",

--- a/app/mobile/package.json
+++ b/app/mobile/package.json
@@ -9,6 +9,7 @@
     "web": "expo start --web"
   },
   "dependencies": {
+    "@react-native-async-storage/async-storage": "1.23.1",
     "@react-navigation/native": "^7.2.2",
     "@react-navigation/native-stack": "^7.14.10",
     "expo": "~52.0.0",

--- a/app/mobile/src/context/AuthContext.tsx
+++ b/app/mobile/src/context/AuthContext.tsx
@@ -1,0 +1,81 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import type { AuthUser } from '../services/mockAuthService';
+
+const TOKEN_KEY = 'token';
+const USER_KEY = 'user';
+
+export type AuthContextValue = {
+  user: AuthUser | null;
+  token: string | null;
+  isReady: boolean;
+  login: (userData: AuthUser, accessToken: string) => Promise<void>;
+  logout: () => Promise<void>;
+};
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [token, setToken] = useState<string | null>(null);
+  const [isReady, setIsReady] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const [t, uJson] = await Promise.all([
+          AsyncStorage.getItem(TOKEN_KEY),
+          AsyncStorage.getItem(USER_KEY),
+        ]);
+        if (cancelled) return;
+        if (t) setToken(t);
+        if (uJson) setUser(JSON.parse(uJson) as AuthUser);
+      } catch {
+        // ignore corrupt storage
+      } finally {
+        if (!cancelled) setIsReady(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const login = useCallback(async (userData: AuthUser, accessToken: string) => {
+    setUser(userData);
+    setToken(accessToken);
+    await AsyncStorage.multiSet([
+      [TOKEN_KEY, accessToken],
+      [USER_KEY, JSON.stringify(userData)],
+    ]);
+  }, []);
+
+  const logout = useCallback(async () => {
+    setUser(null);
+    setToken(null);
+    await AsyncStorage.multiRemove([TOKEN_KEY, USER_KEY]);
+  }, []);
+
+  const value = useMemo(
+    () => ({ user, token, isReady, login, logout }),
+    [user, token, isReady, login, logout]
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth(): AuthContextValue {
+  const ctx = useContext(AuthContext);
+  if (!ctx) {
+    throw new Error('useAuth must be used within AuthProvider');
+  }
+  return ctx;
+}

--- a/app/mobile/src/lib/authValidation.ts
+++ b/app/mobile/src/lib/authValidation.ts
@@ -1,0 +1,45 @@
+/**
+ * Client-side validation for auth forms.
+ * Web (`LoginPage` / `RegisterPage`) only checks required fields; mobile adds light format rules.
+ */
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export type LoginFieldErrors = Partial<Record<'email' | 'password', string>>;
+export type RegisterFieldErrors = Partial<
+  Record<'username' | 'email' | 'password', string>
+>;
+
+export function isValidEmail(value: string): boolean {
+  return EMAIL_RE.test(value.trim());
+}
+
+const PASSWORD_MIN_LENGTH = 8;
+
+export function validateLoginForm(email: string, password: string): LoginFieldErrors {
+  const errs: LoginFieldErrors = {};
+  const e = email.trim();
+  if (!e) errs.email = 'Email is required';
+  else if (!isValidEmail(e)) errs.email = 'Enter a valid email address';
+  if (!password) errs.password = 'Password is required';
+  return errs;
+}
+
+export function validateRegisterForm(
+  username: string,
+  email: string,
+  password: string
+): RegisterFieldErrors {
+  const errs: RegisterFieldErrors = {};
+  const u = username.trim();
+  const em = email.trim();
+  if (!u) errs.username = 'Username is required';
+  else if (u.length < 2) errs.username = 'Username must be at least 2 characters';
+  if (!em) errs.email = 'Email is required';
+  else if (!isValidEmail(em)) errs.email = 'Enter a valid email address';
+  if (!password) errs.password = 'Password is required';
+  else if (password.length < PASSWORD_MIN_LENGTH) {
+    errs.password = `Password must be at least ${PASSWORD_MIN_LENGTH} characters`;
+  }
+  return errs;
+}

--- a/app/mobile/src/navigation/PublicStackNavigator.tsx
+++ b/app/mobile/src/navigation/PublicStackNavigator.tsx
@@ -1,6 +1,8 @@
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import HomeScreen from '../screens/HomeScreen';
+import LoginScreen from '../screens/LoginScreen';
 import RecipeDetailScreen from '../screens/RecipeDetailScreen';
+import RegisterScreen from '../screens/RegisterScreen';
 import SearchScreen from '../screens/SearchScreen';
 import StoryDetailScreen from '../screens/StoryDetailScreen';
 import type { RootStackParamList } from './types';
@@ -8,8 +10,7 @@ import type { RootStackParamList } from './types';
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
 /**
- * Public routes only — mirrors web `App.js` routes that are not wrapped in `ProtectedRoute`.
- * Auth-gated screens are added in a later milestone.
+ * Public routes — mirrors web `App.js` routes outside `ProtectedRoute`, including `/login` and `/register`.
  */
 export function PublicStackNavigator() {
   return (
@@ -18,6 +19,16 @@ export function PublicStackNavigator() {
         name="Home"
         component={HomeScreen}
         options={{ title: 'Home' }}
+      />
+      <Stack.Screen
+        name="Login"
+        component={LoginScreen}
+        options={{ title: 'Log In' }}
+      />
+      <Stack.Screen
+        name="Register"
+        component={RegisterScreen}
+        options={{ title: 'Register' }}
       />
       <Stack.Screen
         name="Search"

--- a/app/mobile/src/navigation/types.ts
+++ b/app/mobile/src/navigation/types.ts
@@ -1,5 +1,7 @@
 export type RootStackParamList = {
   Home: undefined;
+  Login: undefined;
+  Register: undefined;
   Search: undefined;
   RecipeDetail: { id: string };
   StoryDetail: { id: string };

--- a/app/mobile/src/screens/HomeScreen.tsx
+++ b/app/mobile/src/screens/HomeScreen.tsx
@@ -1,47 +1,85 @@
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { useAuth } from '../context/AuthContext';
 import type { RootStackParamList } from '../navigation/types';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Home'>;
 
 export default function HomeScreen({ navigation }: Props) {
+  const { user, token, logout } = useAuth();
+
   return (
     <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
       <View style={styles.container}>
-        <Text style={styles.heading} accessibilityRole="header">
-          Home
-        </Text>
-        <Text style={styles.lead}>
-          Public routes: Home, Search, Recipe detail, Story detail (no sign-in required).
-        </Text>
+        <View style={styles.main}>
+          <Text style={styles.heading} accessibilityRole="header">
+            Home
+          </Text>
+          <Text style={styles.lead}>
+            Public routes: Home, Search, Recipe detail, Story detail (no sign-in required).
+          </Text>
 
-        <Pressable
-          style={({ pressed }) => [styles.button, pressed && styles.buttonPressed]}
-          onPress={() => navigation.navigate('Search')}
-          accessibilityRole="button"
-          accessibilityLabel="Go to Search"
-        >
-          <Text style={styles.buttonText}>Search</Text>
-        </Pressable>
+          <Pressable
+            style={({ pressed }) => [styles.button, pressed && styles.buttonPressed]}
+            onPress={() => navigation.navigate('Search')}
+            accessibilityRole="button"
+            accessibilityLabel="Go to Search"
+          >
+            <Text style={styles.buttonText}>Search</Text>
+          </Pressable>
 
-        <Pressable
-          style={({ pressed }) => [styles.button, pressed && styles.buttonPressed]}
-          onPress={() => navigation.navigate('RecipeDetail', { id: '1' })}
-          accessibilityRole="button"
-          accessibilityLabel="Open sample recipe"
-        >
-          <Text style={styles.buttonText}>Sample recipe (id 1)</Text>
-        </Pressable>
+          <Pressable
+            style={({ pressed }) => [styles.button, pressed && styles.buttonPressed]}
+            onPress={() => navigation.navigate('RecipeDetail', { id: '1' })}
+            accessibilityRole="button"
+            accessibilityLabel="Open sample recipe"
+          >
+            <Text style={styles.buttonText}>Sample recipe (id 1)</Text>
+          </Pressable>
 
-        <Pressable
-          style={({ pressed }) => [styles.button, pressed && styles.buttonPressed]}
-          onPress={() => navigation.navigate('StoryDetail', { id: '1' })}
-          accessibilityRole="button"
-          accessibilityLabel="Open sample story"
-        >
-          <Text style={styles.buttonText}>Sample story (id 1)</Text>
-        </Pressable>
+          <Pressable
+            style={({ pressed }) => [styles.button, pressed && styles.buttonPressed]}
+            onPress={() => navigation.navigate('StoryDetail', { id: '1' })}
+            accessibilityRole="button"
+            accessibilityLabel="Open sample story"
+          >
+            <Text style={styles.buttonText}>Sample story (id 1)</Text>
+          </Pressable>
+        </View>
+
+        <View style={styles.authFooter}>
+          {token && user ? (
+            <>
+              <Text style={styles.signedInText}>Signed in as {user.username}</Text>
+              <Pressable
+                onPress={() => void logout()}
+                accessibilityRole="button"
+                accessibilityLabel="Log out"
+              >
+                <Text style={styles.link}>Log out</Text>
+              </Pressable>
+            </>
+          ) : (
+            <View style={styles.authRow}>
+              <Pressable
+                onPress={() => navigation.navigate('Login')}
+                accessibilityRole="button"
+                accessibilityLabel="Go to Log In"
+              >
+                <Text style={styles.link}>Log In</Text>
+              </Pressable>
+              <Text style={styles.authSep}> · </Text>
+              <Pressable
+                onPress={() => navigation.navigate('Register')}
+                accessibilityRole="button"
+                accessibilityLabel="Go to Register"
+              >
+                <Text style={styles.link}>Register</Text>
+              </Pressable>
+            </View>
+          )}
+        </View>
       </View>
     </SafeAreaView>
   );
@@ -52,6 +90,9 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     padding: 20,
+  },
+  main: {
+    flex: 1,
     justifyContent: 'center',
   },
   heading: {
@@ -80,4 +121,15 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: '600',
   },
+  authFooter: {
+    paddingTop: 16,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: '#e2e8f0',
+    alignItems: 'center',
+    gap: 8,
+  },
+  authRow: { flexDirection: 'row', flexWrap: 'wrap', alignItems: 'center' },
+  authSep: { fontSize: 15, color: '#94a3b8' },
+  link: { fontSize: 15, color: '#2563eb', fontWeight: '600' },
+  signedInText: { fontSize: 15, color: '#64748b' },
 });

--- a/app/mobile/src/screens/LoginScreen.tsx
+++ b/app/mobile/src/screens/LoginScreen.tsx
@@ -1,0 +1,183 @@
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { CommonActions } from '@react-navigation/native';
+import { useState } from 'react';
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useAuth } from '../context/AuthContext';
+import { validateLoginForm } from '../lib/authValidation';
+import type { RootStackParamList } from '../navigation/types';
+import { mockLoginRequest } from '../services/mockAuthService';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'Login'>;
+
+export default function LoginScreen({ navigation }: Props) {
+  const { login } = useAuth();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [apiError, setApiError] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleSubmit() {
+    const errs = validateLoginForm(email, password);
+    if (Object.keys(errs).length > 0) {
+      setErrors(errs);
+      return;
+    }
+    setErrors({});
+    setApiError('');
+    setSubmitting(true);
+    try {
+      const data = await mockLoginRequest(email, password);
+      await login(data.user, data.access);
+      navigation.dispatch(
+        CommonActions.reset({
+          index: 0,
+          routes: [{ name: 'Home' }],
+        })
+      );
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Login failed';
+      setApiError(message);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
+      <KeyboardAvoidingView
+        style={styles.flex}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
+        <ScrollView
+          keyboardShouldPersistTaps="handled"
+          contentContainerStyle={styles.scrollContent}
+        >
+          <Text style={styles.heading} accessibilityRole="header">
+            Log In
+          </Text>
+
+          <View style={styles.field}>
+            <Text style={styles.label} nativeID="login-email-label">
+              Email
+            </Text>
+            <TextInput
+              style={styles.input}
+              value={email}
+              onChangeText={setEmail}
+              keyboardType="email-address"
+              autoCapitalize="none"
+              autoCorrect={false}
+              editable={!submitting}
+              accessibilityLabel="Email"
+              accessibilityLabelledBy="login-email-label"
+            />
+            {errors.email ? <Text style={styles.fieldError}>{errors.email}</Text> : null}
+          </View>
+
+          <View style={styles.field}>
+            <Text style={styles.label} nativeID="login-password-label">
+              Password
+            </Text>
+            <TextInput
+              style={styles.input}
+              value={password}
+              onChangeText={setPassword}
+              secureTextEntry
+              editable={!submitting}
+              accessibilityLabel="Password"
+              accessibilityLabelledBy="login-password-label"
+            />
+            {errors.password ? (
+              <Text style={styles.fieldError}>{errors.password}</Text>
+            ) : null}
+          </View>
+
+          {apiError ? <Text style={styles.apiError}>{apiError}</Text> : null}
+
+          <Pressable
+            style={({ pressed }) => [
+              styles.primaryButton,
+              (pressed || submitting) && styles.primaryButtonPressed,
+            ]}
+            onPress={handleSubmit}
+            disabled={submitting}
+            accessibilityRole="button"
+            accessibilityLabel="Submit log in"
+          >
+            {submitting ? (
+              <ActivityIndicator color="#fff" />
+            ) : (
+              <Text style={styles.primaryButtonText}>Log In</Text>
+            )}
+          </Pressable>
+
+          <View style={styles.footer}>
+            <Text style={styles.footerText}>Don&apos;t have an account? </Text>
+            <Pressable
+              onPress={() => navigation.navigate('Register')}
+              accessibilityRole="button"
+              accessibilityLabel="Go to Register"
+            >
+              <Text style={styles.link}>Register</Text>
+            </Pressable>
+          </View>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: '#fff' },
+  flex: { flex: 1 },
+  scrollContent: {
+    padding: 20,
+    paddingBottom: 40,
+  },
+  heading: {
+    fontSize: 28,
+    fontWeight: '700',
+    marginBottom: 24,
+  },
+  field: { marginBottom: 16 },
+  label: { fontSize: 16, fontWeight: '600', marginBottom: 6 },
+  input: {
+    borderWidth: 1,
+    borderColor: '#cbd5e1',
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 12,
+    fontSize: 16,
+  },
+  fieldError: { color: '#b91c1c', marginTop: 6, fontSize: 14 },
+  apiError: { color: '#b91c1c', marginBottom: 12, fontSize: 15 },
+  primaryButton: {
+    backgroundColor: '#2563eb',
+    paddingVertical: 14,
+    borderRadius: 8,
+    alignItems: 'center',
+    marginTop: 8,
+  },
+  primaryButtonPressed: { opacity: 0.88 },
+  primaryButtonText: { color: '#fff', fontSize: 16, fontWeight: '600' },
+  footer: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+    marginTop: 24,
+  },
+  footerText: { fontSize: 15, color: '#64748b' },
+  link: { fontSize: 15, color: '#2563eb', fontWeight: '600' },
+});

--- a/app/mobile/src/screens/RegisterScreen.tsx
+++ b/app/mobile/src/screens/RegisterScreen.tsx
@@ -1,0 +1,203 @@
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { CommonActions } from '@react-navigation/native';
+import { useState } from 'react';
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useAuth } from '../context/AuthContext';
+import { validateRegisterForm } from '../lib/authValidation';
+import type { RootStackParamList } from '../navigation/types';
+import { mockRegisterRequest } from '../services/mockAuthService';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'Register'>;
+
+export default function RegisterScreen({ navigation }: Props) {
+  const { login } = useAuth();
+  const [username, setUsername] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [apiError, setApiError] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleSubmit() {
+    const errs = validateRegisterForm(username, email, password);
+    if (Object.keys(errs).length > 0) {
+      setErrors(errs);
+      return;
+    }
+    setErrors({});
+    setApiError('');
+    setSubmitting(true);
+    try {
+      const data = await mockRegisterRequest(username, email, password);
+      await login(data.user, data.access);
+      navigation.dispatch(
+        CommonActions.reset({
+          index: 0,
+          routes: [{ name: 'Home' }],
+        })
+      );
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Registration failed';
+      setApiError(message);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
+      <KeyboardAvoidingView
+        style={styles.flex}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
+        <ScrollView
+          keyboardShouldPersistTaps="handled"
+          contentContainerStyle={styles.scrollContent}
+        >
+          <Text style={styles.heading} accessibilityRole="header">
+            Register
+          </Text>
+
+          <View style={styles.field}>
+            <Text style={styles.label} nativeID="register-username-label">
+              Username
+            </Text>
+            <TextInput
+              style={styles.input}
+              value={username}
+              onChangeText={setUsername}
+              autoCapitalize="none"
+              autoCorrect={false}
+              editable={!submitting}
+              accessibilityLabel="Username"
+              accessibilityLabelledBy="register-username-label"
+            />
+            {errors.username ? (
+              <Text style={styles.fieldError}>{errors.username}</Text>
+            ) : null}
+          </View>
+
+          <View style={styles.field}>
+            <Text style={styles.label} nativeID="register-email-label">
+              Email
+            </Text>
+            <TextInput
+              style={styles.input}
+              value={email}
+              onChangeText={setEmail}
+              keyboardType="email-address"
+              autoCapitalize="none"
+              autoCorrect={false}
+              editable={!submitting}
+              accessibilityLabel="Email"
+              accessibilityLabelledBy="register-email-label"
+            />
+            {errors.email ? <Text style={styles.fieldError}>{errors.email}</Text> : null}
+          </View>
+
+          <View style={styles.field}>
+            <Text style={styles.label} nativeID="register-password-label">
+              Password
+            </Text>
+            <TextInput
+              style={styles.input}
+              value={password}
+              onChangeText={setPassword}
+              secureTextEntry
+              editable={!submitting}
+              accessibilityLabel="Password"
+              accessibilityLabelledBy="register-password-label"
+            />
+            {errors.password ? (
+              <Text style={styles.fieldError}>{errors.password}</Text>
+            ) : null}
+          </View>
+
+          {apiError ? <Text style={styles.apiError}>{apiError}</Text> : null}
+
+          <Pressable
+            style={({ pressed }) => [
+              styles.primaryButton,
+              (pressed || submitting) && styles.primaryButtonPressed,
+            ]}
+            onPress={handleSubmit}
+            disabled={submitting}
+            accessibilityRole="button"
+            accessibilityLabel="Submit registration"
+          >
+            {submitting ? (
+              <ActivityIndicator color="#fff" />
+            ) : (
+              <Text style={styles.primaryButtonText}>Register</Text>
+            )}
+          </Pressable>
+
+          <View style={styles.footer}>
+            <Text style={styles.footerText}>Already have an account? </Text>
+            <Pressable
+              onPress={() => navigation.navigate('Login')}
+              accessibilityRole="button"
+              accessibilityLabel="Go to Log In"
+            >
+              <Text style={styles.link}>Log In</Text>
+            </Pressable>
+          </View>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: '#fff' },
+  flex: { flex: 1 },
+  scrollContent: {
+    padding: 20,
+    paddingBottom: 40,
+  },
+  heading: {
+    fontSize: 28,
+    fontWeight: '700',
+    marginBottom: 24,
+  },
+  field: { marginBottom: 16 },
+  label: { fontSize: 16, fontWeight: '600', marginBottom: 6 },
+  input: {
+    borderWidth: 1,
+    borderColor: '#cbd5e1',
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 12,
+    fontSize: 16,
+  },
+  fieldError: { color: '#b91c1c', marginTop: 6, fontSize: 14 },
+  apiError: { color: '#b91c1c', marginBottom: 12, fontSize: 15 },
+  primaryButton: {
+    backgroundColor: '#2563eb',
+    paddingVertical: 14,
+    borderRadius: 8,
+    alignItems: 'center',
+    marginTop: 8,
+  },
+  primaryButtonPressed: { opacity: 0.88 },
+  primaryButtonText: { color: '#fff', fontSize: 16, fontWeight: '600' },
+  footer: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+    marginTop: 24,
+  },
+  footerText: { fontSize: 15, color: '#64748b' },
+  link: { fontSize: 15, color: '#2563eb', fontWeight: '600' },
+});

--- a/app/mobile/src/services/mockAuthService.ts
+++ b/app/mobile/src/services/mockAuthService.ts
@@ -1,0 +1,60 @@
+/**
+ * Stand-in for web `authService` (`loginRequest` / `registerRequest`).
+ * Replace with real HTTP calls to `${API}/api/auth/login/` and `/register/` when backend is ready.
+ */
+
+export type AuthUser = {
+  id: string;
+  username: string;
+  email: string;
+};
+
+export type AuthSuccess = {
+  access: string;
+  user: AuthUser;
+};
+
+function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Use password `wrong` or email containing `fail@` to simulate API failure. */
+export async function mockLoginRequest(
+  email: string,
+  password: string
+): Promise<AuthSuccess> {
+  await delay(450);
+  const e = email.trim().toLowerCase();
+  if (password === 'wrong' || e.includes('fail@')) {
+    throw new Error('Login failed');
+  }
+  const local = e.split('@')[0] || 'user';
+  return {
+    access: `mock-jwt-${Date.now()}`,
+    user: {
+      id: '1',
+      username: local,
+      email: email.trim(),
+    },
+  };
+}
+
+/** Use username `taken` to simulate registration conflict. */
+export async function mockRegisterRequest(
+  username: string,
+  email: string,
+  password: string
+): Promise<AuthSuccess> {
+  await delay(450);
+  if (username.trim().toLowerCase() === 'taken') {
+    throw new Error('Registration failed');
+  }
+  return {
+    access: `mock-jwt-${Date.now()}`,
+    user: {
+      id: '2',
+      username: username.trim(),
+      email: email.trim(),
+    },
+  };
+}


### PR DESCRIPTION
- AuthContext + AsyncStorage parity with web AuthContext/localStorage
- LoginScreen / RegisterScreen aligned with frontend pages; cross-links
- mockAuthService placeholders; authValidation for email and password rules
- Wire Login/Register into stack; Home footer for auth links and logout