### PR TITLE
feat(mobile): story detail view with linked recipe preview card

### DIFF
--- a/app/mobile/README.md
+++ b/app/mobile/README.md
@@ -19,7 +19,7 @@ These screens are reachable without signing in, aligned with public routes in `a
 | Recipe detail | `/recipes/:id`   | Fetches `GET /api/recipes/:id/` then falls back to `mocks/recipes`; video (`expo-av`), description, ingredients; **Edit** only after auth is ready and `isRecipeAuthor(user, recipe)` (`src/utils/recipeAuthor.ts`) |
 | Edit recipe   | `/recipes/:id/edit` | Pre-filled form reusing create pickers/sections; `PATCH /api/recipes/:id/` + `FormData`, mock fallback; success toast then back to detail |
 | Create story  | `/stories/new`   | Story create form: title + body + language + optional linked recipe via mini-search picker (API list with mock fallback); mock submit shows toast and navigates to detail |
-| Story detail  | `/stories/:id`   | Mock data; linked recipe → recipe screen |
+| Story detail  | `/stories/:id`   | Fetches `GET /api/stories/:id/` then falls back to `mocks/stories`; shows story text + linked recipe preview card (navigates to recipe detail) |
 | New recipe    | (authoring)      | Full create form: description + dynamic ingredient list + video picker UI + **Q&A toggle (`qa_enabled`)** + client-side validation; ingredient/unit pickers try `/api/ingredients/` & `/api/units/` then fall back to mocks |
 
 Mock data lives under `src/mocks/`. Catalog lists use `src/services/ingredientUnitService.ts` (same paths as web `recipeService.js`); if the server is down, in-memory mock catalogs are used.

--- a/app/mobile/src/components/story/LinkedRecipePreviewCard.tsx
+++ b/app/mobile/src/components/story/LinkedRecipePreviewCard.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+
+type LinkedRecipe = { id: string; title: string; region?: string };
+
+type Props = {
+  recipe: LinkedRecipe;
+  onPress: () => void;
+};
+
+export function LinkedRecipePreviewCard({ recipe, onPress }: Props) {
+  const tag = recipe.region ?? 'Recipe';
+
+  return (
+    <Pressable
+      onPress={onPress}
+      style={({ pressed }) => [styles.card, pressed && styles.pressed]}
+      accessibilityRole="button"
+      accessibilityLabel={`Open linked recipe ${recipe.title}`}
+    >
+      <View style={styles.thumb}>
+        <Text style={styles.thumbText}>R</Text>
+      </View>
+      <View style={styles.body}>
+        <Text style={styles.title} numberOfLines={2}>
+          {recipe.title}
+        </Text>
+        <View style={styles.tag}>
+          <Text style={styles.tagText} numberOfLines={1}>
+            {tag}
+          </Text>
+        </View>
+      </View>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    borderWidth: 1,
+    borderColor: '#e2e8f0',
+    borderRadius: 12,
+    backgroundColor: '#fff',
+    overflow: 'hidden',
+    flexDirection: 'row',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.08,
+    shadowRadius: 10,
+    elevation: 2,
+  },
+  pressed: { opacity: 0.9 },
+  thumb: {
+    width: 78,
+    backgroundColor: '#0ea5e9',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  thumbText: { color: '#fff', fontSize: 22, fontWeight: '900' },
+  body: { flex: 1, padding: 12, gap: 10 },
+  title: { fontSize: 16, fontWeight: '800', color: '#0f172a' },
+  tag: {
+    alignSelf: 'flex-start',
+    backgroundColor: '#f1f5f9',
+    borderWidth: 1,
+    borderColor: '#e2e8f0',
+    borderRadius: 999,
+    paddingVertical: 4,
+    paddingHorizontal: 8,
+  },
+  tagText: { fontSize: 12, fontWeight: '800', color: '#0f172a' },
+});
+

--- a/app/mobile/src/screens/StoryDetailScreen.tsx
+++ b/app/mobile/src/screens/StoryDetailScreen.tsx
@@ -1,45 +1,50 @@
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { useEffect, useState } from 'react';
-import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { LinkedRecipePreviewCard } from '../components/story/LinkedRecipePreviewCard';
+import { ErrorView } from '../components/ui/ErrorView';
+import { LoadingView } from '../components/ui/LoadingView';
 import type { RootStackParamList } from '../navigation/types';
-import { getMockStoryById } from '../mocks/stories';
+import { fetchStoryById } from '../services/storyService';
+import type { StoryDetail } from '../types/story';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'StoryDetail'>;
 
-const MOCK_LOAD_MS = 250;
-
 export default function StoryDetailScreen({ route, navigation }: Props) {
   const { id } = route.params;
+  const [story, setStory] = useState<StoryDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [reloadToken, setReloadToken] = useState(0);
 
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
     setError(null);
-    const t = setTimeout(() => {
-      const story = getMockStoryById(id);
-      if (cancelled) return;
-      if (!story) {
-        setError('Could not load story.');
-      }
-      setLoading(false);
-    }, MOCK_LOAD_MS);
+    fetchStoryById(id)
+      .then((data) => {
+        if (!cancelled) setStory(data);
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setStory(null);
+          setError('Could not load story.');
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
     return () => {
       cancelled = true;
-      clearTimeout(t);
     };
-  }, [id]);
-
-  const story = !loading && !error ? getMockStoryById(id) : null;
+  }, [id, reloadToken]);
 
   if (loading) {
     return (
       <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
         <View style={styles.centered}>
-          <ActivityIndicator accessibilityLabel="Loading" />
-          <Text style={styles.loadingText}>Loading...</Text>
+          <LoadingView message="Loading story…" />
         </View>
       </SafeAreaView>
     );
@@ -48,8 +53,11 @@ export default function StoryDetailScreen({ route, navigation }: Props) {
   if (error || !story) {
     return (
       <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
-        <View style={styles.padded}>
-          <Text style={styles.error}>{error ?? 'Story not found.'}</Text>
+        <View style={styles.paddedCenter}>
+          <ErrorView
+            message={error ?? 'Story not found.'}
+            onRetry={() => setReloadToken((t) => t + 1)}
+          />
         </View>
       </SafeAreaView>
     );
@@ -57,7 +65,7 @@ export default function StoryDetailScreen({ route, navigation }: Props) {
 
   return (
     <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
-      <View style={styles.padded}>
+      <ScrollView contentContainerStyle={styles.padded}>
         <Text style={styles.title} accessibilityRole="header">
           {story.title}
         </Text>
@@ -72,44 +80,32 @@ export default function StoryDetailScreen({ route, navigation }: Props) {
         {story.linked_recipe ? (
           <View style={styles.linked}>
             <Text style={styles.linkedHeading}>Linked recipe</Text>
-            <Pressable
+            <LinkedRecipePreviewCard
               onPress={() =>
                 navigation.navigate('RecipeDetail', { id: story.linked_recipe!.id })
               }
-              accessibilityRole="button"
-              accessibilityLabel={`Open linked recipe ${story.linked_recipe.title}`}
-            >
-              <View style={styles.linkedRow}>
-                <Text style={styles.link}>{story.linked_recipe.title}</Text>
-                {story.linked_recipe.region ? (
-                  <Text style={styles.linkedRegion}> — {story.linked_recipe.region}</Text>
-                ) : null}
-              </View>
-            </Pressable>
+              recipe={story.linked_recipe}
+            />
           </View>
         ) : null}
-      </View>
+      </ScrollView>
     </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
   safe: { flex: 1, backgroundColor: '#fff' },
-  padded: { flex: 1, padding: 20 },
+  padded: { padding: 20, paddingBottom: 32 },
+  paddedCenter: { flex: 1, padding: 20, justifyContent: 'center' },
   centered: {
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
     padding: 20,
   },
-  loadingText: { marginTop: 8, fontSize: 16 },
-  title: { fontSize: 26, fontWeight: '700' },
-  meta: { fontSize: 16, opacity: 0.75, marginTop: 8 },
-  body: { fontSize: 16, marginTop: 16, lineHeight: 24 },
+  title: { fontSize: 26, fontWeight: '800', color: '#0f172a' },
+  meta: { fontSize: 15, color: '#64748b', marginTop: 8 },
+  body: { fontSize: 16, marginTop: 16, lineHeight: 24, color: '#334155' },
   linked: { marginTop: 28, paddingTop: 16, borderTopWidth: 1, borderTopColor: '#e2e8f0' },
-  linkedHeading: { fontSize: 18, fontWeight: '600', marginBottom: 8 },
-  linkedRow: { flexDirection: 'row', flexWrap: 'wrap', alignItems: 'baseline' },
-  link: { fontSize: 16, color: '#2563eb', fontWeight: '600' },
-  linkedRegion: { fontSize: 16, opacity: 0.75 },
-  error: { fontSize: 16, color: '#b91c1c' },
+  linkedHeading: { fontSize: 18, fontWeight: '800', marginBottom: 10, color: '#0f172a' },
 });

--- a/app/mobile/src/services/storyService.ts
+++ b/app/mobile/src/services/storyService.ts
@@ -1,0 +1,23 @@
+import { getMockStoryById } from '../mocks/stories';
+import type { StoryDetail } from '../types/story';
+import { apiGetJson } from './httpClient';
+
+/** Same endpoint as web `fetchStory` (`GET /api/stories/:id/`), with mock fallback. */
+export async function fetchStoryById(id: string): Promise<StoryDetail> {
+  try {
+    const data = await apiGetJson<StoryDetail>(`/api/stories/${id}/`);
+    return normalizeStoryDetail(data);
+  } catch {
+    const mock = getMockStoryById(id);
+    if (!mock) throw new Error('Could not load story.');
+    return mock;
+  }
+}
+
+function normalizeStoryDetail(data: StoryDetail): StoryDetail {
+  return {
+    ...data,
+    linked_recipe: data.linked_recipe ?? null,
+  };
+}
+

--- a/app/mobile/src/types/story.ts
+++ b/app/mobile/src/types/story.ts
@@ -1,0 +1,9 @@
+export type StoryDetail = {
+  id: number | string;
+  title: string;
+  body: string;
+  language?: 'en' | 'tr' | string;
+  author?: { id?: number; username: string };
+  linked_recipe?: { id: string; title: string; region?: string } | null;
+};
+


### PR DESCRIPTION
Wire StoryDetailScreen to GET /api/stories/:id/ with mock fallback and add a linked recipe preview card (thumbnail placeholder + region tag) that navigates to RecipeDetail. Use shared loading/error primitives.