### PR TITLE
feat(mobile): story creation form with validation and mock submit

### DIFF
--- a/app/mobile/README.md
+++ b/app/mobile/README.md
@@ -18,6 +18,7 @@ These screens are reachable without signing in, aligned with public routes in `a
 | Search        | `/search`        | Search state shape: `{ query, region }`; Home has search bar + region picker; results render as a 2-column grid of result cards (title + thumbnail placeholder + region tag) from mock data; empty state for pristine/no-results |
 | Recipe detail | `/recipes/:id`   | Fetches `GET /api/recipes/:id/` then falls back to `mocks/recipes`; video (`expo-av`), description, ingredients; **Edit** only after auth is ready and `isRecipeAuthor(user, recipe)` (`src/utils/recipeAuthor.ts`) |
 | Edit recipe   | `/recipes/:id/edit` | Pre-filled form reusing create pickers/sections; `PATCH /api/recipes/:id/` + `FormData`, mock fallback; success toast then back to detail |
+| Create story  | `/stories/new`   | Story create form: title + body + language + optional linked recipe (placeholder until mini-search task); mock submit shows toast and navigates to detail |
 | Story detail  | `/stories/:id`   | Mock data; linked recipe → recipe screen |
 | New recipe    | (authoring)      | Full create form: description + dynamic ingredient list + video picker UI + **Q&A toggle (`qa_enabled`)** + client-side validation; ingredient/unit pickers try `/api/ingredients/` & `/api/units/` then fall back to mocks |
 

--- a/app/mobile/src/mocks/stories.ts
+++ b/app/mobile/src/mocks/stories.ts
@@ -4,6 +4,7 @@ export type MockStory = {
   id: string;
   title: string;
   body: string;
+  language?: 'en' | 'tr';
   author?: { username: string };
   linked_recipe?: { id: string; title: string; region?: string };
 };
@@ -13,6 +14,7 @@ const STORIES: Record<string, MockStory> = {
     id: '1',
     title: 'Mock kitchen story',
     body: 'This is placeholder story content for development.',
+    language: 'en',
     author: { username: 'demo_user' },
     linked_recipe: { id: '1', title: 'Mock Anatolian stew', region: 'Anatolia' },
   },
@@ -20,10 +22,33 @@ const STORIES: Record<string, MockStory> = {
     id: '2',
     title: 'Another mock story',
     body: 'More placeholder text.',
+    language: 'tr',
     author: { username: 'demo_user' },
   },
 };
 
 export function getMockStoryById(id: string): MockStory | null {
   return STORIES[id] ?? null;
+}
+
+/** In-memory create for StoryCreate UI when API is unavailable. */
+export function mockCreateStory(input: {
+  title: string;
+  body: string;
+  language: 'en' | 'tr';
+  linked_recipe: MockStory['linked_recipe'] | null;
+  author?: MockStory['author'];
+}): MockStory {
+  const id = String(Date.now());
+  const story: MockStory = {
+    id,
+    title: input.title,
+    body: input.body,
+    language: input.language,
+    author: input.author,
+    linked_recipe: input.linked_recipe ?? undefined,
+  };
+  // mutate is OK for a mock store
+  STORIES[id] = story;
+  return story;
 }

--- a/app/mobile/src/navigation/PublicStackNavigator.tsx
+++ b/app/mobile/src/navigation/PublicStackNavigator.tsx
@@ -6,6 +6,7 @@ import RecipeDetailScreen from '../screens/RecipeDetailScreen';
 import RecipeEditScreen from '../screens/RecipeEditScreen';
 import RegisterScreen from '../screens/RegisterScreen';
 import SearchScreen from '../screens/SearchScreen';
+import StoryCreateScreen from '../screens/StoryCreateScreen';
 import StoryDetailScreen from '../screens/StoryDetailScreen';
 import type { RootStackParamList } from './types';
 
@@ -56,6 +57,11 @@ export function PublicStackNavigator() {
         name="StoryDetail"
         component={StoryDetailScreen}
         options={{ title: 'Story' }}
+      />
+      <Stack.Screen
+        name="StoryCreate"
+        component={StoryCreateScreen}
+        options={{ title: 'Create story' }}
       />
     </Stack.Navigator>
   );

--- a/app/mobile/src/navigation/types.ts
+++ b/app/mobile/src/navigation/types.ts
@@ -6,6 +6,7 @@ export type RootStackParamList = {
   RecipeDetail: { id: string };
   /** Pre-filled edit form — same API as web `RecipeEditPage`. */
   RecipeEdit: { id: string };
+  StoryCreate: undefined;
   StoryDetail: { id: string };
   /** Recipe authoring shell — ingredient/unit selection UI (full form later). */
   RecipeCreate: undefined;

--- a/app/mobile/src/screens/HomeScreen.tsx
+++ b/app/mobile/src/screens/HomeScreen.tsx
@@ -95,6 +95,15 @@ export default function HomeScreen({ navigation }: Props) {
 
           <Pressable
             style={({ pressed }) => [styles.button, pressed && styles.buttonPressed]}
+            onPress={() => navigation.navigate('StoryCreate')}
+            accessibilityRole="button"
+            accessibilityLabel="Create a story"
+          >
+            <Text style={styles.buttonText}>Create story</Text>
+          </Pressable>
+
+          <Pressable
+            style={({ pressed }) => [styles.button, pressed && styles.buttonPressed]}
             onPress={() => navigation.navigate('RecipeDetail', { id: '1' })}
             accessibilityRole="button"
             accessibilityLabel="Open sample recipe"

--- a/app/mobile/src/screens/StoryCreateScreen.tsx
+++ b/app/mobile/src/screens/StoryCreateScreen.tsx
@@ -1,0 +1,214 @@
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import React, { useMemo, useState } from 'react';
+import { Pressable, ScrollView, StyleSheet, Text, TextInput, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { InlineFieldError } from '../components/recipe/InlineFieldError';
+import { recipeFormStyles as form } from '../components/recipe/recipeFormStyles';
+import { useAuth } from '../context/AuthContext';
+import { useToast } from '../context/ToastContext';
+import type { RootStackParamList } from '../navigation/types';
+import { mockSubmitStoryCreate, type StoryLanguage } from '../services/mockStoryService';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'StoryCreate'>;
+
+type RegionRecipeLink = { id: string; title: string; region?: string };
+
+const LANGS: { label: string; value: StoryLanguage }[] = [
+  { label: 'English', value: 'en' },
+  { label: 'Turkish', value: 'tr' },
+];
+
+export default function StoryCreateScreen({ navigation }: Props) {
+  const { user } = useAuth();
+  const { showToast } = useToast();
+
+  const [title, setTitle] = useState('');
+  const [body, setBody] = useState('');
+  const [language, setLanguage] = useState<StoryLanguage>('en');
+  const [linkedRecipe, setLinkedRecipe] = useState<RegionRecipeLink | null>(null);
+
+  const [attemptedSubmit, setAttemptedSubmit] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  const errors = useMemo(() => {
+    const e: { title?: string; body?: string } = {};
+    if (!title.trim()) e.title = 'Title is required.';
+    if (!body.trim()) e.body = 'Body is required.';
+    return e;
+  }, [title, body]);
+
+  const isValid = !errors.title && !errors.body;
+
+  function submit() {
+    setAttemptedSubmit(true);
+    if (!isValid || submitting) return;
+
+    setSubmitting(true);
+    void (async () => {
+      try {
+        const created = await mockSubmitStoryCreate({
+          title,
+          body,
+          language,
+          is_published: true,
+          linked_recipe: linkedRecipe,
+          author: user ? { username: user.username } : undefined,
+        });
+        showToast('Story published!', 'success');
+        navigation.navigate('StoryDetail', { id: created.id });
+      } catch {
+        showToast('Failed to publish story. Please try again.', 'error');
+      } finally {
+        setSubmitting(false);
+      }
+    })();
+  }
+
+  return (
+    <SafeAreaView style={form.safe} edges={['top', 'left', 'right']}>
+      <ScrollView contentContainerStyle={form.scroll} keyboardShouldPersistTaps="handled">
+        <Text style={form.heading} accessibilityRole="header">
+          Create story
+        </Text>
+        <Text style={form.lead}>
+          Write a story and optionally link a recipe. Linking will be upgraded to a mini-search
+          in the next task; for now this is a placeholder.
+        </Text>
+
+        <View style={form.section}>
+          <Text style={form.sectionTitle}>Title</Text>
+          <TextInput
+            value={title}
+            onChangeText={setTitle}
+            placeholder="Story title"
+            placeholderTextColor="#94a3b8"
+            style={[form.input, attemptedSubmit && !!errors.title && form.inputError]}
+            accessibilityLabel="Story title"
+          />
+          {attemptedSubmit ? <InlineFieldError message={errors.title} /> : null}
+        </View>
+
+        <View style={form.section}>
+          <Text style={form.sectionTitle}>Body</Text>
+          <TextInput
+            value={body}
+            onChangeText={setBody}
+            placeholder="Write your story…"
+            placeholderTextColor="#94a3b8"
+            style={[form.textArea, attemptedSubmit && !!errors.body && form.inputError]}
+            multiline
+            accessibilityLabel="Story body"
+          />
+          {attemptedSubmit ? <InlineFieldError message={errors.body} /> : null}
+        </View>
+
+        <View style={form.section}>
+          <Text style={form.sectionTitle}>Language</Text>
+          <View style={styles.langRow}>
+            {LANGS.map((l) => {
+              const active = l.value === language;
+              return (
+                <Pressable
+                  key={l.value}
+                  onPress={() => setLanguage(l.value)}
+                  style={({ pressed }) => [
+                    styles.langPill,
+                    active && styles.langPillActive,
+                    pressed && { opacity: 0.9 },
+                  ]}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Set language ${l.label}`}
+                >
+                  <Text style={[styles.langText, active && styles.langTextActive]}>{l.label}</Text>
+                </Pressable>
+              );
+            })}
+          </View>
+        </View>
+
+        <View style={form.section}>
+          <Text style={form.sectionTitle}>Link a recipe (optional)</Text>
+          {linkedRecipe ? (
+            <View style={styles.linkedBox}>
+              <Text style={styles.linkedText}>
+                Linked: {linkedRecipe.title}
+                {linkedRecipe.region ? ` — ${linkedRecipe.region}` : ''}
+              </Text>
+              <Pressable
+                onPress={() => setLinkedRecipe(null)}
+                accessibilityRole="button"
+                accessibilityLabel="Remove linked recipe"
+              >
+                <Text style={styles.removeLink}>Remove</Text>
+              </Pressable>
+            </View>
+          ) : (
+            <Text style={styles.muted}>
+              No recipe linked. You’ll be able to search and select one of your recipes in the next
+              step.
+            </Text>
+          )}
+
+          {/* Placeholder action so UX has an entry point without implementing #171 yet. */}
+          {!linkedRecipe ? (
+            <Pressable
+              onPress={() =>
+                setLinkedRecipe({ id: '1', title: 'Mock Anatolian stew', region: 'Anatolia' })
+              }
+              style={({ pressed }) => [form.secondaryButton, pressed && form.buttonPressed]}
+              accessibilityRole="button"
+              accessibilityLabel="Link sample recipe"
+            >
+              <Text style={form.secondaryButtonText}>Link sample recipe</Text>
+            </Pressable>
+          ) : null}
+        </View>
+
+        <Pressable
+          onPress={submit}
+          disabled={submitting}
+          style={({ pressed }) => [
+            form.primaryButton,
+            pressed && form.buttonPressed,
+            submitting && { opacity: 0.7 },
+          ]}
+          accessibilityRole="button"
+          accessibilityLabel="Publish story"
+        >
+          <Text style={form.primaryButtonText}>{submitting ? 'Publishing…' : 'Publish (mock)'}</Text>
+        </Pressable>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  langRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 10 },
+  langPill: {
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    borderRadius: 999,
+    borderWidth: 1,
+    borderColor: '#cbd5e1',
+    backgroundColor: '#fff',
+  },
+  langPillActive: { backgroundColor: '#2563eb', borderColor: '#2563eb' },
+  langText: { fontSize: 14, fontWeight: '700', color: '#0f172a' },
+  langTextActive: { color: '#fff' },
+  muted: { fontSize: 14, color: '#64748b', lineHeight: 20, marginBottom: 12 },
+  linkedBox: {
+    borderWidth: 1,
+    borderColor: '#e2e8f0',
+    borderRadius: 12,
+    padding: 12,
+    backgroundColor: '#f8fafc',
+    marginBottom: 12,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 12,
+  },
+  linkedText: { flex: 1, fontSize: 14, color: '#0f172a', fontWeight: '600' },
+  removeLink: { color: '#dc2626', fontWeight: '800', fontSize: 14 },
+});
+

