### PR TITLE
fix: search page never displays results due to response format mismatch

### DIFF
--- a/app/frontend/src/__tests__/searchService.test.js
+++ b/app/frontend/src/__tests__/searchService.test.js
@@ -24,11 +24,18 @@ describe('search', () => {
     });
   });
 
-  it('returns the data array from the response', async () => {
-    const results = [{ type: 'recipe', id: 1, title: 'Baklava' }];
-    apiClient.get.mockResolvedValue({ data: results });
+  it('normalizes and merges recipes and stories from the response', async () => {
+    const apiResponse = {
+      recipes: [{ result_type: 'recipe', id: 1, title: 'Baklava', region_tag: 'Aegean', image: '/img.jpg' }],
+      stories: [{ result_type: 'story', id: 2, title: 'Kitchen tales', region_tag: null }],
+      total_count: 2,
+    };
+    apiClient.get.mockResolvedValue({ data: apiResponse });
     const result = await search('baklava', '', '');
-    expect(result).toEqual(results);
+    expect(result).toEqual([
+      { type: 'recipe', id: 1, title: 'Baklava', region: 'Aegean', thumbnail: '/img.jpg' },
+      { type: 'story', id: 2, title: 'Kitchen tales', region: null, thumbnail: null },
+    ]);
   });
 
   it('propagates API errors', async () => {

--- a/app/frontend/src/services/searchService.js
+++ b/app/frontend/src/services/searchService.js
@@ -3,13 +3,24 @@ import { filterMockResults, MOCK_REGIONS } from '../mocks/searchResults';
 
 const USE_MOCK = process.env.REACT_APP_USE_MOCK === 'true';
 
+function normalizeResult(item) {
+  return {
+    type: item.result_type,
+    id: item.id,
+    title: item.title,
+    region: item.region_tag ?? null,
+    thumbnail: item.image ?? null,
+  };
+}
+
 export async function search(q, region, language) {
   if (USE_MOCK) return filterMockResults(q, region);
   const params = { q };
   if (region) params.region = region;
   if (language) params.language = language;
   const response = await apiClient.get('/api/search/', { params });
-  return response.data;
+  const { recipes = [], stories = [] } = response.data;
+  return [...recipes, ...stories].map(normalizeResult);
 }
 
 export async function fetchRegions() {


### PR DESCRIPTION
## Summary
- Search page was completely broken — neither result cards nor the empty state message ever appeared
- Root cause: backend returns `{recipes: [], stories: [], total_count}` but the frontend treated it as a flat array; since objects don't have `.length`, the rendering conditions always evaluated to falsy

## Changes
- `searchService.js`: merge `recipes` and `stories` arrays from the API response into a single flat array, mapping `result_type` → `type`, `region_tag` → `region`, `image` → `thumbnail` so `SearchResultCard` receives the props it expects
- `searchService.test.js`: updated to verify the normalization logic with realistic API response shape

## Test plan
- [x] All 140 existing frontend tests pass
- [ ] Search with a matching query displays recipe and story cards
- [ ] Recipe and story results show correct type badge
- [ ] Region tag appears on cards when available
- [ ] Empty query returns all published content
- [ ] Non-matching query shows "No results found" message
