### PR TITLE
fix: recipe detail and edit pages crash due to nested field assumptions

### DIFF
--- a/app/frontend/src/__tests__/RecipeDetailPage.test.jsx
+++ b/app/frontend/src/__tests__/RecipeDetailPage.test.jsx
@@ -3,18 +3,21 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { AuthContext } from '../context/AuthContext';
 import RecipeDetailPage from '../pages/RecipeDetailPage';
 import * as recipeService from '../services/recipeService';
+import * as searchService from '../services/searchService';
 
 jest.mock('../services/recipeService');
+jest.mock('../services/searchService');
 
 const mockRecipe = {
   id: 1,
   title: 'Baklava',
   description: 'A sweet pastry.',
-  region: 'Aegean',
+  region: 1,
   video: 'http://example.com/video.mp4',
-  author: { id: 3, username: 'eren' },
+  author: 3,
+  author_username: 'eren',
   ingredients: [
-    { ingredient: { id: 1, name: 'Phyllo dough' }, amount: '500', unit: { id: 1, name: 'g' } },
+    { ingredient: 1, ingredient_name: 'Phyllo dough', amount: '500', unit: 1, unit_name: 'g' },
   ],
   is_published: true,
   qa_enabled: true,
@@ -34,6 +37,10 @@ function renderPage(recipeId = '1', authUser = null) {
 
 beforeEach(() => {
   recipeService.fetchRecipe.mockResolvedValue(mockRecipe);
+  searchService.fetchRegions.mockResolvedValue([
+    { id: 1, name: 'Aegean' },
+    { id: 2, name: 'Mediterranean' },
+  ]);
 });
 
 describe('RecipeDetailPage', () => {

--- a/app/frontend/src/__tests__/RecipeEditPage.test.jsx
+++ b/app/frontend/src/__tests__/RecipeEditPage.test.jsx
@@ -19,9 +19,10 @@ const mockRecipe = {
   description: 'A sweet pastry.',
   region: 1,
   video: null,
-  author: { id: 3, username: 'eren' },
+  author: 3,
+  author_username: 'eren',
   ingredients: [
-    { ingredient: { id: 1, name: 'Phyllo dough' }, amount: '500', unit: { id: 1, name: 'g' } },
+    { ingredient: 1, ingredient_name: 'Phyllo dough', amount: '500', unit: 1, unit_name: 'g' },
   ],
   is_published: true,
   qa_enabled: false,

--- a/app/frontend/src/pages/RecipeDetailPage.jsx
+++ b/app/frontend/src/pages/RecipeDetailPage.jsx
@@ -2,17 +2,20 @@ import { useState, useEffect, useContext } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { AuthContext } from '../context/AuthContext';
 import { fetchRecipe } from '../services/recipeService';
+import { fetchRegions } from '../services/searchService';
 import './RecipeDetailPage.css';
 
 export default function RecipeDetailPage() {
   const { id } = useParams();
   const { user } = useContext(AuthContext);
   const [recipe, setRecipe] = useState(null);
+  const [regions, setRegions] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
 
   useEffect(() => {
     let cancelled = false;
+    fetchRegions().then((r) => { if (!cancelled) setRegions(r); }).catch(() => {});
     fetchRecipe(id)
       .then((data) => { if (!cancelled) setRecipe(data); })
       .catch(() => { if (!cancelled) setError('Could not load recipe.'); })
@@ -24,13 +27,14 @@ export default function RecipeDetailPage() {
   if (error) return <p className="page-status page-error">{error}</p>;
   if (!recipe) return null;
 
-  const isAuthor = user && recipe.author && user.id === recipe.author.id;
+  const isAuthor = user && user.id === recipe.author;
+  const regionName = regions.find((r) => r.id === recipe.region)?.name;
 
   return (
     <main className="page-card recipe-detail">
       <div className="recipe-detail-header">
         <div>
-          {recipe.region && <span className="recipe-region-tag">{recipe.region}</span>}
+          {regionName && <span className="recipe-region-tag">{regionName}</span>}
           <h1 className="recipe-title">{recipe.title}</h1>
         </div>
         {isAuthor && (
@@ -57,9 +61,9 @@ export default function RecipeDetailPage() {
         <h2>Ingredients</h2>
         <ul className="ingredients-list">
           {recipe.ingredients.map((ri) => (
-            <li key={ri.ingredient.id} className="ingredient-item">
-              <span className="ingredient-name">{ri.ingredient.name}</span>
-              <span className="ingredient-amount">{ri.amount} {ri.unit.name}</span>
+            <li key={ri.ingredient} className="ingredient-item">
+              <span className="ingredient-name">{ri.ingredient_name}</span>
+              <span className="ingredient-amount">{ri.amount} {ri.unit_name}</span>
             </li>
           ))}
         </ul>

--- a/app/frontend/src/pages/RecipeEditPage.jsx
+++ b/app/frontend/src/pages/RecipeEditPage.jsx
@@ -17,11 +17,11 @@ import './RecipeEditPage.css';
 function makeRowFromIngredient(ri) {
   return {
     id: `row-${Math.random().toString(36).slice(2)}`,
-    ingredientId: ri.ingredient.id,
-    ingredientName: ri.ingredient.name,
+    ingredientId: ri.ingredient,
+    ingredientName: ri.ingredient_name,
     amount: ri.amount,
-    unitId: ri.unit.id,
-    unitName: ri.unit.name,
+    unitId: ri.unit,
+    unitName: ri.unit_name,
   };
 }
 
@@ -160,7 +160,7 @@ export default function RecipeEditPage() {
 
   if (loading) return <p className="page-status">Loading…</p>;
   if (loadError) return <p className="page-status page-error">{loadError}</p>;
-  if (recipe && user && recipe.author && user.id !== recipe.author.id) {
+  if (recipe && user && user.id !== recipe.author) {
     return <p className="page-status page-error">You are not authorized to edit this recipe.</p>;
   }
 


### PR DESCRIPTION
## Summary
- Recipe detail and edit pages expected nested objects (`author.id`, `ingredient.name`, `unit.name`) but the backend returns flat fields (`author` as int, `author_username`, `ingredient_name`, `unit_name`)
- Region was displayed as an integer ID instead of the region name

## Changes

### RecipeDetailPage.jsx
- `recipe.author.id` → `recipe.author` (int comparison for edit button visibility)
- `ri.ingredient.name` → `ri.ingredient_name`, `ri.unit.name` → `ri.unit_name`
- Added region lookup: fetches regions list and resolves the FK ID to a display name

### RecipeEditPage.jsx
- `makeRowFromIngredient`: `ri.ingredient.id` → `ri.ingredient`, `ri.ingredient.name` → `ri.ingredient_name`, same for unit
- Author permission check: `recipe.author.id` → `recipe.author`

### Tests
- Updated mock data in both test files to match the real API response shape

## Test plan
- [x] All 140 frontend tests pass
- [x] Recipe detail page renders ingredients with name, amount, unit
- [x] Edit button only appears for the recipe author
- [x] Region displays as name (e.g. "Aegean") not integer
- [x] Edit page pre-populates ingredient rows correctly from API data
