### PR TITLE
feat(mobile): global success/error toasts for recipe create

### DIFF
--- a/app/mobile/App.tsx
+++ b/app/mobile/App.tsx
@@ -1,15 +1,21 @@
 import { NavigationContainer } from '@react-navigation/native';
 import { StatusBar } from 'expo-status-bar';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { AuthProvider } from './src/context/AuthContext';
+import { ToastProvider } from './src/context/ToastContext';
 import { PublicStackNavigator } from './src/navigation/PublicStackNavigator';
 
 export default function App() {
   return (
-    <AuthProvider>
-      <NavigationContainer>
-        <StatusBar style="auto" />
-        <PublicStackNavigator />
-      </NavigationContainer>
-    </AuthProvider>
+    <SafeAreaProvider>
+      <AuthProvider>
+        <ToastProvider>
+          <NavigationContainer>
+            <StatusBar style="auto" />
+            <PublicStackNavigator />
+          </NavigationContainer>
+        </ToastProvider>
+      </AuthProvider>
+    </SafeAreaProvider>
   );
 }

--- a/app/mobile/README.md
+++ b/app/mobile/README.md
@@ -24,6 +24,10 @@ Mock data lives under `src/mocks/`. Catalog lists use `src/services/ingredientUn
 
 Set **`EXPO_PUBLIC_API_URL`** (e.g. in `.env`) so a device or simulator can reach your API — same idea as web `REACT_APP_API_URL`. Default base URL is `http://localhost:8000`.
 
+## Success toasts (aligned with web `Toast.jsx`)
+
+`ToastProvider` + `useToast()` live in `src/context/ToastContext.tsx` (bottom-right banner, success/error colors, 3s auto-dismiss). Recipe create calls `showToast('Recipe published!', 'success')` after mock submit — reuse `useToast()` on future edit/save flows.
+
 ## Auth UI (login / register)
 
 Aligned with `app/frontend/src/pages/LoginPage.jsx` and `RegisterPage.jsx`:

--- a/app/mobile/src/context/ToastContext.tsx
+++ b/app/mobile/src/context/ToastContext.tsx
@@ -1,0 +1,151 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+import { Animated, Pressable, StyleSheet, Text, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+/** Matches web `Toast.jsx` (`success` | `error`). */
+export type ToastType = 'success' | 'error';
+
+type ToastState = { message: string; type: ToastType } | null;
+
+type ToastContextValue = {
+  showToast: (message: string, type?: ToastType) => void;
+};
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+/** Same duration as web `RecipeCreatePage` / `RecipeEditPage` (`setTimeout` 3000). */
+const DISMISS_MS = 3000;
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toast, setToast] = useState<ToastState>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearTimer = useCallback(() => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+  }, []);
+
+  const showToast = useCallback(
+    (message: string, type: ToastType = 'success') => {
+      clearTimer();
+      setToast({ message, type });
+      timeoutRef.current = setTimeout(() => {
+        setToast(null);
+        timeoutRef.current = null;
+      }, DISMISS_MS);
+    },
+    [clearTimer],
+  );
+
+  useEffect(() => () => clearTimer(), [clearTimer]);
+
+  const dismiss = useCallback(() => {
+    clearTimer();
+    setToast(null);
+  }, [clearTimer]);
+
+  return (
+    <ToastContext.Provider value={{ showToast }}>
+      {children}
+      <ToastOverlay toast={toast} onDismiss={dismiss} />
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast(): ToastContextValue {
+  const ctx = useContext(ToastContext);
+  if (!ctx) throw new Error('useToast must be used within ToastProvider');
+  return ctx;
+}
+
+function ToastOverlay({
+  toast,
+  onDismiss,
+}: {
+  toast: ToastState;
+  onDismiss: () => void;
+}) {
+  const insets = useSafeAreaInsets();
+  const slide = useRef(new Animated.Value(40)).current;
+  const opacity = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    if (!toast) return;
+    slide.setValue(40);
+    opacity.setValue(0);
+    Animated.parallel([
+      Animated.timing(slide, {
+        toValue: 0,
+        duration: 200,
+        useNativeDriver: true,
+      }),
+      Animated.timing(opacity, {
+        toValue: 1,
+        duration: 200,
+        useNativeDriver: true,
+      }),
+    ]).start();
+  }, [toast, opacity, slide]);
+
+  if (!toast) return null;
+
+  const backgroundColor = toast.type === 'success' ? '#16a34a' : '#dc2626';
+
+  return (
+    <View
+      style={[styles.root, { paddingBottom: Math.max(insets.bottom, 8) + 16 }]}
+      pointerEvents="box-none"
+    >
+      <Animated.View
+        style={{
+          transform: [{ translateY: slide }],
+          opacity,
+        }}
+      >
+        <Pressable
+          onPress={onDismiss}
+          accessibilityRole="alert"
+          accessibilityLabel={toast.message}
+          style={[styles.banner, { backgroundColor }]}
+        >
+          <Text style={styles.text}>{toast.message}</Text>
+        </Pressable>
+      </Animated.View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    ...StyleSheet.absoluteFillObject,
+    justifyContent: 'flex-end',
+    alignItems: 'flex-end',
+    paddingHorizontal: 16,
+    zIndex: 1000,
+  },
+  banner: {
+    maxWidth: '92%',
+    paddingVertical: 12,
+    paddingHorizontal: 20,
+    borderRadius: 6,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.15,
+    shadowRadius: 12,
+    elevation: 6,
+  },
+  text: {
+    color: '#fff',
+    fontSize: 14,
+    fontWeight: '500',
+  },
+});

