### PR TITLE
fix(mobile): author-only Edit visibility after auth hydration

### DIFF
--- a/app/mobile/README.md
+++ b/app/mobile/README.md
@@ -16,7 +16,7 @@ These screens are reachable without signing in, aligned with public routes in `a
 |---------------|------------------|--------------------------------|
 | Home          | `/`              | Entry + shortcuts to other screens |
 | Search        | `/search`        | Mock list + filter (no API)    |
-| Recipe detail | `/recipes/:id`   | Fetches `GET /api/recipes/:id/` then falls back to `mocks/recipes`; video (`expo-av`), description, ingredients; **Edit** when signed in as author |
+| Recipe detail | `/recipes/:id`   | Fetches `GET /api/recipes/:id/` then falls back to `mocks/recipes`; video (`expo-av`), description, ingredients; **Edit** only after auth is ready and `isRecipeAuthor(user, recipe)` (`src/utils/recipeAuthor.ts`) |
 | Edit recipe   | `/recipes/:id/edit` | Pre-filled form reusing create pickers/sections; `PATCH /api/recipes/:id/` + `FormData`, mock fallback; success toast then back to detail |
 | Story detail  | `/stories/:id`   | Mock data; linked recipe → recipe screen |
 | New recipe    | (authoring)      | Full create form: description + dynamic ingredient list + video picker UI + client-side validation; ingredient/unit pickers try `/api/ingredients/` & `/api/units/` then fall back to mocks |

--- a/app/mobile/src/screens/RecipeDetailScreen.tsx
+++ b/app/mobile/src/screens/RecipeDetailScreen.tsx
@@ -9,12 +9,13 @@ import { LoadingView } from '../components/ui/LoadingView';
 import type { RootStackParamList } from '../navigation/types';
 import { fetchRecipeById } from '../services/recipeService';
 import type { RecipeDetail } from '../types/recipe';
+import { isRecipeAuthor } from '../utils/recipeAuthor';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'RecipeDetail'>;
 
 export default function RecipeDetailScreen({ route, navigation }: Props) {
   const { id } = route.params;
-  const { user, isAuthenticated } = useAuth();
+  const { user, isAuthenticated, isReady } = useAuth();
   const [recipe, setRecipe] = useState<RecipeDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -67,11 +68,8 @@ export default function RecipeDetailScreen({ route, navigation }: Props) {
 
   const ingredients = recipe.ingredients ?? [];
 
-  const canEdit =
-    isAuthenticated &&
-    recipe.author != null &&
-    user != null &&
-    Number(user.id) === Number(recipe.author.id);
+  /** Hide Edit until session is restored from storage (avoids flash for signed-in authors). */
+  const canEdit = isReady && isAuthenticated && isRecipeAuthor(user, recipe);
 
   return (
     <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>

--- a/app/mobile/src/screens/RecipeEditScreen.tsx
+++ b/app/mobile/src/screens/RecipeEditScreen.tsx
@@ -21,6 +21,7 @@ import { useToast } from '../context/ToastContext';
 import type { RootStackParamList } from '../navigation/types';
 import { fetchRecipeById, updateRecipeById } from '../services/recipeService';
 import type { RecipeDetail } from '../types/recipe';
+import { isRecipeAuthor } from '../utils/recipeAuthor';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'RecipeEdit'>;
 
@@ -67,7 +68,7 @@ export default function RecipeEditScreen({ route, navigation }: Props) {
     fetchRecipeById(id)
       .then((data) => {
         if (cancelled) return;
-        if (data.author && user && Number(user.id) !== Number(data.author.id)) {
+        if (data.author && user && !isRecipeAuthor(user, data)) {
           setLoadState('forbidden');
           return;
         }

--- a/app/mobile/src/utils/recipeAuthor.ts
+++ b/app/mobile/src/utils/recipeAuthor.ts
@@ -1,0 +1,14 @@
+import type { AuthUser } from '../services/mockAuthService';
+import type { RecipeDetail } from '../types/recipe';
+
+/**
+ * Same intent as web `RecipeDetailPage` (`user && recipe.author && user.id === recipe.author.id`),
+ * with numeric coercion so string `id` from mock auth matches numeric API author ids.
+ */
+export function isRecipeAuthor(
+  user: AuthUser | null | undefined,
+  recipe: RecipeDetail | null | undefined,
+): boolean {
+  if (!user || !recipe?.author) return false;
+  return Number(user.id) === Number(recipe.author.id);
+}


### PR DESCRIPTION
Add isRecipeAuthor helper (session id vs recipe.author.id with numeric coercion). Recipe detail shows Edit only when isReady, authenticated, and author matches. Reuse helper in RecipeEdit forbidden check.