### PR TITLE
feat(mobile): recipe detail with API fetch, video, ingredients

### DIFF
--- a/app/mobile/README.md
+++ b/app/mobile/README.md
@@ -16,7 +16,7 @@ These screens are reachable without signing in, aligned with public routes in `a
 |---------------|------------------|--------------------------------|
 | Home          | `/`              | Entry + shortcuts to other screens |
 | Search        | `/search`        | Mock list + filter (no API)    |
-| Recipe detail | `/recipes/:id`   | Mock data + short loading state |
+| Recipe detail | `/recipes/:id`   | Fetches `GET /api/recipes/:id/` then falls back to `mocks/recipes`; video (`expo-av`), description, ingredients |
 | Story detail  | `/stories/:id`   | Mock data; linked recipe → recipe screen |
 | New recipe    | (authoring)      | Full create form: description + dynamic ingredient list + video picker UI + client-side validation; ingredient/unit pickers try `/api/ingredients/` & `/api/units/` then fall back to mocks |
 

--- a/app/mobile/package-lock.json
+++ b/app/mobile/package-lock.json
@@ -12,6 +12,7 @@
         "@react-navigation/native": "^7.2.2",
         "@react-navigation/native-stack": "^7.14.10",
         "expo": "~52.0.0",
+        "expo-av": "~15.0.2",
         "expo-image-picker": "~16.0.6",
         "expo-status-bar": "~1.12.1",
         "react": "18.2.0",
@@ -6815,6 +6816,23 @@
           "optional": true
         },
         "react-native-webview": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/expo-av": {
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/expo-av/-/expo-av-15.0.2.tgz",
+      "integrity": "sha512-AHIHXdqLgK1dfHZF0JzX3YSVySGMrWn9QtPzaVjw54FAzvXfMt4sIoq4qRL/9XWCP9+ICcCs/u3EcvmxQjrfcA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*",
+        "react-native-web": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-web": {
           "optional": true
         }
       }

--- a/app/mobile/package.json
+++ b/app/mobile/package.json
@@ -13,6 +13,7 @@
     "@react-navigation/native": "^7.2.2",
     "@react-navigation/native-stack": "^7.14.10",
     "expo": "~52.0.0",
+    "expo-av": "~15.0.2",
     "expo-image-picker": "~16.0.6",
     "expo-status-bar": "~1.12.1",
     "react": "18.2.0",

--- a/app/mobile/src/mocks/recipes.ts
+++ b/app/mobile/src/mocks/recipes.ts
@@ -1,16 +1,35 @@
-/** Placeholder data until mobile calls DRF (see web `recipeService`). */
+import type { RecipeDetail } from '../types/recipe';
 
-export type MockRecipe = {
-  id: string;
-  title: string;
-  region: string;
+/** Public sample MP4 for mock / offline recipe video playback. */
+const SAMPLE_VIDEO =
+  'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4';
+
+const DETAILS: Record<string, RecipeDetail> = {
+  '1': {
+    id: 1,
+    title: 'Mock Anatolian stew',
+    region: 'Anatolia',
+    description:
+      'A hearty mock stew for development. When the API is available, this screen shows live data instead.',
+    video: SAMPLE_VIDEO,
+    author: { id: 1, username: 'demo_chef' },
+    ingredients: [
+      { ingredient: { id: 1, name: 'Tomato' }, amount: '400', unit: { id: 1, name: 'g' } },
+      { ingredient: { id: 2, name: 'Onion' }, amount: '1', unit: { id: 2, name: 'cup' } },
+    ],
+  },
+  '2': {
+    id: 2,
+    title: 'Mock Aegean salad',
+    region: 'Aegean',
+    description: 'Fresh mock salad with olive oil and herbs.',
+    video: SAMPLE_VIDEO,
+    ingredients: [
+      { ingredient: { id: 3, name: 'Olives' }, amount: '100', unit: { id: 1, name: 'g' } },
+    ],
+  },
 };
 
-const RECIPES: Record<string, MockRecipe> = {
-  '1': { id: '1', title: 'Mock Anatolian stew', region: 'Anatolia' },
-  '2': { id: '2', title: 'Mock Aegean salad', region: 'Aegean' },
-};
-
-export function getMockRecipeById(id: string): MockRecipe | null {
-  return RECIPES[id] ?? null;
+export function getMockRecipeDetailById(id: string): RecipeDetail | null {
+  return DETAILS[id] ?? null;
 }

--- a/app/mobile/src/screens/RecipeDetailScreen.tsx
+++ b/app/mobile/src/screens/RecipeDetailScreen.tsx
@@ -1,46 +1,50 @@
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { ResizeMode, Video } from 'expo-av';
 import { useEffect, useState } from 'react';
-import { ActivityIndicator, StyleSheet, Text, View } from 'react-native';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { ErrorView } from '../components/ui/ErrorView';
+import { LoadingView } from '../components/ui/LoadingView';
 import type { RootStackParamList } from '../navigation/types';
-import { getMockRecipeById } from '../mocks/recipes';
+import { fetchRecipeById } from '../services/recipeService';
+import type { RecipeDetail } from '../types/recipe';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'RecipeDetail'>;
 
-/** Short delay mirrors web async fetch UX without calling the API. */
-const MOCK_LOAD_MS = 250;
-
 export default function RecipeDetailScreen({ route }: Props) {
   const { id } = route.params;
+  const [recipe, setRecipe] = useState<RecipeDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [reloadToken, setReloadToken] = useState(0);
 
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
     setError(null);
-    const t = setTimeout(() => {
-      const recipe = getMockRecipeById(id);
-      if (cancelled) return;
-      if (!recipe) {
-        setError('Could not load recipe.');
-      }
-      setLoading(false);
-    }, MOCK_LOAD_MS);
+    fetchRecipeById(id)
+      .then((data) => {
+        if (!cancelled) setRecipe(data);
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setRecipe(null);
+          setError('Could not load recipe.');
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
     return () => {
       cancelled = true;
-      clearTimeout(t);
     };
-  }, [id]);
-
-  const recipe = !loading && !error ? getMockRecipeById(id) : null;
+  }, [id, reloadToken]);
 
   if (loading) {
     return (
       <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
         <View style={styles.centered}>
-          <ActivityIndicator accessibilityLabel="Loading" />
-          <Text style={styles.loadingText}>Loading...</Text>
+          <LoadingView message="Loading recipe…" />
         </View>
       </SafeAreaView>
     );
@@ -50,40 +54,124 @@ export default function RecipeDetailScreen({ route }: Props) {
     return (
       <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
         <View style={styles.padded}>
-          <Text style={styles.error}>{error ?? 'Recipe not found.'}</Text>
+          <ErrorView
+            message={error ?? 'Recipe not found.'}
+            onRetry={() => setReloadToken((t) => t + 1)}
+          />
         </View>
       </SafeAreaView>
     );
   }
 
+  const ingredients = recipe.ingredients ?? [];
+
   return (
     <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
-      <View style={styles.padded}>
+      <ScrollView contentContainerStyle={styles.scroll}>
         <Text style={styles.title} accessibilityRole="header">
           {recipe.title}
         </Text>
-        <Text style={styles.meta}>{recipe.region}</Text>
-        <Text style={styles.placeholder}>
-          Placeholder: video, ingredients, and author actions will connect to the API in a
-          later step.
-        </Text>
-      </View>
+        {recipe.region ? <Text style={styles.meta}>{recipe.region}</Text> : null}
+        {recipe.author?.username ? (
+          <Text style={styles.author}>By {recipe.author.username}</Text>
+        ) : null}
+
+        {recipe.video ? (
+          <View style={styles.videoWrap} accessibilityLabel="Recipe video">
+            <Video
+              style={styles.video}
+              source={{ uri: recipe.video }}
+              useNativeControls
+              resizeMode={ResizeMode.CONTAIN}
+              isLooping={false}
+            />
+          </View>
+        ) : (
+          <Text style={styles.noVideo}>No video for this recipe.</Text>
+        )}
+
+        {recipe.description ? (
+          <Text style={styles.description}>{recipe.description}</Text>
+        ) : (
+          <Text style={styles.muted}>No description.</Text>
+        )}
+
+        <Text style={styles.sectionTitle}>Ingredients</Text>
+        {ingredients.length === 0 ? (
+          <Text style={styles.muted}>No ingredients listed.</Text>
+        ) : (
+          <View style={styles.list}>
+            {ingredients.map((ri, index) => (
+              <View
+                key={`${ri.ingredient.id}-${index}`}
+                style={styles.ingredientRow}
+              >
+                <Text style={styles.ingredientName}>{ri.ingredient.name}</Text>
+                <Text style={styles.ingredientAmount}>
+                  {' — '}
+                  {String(ri.amount)} {ri.unit.name}
+                </Text>
+              </View>
+            ))}
+          </View>
+        )}
+      </ScrollView>
     </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
   safe: { flex: 1, backgroundColor: '#fff' },
-  padded: { flex: 1, padding: 20 },
+  scroll: { padding: 20, paddingBottom: 32 },
+  padded: { flex: 1, padding: 20, justifyContent: 'center' },
   centered: {
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
     padding: 20,
   },
-  loadingText: { marginTop: 8, fontSize: 16 },
-  title: { fontSize: 26, fontWeight: '700' },
-  meta: { fontSize: 16, opacity: 0.75, marginTop: 8 },
-  placeholder: { fontSize: 14, opacity: 0.65, marginTop: 20, lineHeight: 20 },
-  error: { fontSize: 16, color: '#b91c1c' },
+  title: { fontSize: 26, fontWeight: '700', color: '#0f172a' },
+  meta: { fontSize: 16, color: '#64748b', marginTop: 8 },
+  author: { fontSize: 15, color: '#64748b', marginTop: 4 },
+  videoWrap: {
+    marginTop: 16,
+    borderRadius: 12,
+    overflow: 'hidden',
+    backgroundColor: '#0f172a',
+  },
+  video: {
+    width: '100%',
+    aspectRatio: 16 / 9,
+  },
+  noVideo: {
+    marginTop: 16,
+    fontSize: 14,
+    color: '#94a3b8',
+    fontStyle: 'italic',
+  },
+  description: {
+    marginTop: 18,
+    fontSize: 16,
+    color: '#334155',
+    lineHeight: 24,
+  },
+  muted: { marginTop: 12, fontSize: 15, color: '#94a3b8' },
+  sectionTitle: {
+    marginTop: 24,
+    fontSize: 18,
+    fontWeight: '700',
+    color: '#0f172a',
+    marginBottom: 10,
+  },
+  list: { gap: 0 },
+  ingredientRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    alignItems: 'baseline',
+    paddingVertical: 10,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: '#e2e8f0',
+  },
+  ingredientName: { fontSize: 16, color: '#0f172a', fontWeight: '600' },
+  ingredientAmount: { fontSize: 16, color: '#475569' },
 });

--- a/app/mobile/src/services/recipeService.ts
+++ b/app/mobile/src/services/recipeService.ts
@@ -1,0 +1,25 @@
+import type { RecipeDetail } from '../types/recipe';
+import { getMockRecipeDetailById } from '../mocks/recipes';
+import { apiGetJson } from './httpClient';
+
+/**
+ * Same endpoint as web `fetchRecipe` in `recipeService.js`.
+ * Falls back to mock detail when the request fails (offline / no backend).
+ */
+export async function fetchRecipeById(id: string): Promise<RecipeDetail> {
+  try {
+    const data = await apiGetJson<RecipeDetail>(`/api/recipes/${id}/`);
+    return normalizeRecipeDetail(data);
+  } catch {
+    const mock = getMockRecipeDetailById(id);
+    if (!mock) throw new Error('Could not load recipe.');
+    return mock;
+  }
+}
+
+function normalizeRecipeDetail(data: RecipeDetail): RecipeDetail {
+  return {
+    ...data,
+    ingredients: Array.isArray(data.ingredients) ? data.ingredients : [],
+  };
+}

--- a/app/mobile/src/types/recipe.ts
+++ b/app/mobile/src/types/recipe.ts
@@ -1,0 +1,18 @@
+/**
+ * Single-recipe payload from GET `/api/recipes/:id/` (see web `RecipeDetailPage.jsx`).
+ */
+export type RecipeIngredientRow = {
+  ingredient: { id: number; name: string };
+  amount: string | number;
+  unit: { id?: number; name: string };
+};
+
+export type RecipeDetail = {
+  id: number | string;
+  title: string;
+  description?: string;
+  region?: string;
+  video?: string | null;
+  author?: { id: number; username: string };
+  ingredients?: RecipeIngredientRow[];
+};


### PR DESCRIPTION
Wire RecipeDetailScreen to GET /api/recipes/:id/ via recipeService with mock fallback matching web shape. Add expo-av video player, description, and ingredient list. Extend mock recipes with sample video URL and full fields.