### PR TITLE
feat(mobile): search results grid with result cards

### DIFF
--- a/app/mobile/README.md
+++ b/app/mobile/README.md
@@ -15,7 +15,7 @@ These screens are reachable without signing in, aligned with public routes in `a
 | Screen        | Web equivalent   | Notes                          |
 |---------------|------------------|--------------------------------|
 | Home          | `/`              | Entry + shortcuts to other screens |
-| Search        | `/search`        | Search state shape: `{ query, region }`; Home has search bar + region picker; results still mock data for now |
+| Search        | `/search`        | Search state shape: `{ query, region }`; Home has search bar + region picker; results render as a 2-column grid of result cards (title + thumbnail placeholder + region tag) from mock data |
 | Recipe detail | `/recipes/:id`   | Fetches `GET /api/recipes/:id/` then falls back to `mocks/recipes`; video (`expo-av`), description, ingredients; **Edit** only after auth is ready and `isRecipeAuthor(user, recipe)` (`src/utils/recipeAuthor.ts`) |
 | Edit recipe   | `/recipes/:id/edit` | Pre-filled form reusing create pickers/sections; `PATCH /api/recipes/:id/` + `FormData`, mock fallback; success toast then back to detail |
 | Story detail  | `/stories/:id`   | Mock data; linked recipe → recipe screen |

--- a/app/mobile/src/components/search/SearchResultCard.tsx
+++ b/app/mobile/src/components/search/SearchResultCard.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import type { MockSearchItem } from '../../mocks/searchResults';
+
+type Props = {
+  item: MockSearchItem;
+  onPress: () => void;
+};
+
+function kindLabel(kind: MockSearchItem['kind']) {
+  return kind === 'recipe' ? 'Recipe' : 'Story';
+}
+
+function thumbColor(kind: MockSearchItem['kind']) {
+  return kind === 'recipe' ? '#0ea5e9' : '#a855f7';
+}
+
+export function SearchResultCard({ item, onPress }: Props) {
+  const tag = item.region ?? kindLabel(item.kind);
+  const initial = kindLabel(item.kind).slice(0, 1);
+
+  return (
+    <Pressable
+      onPress={onPress}
+      style={({ pressed }) => [styles.card, pressed && styles.cardPressed]}
+      accessibilityRole="button"
+      accessibilityLabel={`Open ${item.kind} ${item.title}`}
+    >
+      <View style={[styles.thumb, { backgroundColor: thumbColor(item.kind) }]}>
+        <Text style={styles.thumbText}>{initial}</Text>
+      </View>
+
+      <View style={styles.body}>
+        <Text style={styles.title} numberOfLines={2}>
+          {item.title}
+        </Text>
+        <View style={styles.metaRow}>
+          <Text style={styles.kind}>{kindLabel(item.kind)}</Text>
+          <View style={styles.dot} />
+          <View style={styles.tag}>
+            <Text style={styles.tagText} numberOfLines={1}>
+              {tag}
+            </Text>
+          </View>
+        </View>
+      </View>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    flex: 1,
+    borderWidth: 1,
+    borderColor: '#e2e8f0',
+    borderRadius: 12,
+    backgroundColor: '#fff',
+    overflow: 'hidden',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.08,
+    shadowRadius: 10,
+    elevation: 2,
+  },
+  cardPressed: { opacity: 0.9 },
+  thumb: {
+    width: '100%',
+    aspectRatio: 16 / 10,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  thumbText: { color: '#fff', fontSize: 26, fontWeight: '800' },
+  body: { padding: 12, gap: 10 },
+  title: { fontSize: 16, fontWeight: '700', color: '#0f172a', minHeight: 40 },
+  metaRow: { flexDirection: 'row', alignItems: 'center', flexWrap: 'wrap', gap: 8 },
+  kind: { fontSize: 12, color: '#475569', fontWeight: '700', textTransform: 'uppercase' },
+  dot: { width: 4, height: 4, borderRadius: 4, backgroundColor: '#cbd5e1' },
+  tag: {
+    backgroundColor: '#f1f5f9',
+    borderWidth: 1,
+    borderColor: '#e2e8f0',
+    borderRadius: 999,
+    paddingVertical: 4,
+    paddingHorizontal: 8,
+  },
+  tagText: { fontSize: 12, color: '#0f172a', fontWeight: '700' },
+});
+

--- a/app/mobile/src/mocks/searchResults.ts
+++ b/app/mobile/src/mocks/searchResults.ts
@@ -5,7 +5,12 @@ export type MockSearchItem = {
   kind: 'recipe' | 'story';
   id: string;
   title: string;
+  /** Subtitle line (kept for backwards compatibility / mock display). */
   subtitle: string;
+  /** Optional region tag (for recipes). */
+  region?: string;
+  /** Optional thumbnail URL (not used yet on mobile). */
+  thumbnail?: string | null;
 };
 
 export const MOCK_SEARCH_RESULTS: MockSearchItem[] = [
@@ -15,6 +20,7 @@ export const MOCK_SEARCH_RESULTS: MockSearchItem[] = [
     id: '1',
     title: 'Mock Anatolian stew',
     subtitle: 'Recipe · Anatolia',
+    region: 'Anatolia',
   },
   {
     key: 'story-1',
@@ -29,5 +35,6 @@ export const MOCK_SEARCH_RESULTS: MockSearchItem[] = [
     id: '2',
     title: 'Mock Aegean salad',
     subtitle: 'Recipe · Aegean',
+    region: 'Aegean',
   },
 ];

--- a/app/mobile/src/screens/SearchScreen.tsx
+++ b/app/mobile/src/screens/SearchScreen.tsx
@@ -9,6 +9,7 @@ import {
   View,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { SearchResultCard } from '../components/search/SearchResultCard';
 import type { RootStackParamList } from '../navigation/types';
 import {
   MOCK_SEARCH_RESULTS,
@@ -33,7 +34,7 @@ function filterItems(query: string, region: string): MockSearchItem[] {
       !q ||
       item.title.toLowerCase().includes(q) ||
       item.subtitle.toLowerCase().includes(q);
-    const matchesRegion = !r || item.subtitle.toLowerCase().includes(r);
+    const matchesRegion = !r || (item.region ?? '').toLowerCase().includes(r);
     return matchesQuery && matchesRegion;
   });
 }
@@ -107,6 +108,9 @@ export default function SearchScreen({ navigation, route }: Props) {
         <FlatList
           data={data}
           keyExtractor={(item) => item.key}
+          numColumns={2}
+          contentContainerStyle={styles.grid}
+          columnWrapperStyle={styles.gridRow}
           ListEmptyComponent={
             <Text style={styles.empty}>
               No matches for “{query.trim() || '…'}” in {selectedRegionLabel}. Try another
@@ -114,15 +118,9 @@ export default function SearchScreen({ navigation, route }: Props) {
             </Text>
           }
           renderItem={({ item }) => (
-            <Pressable
-              style={({ pressed }) => [styles.card, pressed && styles.cardPressed]}
-              onPress={() => onPressItem(item)}
-              accessibilityRole="button"
-              accessibilityLabel={`Open ${item.kind} ${item.title}`}
-            >
-              <Text style={styles.cardTitle}>{item.title}</Text>
-              <Text style={styles.cardSubtitle}>{item.subtitle}</Text>
-            </Pressable>
+            <View style={styles.gridItem}>
+              <SearchResultCard item={item} onPress={() => onPressItem(item)} />
+            </View>
           )}
         />
       </View>
@@ -161,16 +159,8 @@ const styles = StyleSheet.create({
   pillActive: { backgroundColor: '#2563eb', borderColor: '#2563eb' },
   pillText: { fontSize: 14, fontWeight: '600', color: '#0f172a' },
   pillTextActive: { color: '#fff' },
-  card: {
-    borderWidth: 1,
-    borderColor: '#e2e8f0',
-    borderRadius: 8,
-    padding: 14,
-    marginBottom: 10,
-    backgroundColor: '#f8fafc',
-  },
-  cardPressed: { opacity: 0.9 },
-  cardTitle: { fontSize: 17, fontWeight: '600' },
-  cardSubtitle: { fontSize: 14, opacity: 0.7, marginTop: 4 },
+  grid: { paddingBottom: 24, gap: 12 },
+  gridRow: { gap: 12 },
+  gridItem: { flex: 1 },
   empty: { fontSize: 15, opacity: 0.7, textAlign: 'center', marginTop: 24 },
 });


### PR DESCRIPTION
Add SearchResultCard component (title, thumbnail placeholder, region tag) and render Search results as a 2-column grid using FlatList. Extend mock search items with a region field for filtering and display.
