### PR TITLE
feat(mobile): guard recipe/story create routes with auth redirect

### DIFF
--- a/app/mobile/README.md
+++ b/app/mobile/README.md
@@ -30,3 +30,13 @@ Aligned with `app/frontend/src/pages/LoginPage.jsx` and `RegisterPage.jsx`:
 - **Mock failures:** login with password `wrong` or email containing `fail@` → error message like web API errors.
 
 Swap `mockLoginRequest` / `mockRegisterRequest` for HTTP calls matching `app/frontend/src/services/authService.js` when the backend is available.
+
+## Protected routes (create recipe / story)
+
+Aligned with web `ProtectedRoute` wrapping `/recipes/new` and `/stories/new` in `app/frontend/src/App.js`:
+
+- **`RecipeCreate`** and **`StoryCreate`** are registered on the stack; each screen wraps its content in `src/components/ProtectedRoute.tsx`.
+- If there is **no token** after `AuthContext` finishes hydrating from `AsyncStorage`, navigation **`replace`s to `Login`** (same effect as web `Navigate to="/login" replace`).
+- Screens are **placeholders** (mock “Save”) until real `recipeService` / `storyService` calls exist.
+
+From **Home**, use **Create recipe** / **Create story** to try the guard when logged out vs logged in.

--- a/app/mobile/src/components/ProtectedRoute.tsx
+++ b/app/mobile/src/components/ProtectedRoute.tsx
@@ -1,0 +1,46 @@
+import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { useEffect, type ReactNode } from 'react';
+import { ActivityIndicator, StyleSheet, View } from 'react-native';
+import { useAuth } from '../context/AuthContext';
+import type { RootStackParamList } from '../navigation/types';
+
+type Navigation = NativeStackNavigationProp<RootStackParamList>;
+
+/**
+ * Mirrors web `ProtectedRoute.jsx`: unauthenticated users are sent to Login (replace, like `Navigate replace`).
+ */
+export function ProtectedRoute({ children }: { children: ReactNode }) {
+  const { token, isReady } = useAuth();
+  const navigation = useNavigation<Navigation>();
+
+  useEffect(() => {
+    if (!isReady) return;
+    if (!token) {
+      navigation.replace('Login');
+    }
+  }, [isReady, token, navigation]);
+
+  if (!isReady) {
+    return (
+      <View style={styles.centered} accessibilityLabel="Loading session">
+        <ActivityIndicator size="large" />
+      </View>
+    );
+  }
+
+  if (!token) {
+    return <View style={styles.centered} />;
+  }
+
+  return <>{children}</>;
+}
+
+const styles = StyleSheet.create({
+  centered: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#fff',
+  },
+});

--- a/app/mobile/src/navigation/PublicStackNavigator.tsx
+++ b/app/mobile/src/navigation/PublicStackNavigator.tsx
@@ -1,16 +1,18 @@
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import HomeScreen from '../screens/HomeScreen';
 import LoginScreen from '../screens/LoginScreen';
+import RecipeCreateScreen from '../screens/RecipeCreateScreen';
 import RecipeDetailScreen from '../screens/RecipeDetailScreen';
 import RegisterScreen from '../screens/RegisterScreen';
 import SearchScreen from '../screens/SearchScreen';