--- a/app/mobile/src/screens/RecipeCreateScreen.tsx
+++ b/app/mobile/src/screens/RecipeCreateScreen.tsx
@@ -1,18 +1,12 @@
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import * as ImagePicker from 'expo-image-picker';
 import React, { useMemo, useState } from 'react';
-import {
-  Alert,
-  Pressable,
-  ScrollView,
-  StyleSheet,
-  Text,
-  TextInput,
-  View,
-} from 'react-native';
+import { Pressable, ScrollView, StyleSheet, Text, TextInput, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { IngredientPicker } from '../components/pickers/IngredientPicker';
 import { UnitPicker } from '../components/pickers/UnitPicker';
+import { useToast } from '../context/ToastContext';
+import { mockSubmitRecipeCreate } from '../services/mockRecipeCreate';
 import type { RootStackParamList } from '../navigation/types';
 import type { CatalogSelection } from '../types/catalog';
 
@@ -44,6 +38,7 @@ function InlineError({ message }: { message?: string }) {
 }
 
 export default function RecipeCreateScreen(_props: Props) {
+  const { showToast } = useToast();
   const [description, setDescription] = useState('');
   const [video, setVideo] = useState<VideoSelection | null>(null);
   const [rows, setRows] = useState<IngredientRow[]>([
@@ -96,7 +91,7 @@ export default function RecipeCreateScreen(_props: Props) {
   async function pickVideo() {
     const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
     if (!permission.granted) {
-      Alert.alert('Permission required', 'Media library permission is needed to pick a video.');
+      showToast('Media library permission is needed to pick a video.', 'error');
       return;
     }
 
@@ -151,13 +146,14 @@ export default function RecipeCreateScreen(_props: Props) {
       })),
     };
 
-    Alert.alert('Mock submit', 'Recipe upload payload is ready.', [
-      { text: 'OK' },
-      {
-        text: 'Show JSON',
-        onPress: () => Alert.alert('Payload', JSON.stringify(payload, null, 2)),
-      },
-    ]);
+    void (async () => {
+      try {
+        await mockSubmitRecipeCreate(payload);
+        showToast('Recipe published!', 'success');
+      } catch {
+        showToast('Failed to publish recipe. Please try again.', 'error');
+      }
+    })();
   }
 
   return (

--- a/app/mobile/src/services/mockRecipeCreate.ts
+++ b/app/mobile/src/services/mockRecipeCreate.ts
@@ -1,0 +1,7 @@
+/**
+ * Stand-in for `createRecipe` until mobile posts real `FormData` to the API.
+ * Keeps the same success/error toast flow as web `RecipeCreatePage.jsx`.
+ */
+export async function mockSubmitRecipeCreate(_payload: unknown): Promise<void> {
+  await new Promise<void>((resolve) => setTimeout(resolve, 400));
+}


### PR DESCRIPTION
Add ToastProvider (web-aligned colors, 3s dismiss, bottom placement) and useToast hook for reuse on future edit flows. Wire RecipeCreate mock submit to show Recipe published; use error toast for video permission denial.
