### PR TITLE
  feat: add GitHub Actions workflow for web app deployment (#275)

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -1,0 +1,48 @@
+name: Deploy Web App
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'app/backend/**'
+      - 'app/frontend/**'
+
+concurrency:
+  group: deploy-web-main
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Deploy to server via SSH
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          password: ${{ secrets.SERVER_PASSWORD }}
+          script: |
+            set -e
+
+            cd /root/bounswe2026group12
+            git fetch origin && git reset --hard origin/main
+
+            # --- Backend ---
+            cd app/backend
+            source venv/bin/activate
+            pip install -r requirements.txt --quiet
+            python manage.py migrate --noinput
+            python manage.py collectstatic --noinput
+            cp -r staticfiles/* /var/www/genipe-static/
+            deactivate
+            systemctl restart genipe-backend
+
+            # --- Frontend ---
+            cd ../frontend
+            npm ci
+            REACT_APP_API_URL=https://genipe.app npm run build
+            cp -r build/* /var/www/genipe/
+            chown -R www-data:www-data /var/www/genipe
+
+            echo "Deploy complete!"


### PR DESCRIPTION
## Summary                                                                                                                                                      
  - Add GitHub Actions workflow to automatically deploy backend and frontend on push to main
  - Triggers only when `app/backend/**` or `app/frontend/**` files change                                                                                         
  - Runs full deploy: git pull, pip install, migrate, collectstatic, restart backend, npm build, copy frontend                                                    
                                                                                                                                                                  
  ## Details                                                                                                                                                      
  - Uses `appleboy/ssh-action` for SSH-based deployment
  - Concurrency group prevents parallel deploys
  - Requires `SERVER_HOST`, `SERVER_USER`, `SERVER_PASSWORD` secrets (already configured)                                                                         
                                                                                                                                                                  
  ## Test plan                                                                                                                                                    
  - [ ] Push a backend change to main and verify workflow triggers                                                                                                
  - [ ] Verify backend restarts and API responds                                                                                                                  
  - [ ] Push a frontend change to main and verify build deploys to `/var/www/genipe/`                                                                             
  - [ ] Verify pushing non-app files (e.g. docs) does NOT trigger the workflow                                                                                    
                                                                                                                                                                  
  Closes #275 