--- a/app/mobile/src/screens/StoryDetailScreen.tsx
+++ b/app/mobile/src/screens/StoryDetailScreen.tsx
@@ -64,6 +64,9 @@ export default function StoryDetailScreen({ route, navigation }: Props) {
         {story.author ? (
           <Text style={styles.meta}>By {story.author.username}</Text>
         ) : null}
+        {story.language ? (
+          <Text style={styles.meta}>Language: {story.language.toUpperCase()}</Text>
+        ) : null}
         <Text style={styles.body}>{story.body}</Text>
 
         {story.linked_recipe ? (

--- a/app/mobile/src/services/mockStoryService.ts
+++ b/app/mobile/src/services/mockStoryService.ts
@@ -1,0 +1,27 @@
+import type { MockStory } from '../mocks/stories';
+import { mockCreateStory } from '../mocks/stories';
+
+export type StoryLanguage = 'en' | 'tr';
+
+export type StoryCreatePayload = {
+  title: string;
+  body: string;
+  language: StoryLanguage;
+  /** Store id only; detail view uses mock story shape for now. */
+  linked_recipe: { id: string; title: string; region?: string } | null;
+  is_published: boolean;
+  author?: { username: string };
+};
+
+/** Stand-in for web `createStory` until backend is wired. */
+export async function mockSubmitStoryCreate(payload: StoryCreatePayload): Promise<MockStory> {
+  await new Promise<void>((resolve) => setTimeout(resolve, 450));
+  return mockCreateStory({
+    title: payload.title.trim(),
+    body: payload.body.trim(),
+    language: payload.language,
+    linked_recipe: payload.linked_recipe,
+    author: payload.author,
+  });
+}
+


### PR DESCRIPTION
Add StoryCreate screen with title/body validation, language picker, and optional linked recipe placeholder. Mock submit persists to in-memory story store, shows success toast, and navigates to StoryDetail. Wire route + Home entry.