+import StoryCreateScreen from '../screens/StoryCreateScreen';
 import StoryDetailScreen from '../screens/StoryDetailScreen';
 import type { RootStackParamList } from './types';
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
 /**
- * Public routes — mirrors web `App.js` routes outside `ProtectedRoute`, including `/login` and `/register`.
+ * Mirrors web `App.js`: public routes + create flows that use in-screen guards (`ProtectedRoute`).
  */
 export function PublicStackNavigator() {
   return (
@@ -29,6 +31,16 @@ export function PublicStackNavigator() {
         name="Register"
         component={RegisterScreen}
         options={{ title: 'Register' }}
+      />
+      <Stack.Screen
+        name="RecipeCreate"
+        component={RecipeCreateScreen}
+        options={{ title: 'Create recipe' }}
+      />
+      <Stack.Screen
+        name="StoryCreate"
+        component={StoryCreateScreen}
+        options={{ title: 'Create story' }}
       />
       <Stack.Screen
         name="Search"

--- a/app/mobile/src/navigation/types.ts
+++ b/app/mobile/src/navigation/types.ts
@@ -3,6 +3,10 @@ export type RootStackParamList = {
   Login: undefined;
   Register: undefined;
   Search: undefined;
+  /** Web: `/recipes/new` (protected). */
+  RecipeCreate: undefined;
+  /** Web: `/stories/new` (protected). */
+  StoryCreate: undefined;
   RecipeDetail: { id: string };
   StoryDetail: { id: string };
 };

--- a/app/mobile/src/screens/HomeScreen.tsx
+++ b/app/mobile/src/screens/HomeScreen.tsx
@@ -46,6 +46,24 @@ export default function HomeScreen({ navigation }: Props) {
           >
             <Text style={styles.buttonText}>Sample story (id 1)</Text>
           </Pressable>
+
+          <Pressable
+            style={({ pressed }) => [styles.secondaryButton, pressed && styles.secondaryPressed]}
+            onPress={() => navigation.navigate('RecipeCreate')}
+            accessibilityRole="button"
+            accessibilityLabel="Create recipe"
+          >
+            <Text style={styles.secondaryButtonText}>Create recipe</Text>
+          </Pressable>
+
+          <Pressable
+            style={({ pressed }) => [styles.secondaryButton, pressed && styles.secondaryPressed]}
+            onPress={() => navigation.navigate('StoryCreate')}
+            accessibilityRole="button"
+            accessibilityLabel="Create story"
+          >
+            <Text style={styles.secondaryButtonText}>Create story</Text>
+          </Pressable>
         </View>
 
         <View style={styles.authFooter}>
@@ -118,6 +136,21 @@ const styles = StyleSheet.create({
   },
   buttonText: {
     color: '#fff',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  secondaryButton: {
+    borderWidth: 2,
+    borderColor: '#2563eb',
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    borderRadius: 8,
+    marginBottom: 12,
+    alignItems: 'center',
+  },
+  secondaryPressed: { opacity: 0.85 },
+  secondaryButtonText: {
+    color: '#2563eb',
     fontSize: 16,
     fontWeight: '600',
   },

--- a/app/mobile/src/screens/RecipeCreateScreen.tsx
+++ b/app/mobile/src/screens/RecipeCreateScreen.tsx
@@ -1,0 +1,81 @@
+import { useState } from 'react';
+import { Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { ProtectedRoute } from '../components/ProtectedRoute';
+
+/**
+ * Placeholder for web `RecipeCreatePage` — full form + API will replace `mockSaveRecipe` later.
+ */
+function RecipeCreateContent() {
+  const [title, setTitle] = useState('');
+  const [saved, setSaved] = useState(false);
+
+  function handleMockSave() {
+    setSaved(true);
+  }
+
+  return (
+    <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
+      <View style={styles.padded}>
+        <Text style={styles.heading} accessibilityRole="header">
+          Create recipe
+        </Text>
+        <Text style={styles.hint}>
+          Placeholder screen. Ingredients, video, and DRF upload will be wired in a later task.
+        </Text>
+        <Text style={styles.label}>Title</Text>
+        <TextInput
+          style={styles.input}
+          value={title}
+          onChangeText={setTitle}
+          placeholder="Working title"
+          accessibilityLabel="Recipe title"
+        />
+        <Pressable
+          style={({ pressed }) => [styles.button, pressed && styles.buttonPressed]}
+          onPress={handleMockSave}
+          accessibilityRole="button"
+          accessibilityLabel="Save recipe mock"
+        >
+          <Text style={styles.buttonText}>Save (mock)</Text>
+        </Pressable>
+        {saved ? (
+          <Text style={styles.success}>Saved locally (no API).</Text>
+        ) : null}
+      </View>
+    </SafeAreaView>
+  );
+}
+
+export default function RecipeCreateScreen() {
+  return (
+    <ProtectedRoute>
+      <RecipeCreateContent />
+    </ProtectedRoute>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: '#fff' },
+  padded: { flex: 1, padding: 20 },
+  heading: { fontSize: 26, fontWeight: '700', marginBottom: 8 },
+  hint: { fontSize: 14, opacity: 0.7, marginBottom: 20, lineHeight: 20 },
+  label: { fontSize: 16, fontWeight: '600', marginBottom: 6 },
+  input: {
+    borderWidth: 1,
+    borderColor: '#cbd5e1',
+    borderRadius: 8,
+    padding: 12,
+    fontSize: 16,
+    marginBottom: 16,
+  },
+  button: {
+    backgroundColor: '#2563eb',
+    paddingVertical: 14,
+    borderRadius: 8,
+    alignItems: 'center',
+  },
+  buttonPressed: { opacity: 0.88 },
+  buttonText: { color: '#fff', fontSize: 16, fontWeight: '600' },
+  success: { marginTop: 16, fontSize: 15, color: '#15803d' },
+});

--- a/app/mobile/src/screens/StoryCreateScreen.tsx
+++ b/app/mobile/src/screens/StoryCreateScreen.tsx
@@ -1,0 +1,92 @@
+import { useState } from 'react';
+import { Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { ProtectedRoute } from '../components/ProtectedRoute';
+
+/**
+ * Placeholder for web `StoryCreatePage` — full form + API will replace mock save later.
+ */
+function StoryCreateContent() {
+  const [title, setTitle] = useState('');
+  const [body, setBody] = useState('');
+  const [saved, setSaved] = useState(false);
+
+  function handleMockSave() {
+    setSaved(true);
+  }
+
+  return (
+    <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
+      <View style={styles.padded}>
+        <Text style={styles.heading} accessibilityRole="header">
+          Create story
+        </Text>
+        <Text style={styles.hint}>
+          Placeholder screen. Linked recipe picker and `createStory` API will be added later.
+        </Text>
+        <Text style={styles.label}>Title</Text>
+        <TextInput
+          style={styles.input}
+          value={title}
+          onChangeText={setTitle}
+          placeholder="Story title"
+          accessibilityLabel="Story title"
+        />
+        <Text style={styles.label}>Body</Text>
+        <TextInput
+          style={[styles.input, styles.multiline]}
+          value={body}
+          onChangeText={setBody}
+          placeholder="Story body"
+          multiline
+          accessibilityLabel="Story body"
+        />
+        <Pressable
+          style={({ pressed }) => [styles.button, pressed && styles.buttonPressed]}
+          onPress={handleMockSave}
+          accessibilityRole="button"
+          accessibilityLabel="Save story mock"
+        >
+          <Text style={styles.buttonText}>Save (mock)</Text>
+        </Pressable>
+        {saved ? (
+          <Text style={styles.success}>Saved locally (no API).</Text>
+        ) : null}
+      </View>
+    </SafeAreaView>
+  );
+}
+
+export default function StoryCreateScreen() {
+  return (
+    <ProtectedRoute>
+      <StoryCreateContent />
+    </ProtectedRoute>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: '#fff' },
+  padded: { flex: 1, padding: 20 },
+  heading: { fontSize: 26, fontWeight: '700', marginBottom: 8 },
+  hint: { fontSize: 14, opacity: 0.7, marginBottom: 20, lineHeight: 20 },
+  label: { fontSize: 16, fontWeight: '600', marginBottom: 6 },
+  input: {
+    borderWidth: 1,
+    borderColor: '#cbd5e1',
+    borderRadius: 8,
+    padding: 12,
+    fontSize: 16,
+    marginBottom: 16,
+  },
+  multiline: { minHeight: 100, textAlignVertical: 'top' },
+  button: {
+    backgroundColor: '#2563eb',
+    paddingVertical: 14,
+    borderRadius: 8,
+    alignItems: 'center',
+  },
+  buttonPressed: { opacity: 0.88 },
+  buttonText: { color: '#fff', fontSize: 16, fontWeight: '600' },
+  success: { marginTop: 16, fontSize: 15, color: '#15803d' },
+});


### PR DESCRIPTION
- Add ProtectedRoute mirroring web ProtectedRoute (replace to Login when no token)
- RecipeCreate and StoryCreate placeholder screens with mock save
- Register routes before detail screens; Home entry points for create flows
- Document behavior in README