### PR TITLE
feat: seed approved ingredients and units via data migration

### DIFF
--- a/app/backend/apps/common/management/commands/seed_test_db.py
+++ b/app/backend/apps/common/management/commands/seed_test_db.py
@@ -94,7 +94,10 @@ class Command(BaseCommand):
 
     def seed_units(self):
         self.stdout.write('Creating units...')
-        units = ['grams', 'kg', 'liters', 'ml', 'cups', 'tablespoons', 'teaspoons', 'units', 'cloves']
+        units = [
+            'grams', 'kg', 'liters', 'ml', 'cups', 'tablespoons', 'teaspoons',
+            'pieces', 'cloves', 'pinch', 'bunch', 'slices',
+        ]
         for name in units:
             unit, created = Unit.objects.get_or_create(name=name, defaults={'is_approved': True})
             if created:
@@ -102,7 +105,16 @@ class Command(BaseCommand):
 
     def seed_ingredients(self):
         self.stdout.write('Creating ingredients...')
-        ingredients = ['Tomato', 'Olive Oil', 'Flour', 'Honey', 'Walnuts', 'Garlic', 'Onion', 'Lentils', 'Rice']
+        ingredients = [
+            'Butter', 'Chicken', 'Cinnamon', 'Cream', 'Cumin', 'Eggplant',
+            'Eggs', 'Feta Cheese', 'Flour', 'Garlic', 'Ginger', 'Green Pepper',
+            'Ground Beef', 'Ground Lamb', 'Honey', 'Lamb', 'Lemon', 'Lentils',
+            'Mint', 'Mozzarella', 'Olive Oil', 'Onion', 'Oregano', 'Paprika',
+            'Parsley', 'Pasta', 'Pepper', 'Phyllo Dough', 'Pine Nuts', 'Pistachios',
+            'Potato', 'Red Pepper Flakes', 'Rice', 'Salt', 'Sesame Seeds',
+            'Sugar', 'Sumac', 'Tahini', 'Thyme', 'Tomato', 'Tomato Paste',
+            'Turmeric', 'Walnuts', 'Yogurt', 'Zucchini',
+        ]
         for name in ingredients:
             ing, created = Ingredient.objects.get_or_create(name=name, defaults={'is_approved': True})
             if created:

--- a/app/backend/apps/recipes/migrations/0005_seed_ingredients_units.py
+++ b/app/backend/apps/recipes/migrations/0005_seed_ingredients_units.py
@@ -1,0 +1,52 @@
+from django.db import migrations
+
+
+INGREDIENTS = [
+    "Butter", "Chicken", "Cinnamon", "Cream", "Cumin", "Eggplant",
+    "Eggs", "Feta Cheese", "Flour", "Garlic", "Ginger", "Green Pepper",
+    "Ground Beef", "Ground Lamb", "Honey", "Lamb", "Lemon", "Lentils",
+    "Mint", "Mozzarella", "Olive Oil", "Onion", "Oregano", "Paprika",
+    "Parsley", "Pasta", "Pepper", "Phyllo Dough", "Pine Nuts", "Pistachios",
+    "Potato", "Red Pepper Flakes", "Rice", "Salt", "Sesame Seeds",
+    "Sugar", "Sumac", "Tahini", "Thyme", "Tomato", "Tomato Paste",
+    "Turmeric", "Walnuts", "Yogurt", "Zucchini",
+]
+
+UNITS = [
+    "grams", "kg", "liters", "ml", "cups", "tablespoons", "teaspoons",
+    "pieces", "cloves", "pinch", "bunch", "slices",
+]
+
+
+def seed_ingredients(apps, schema_editor):
+    Ingredient = apps.get_model("recipes", "Ingredient")
+    for name in INGREDIENTS:
+        Ingredient.objects.get_or_create(name=name, defaults={"is_approved": True})
+
+
+def unseed_ingredients(apps, schema_editor):
+    Ingredient = apps.get_model("recipes", "Ingredient")
+    Ingredient.objects.filter(name__in=INGREDIENTS).delete()
+
+
+def seed_units(apps, schema_editor):
+    Unit = apps.get_model("recipes", "Unit")
+    for name in UNITS:
+        Unit.objects.get_or_create(name=name, defaults={"is_approved": True})
+
+
+def unseed_units(apps, schema_editor):
+    Unit = apps.get_model("recipes", "Unit")
+    Unit.objects.filter(name__in=UNITS).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("recipes", "0004_seed_regions"),
+    ]
+
+    operations = [
+        migrations.RunPython(seed_ingredients, unseed_ingredients),
+        migrations.RunPython(seed_units, unseed_units),
+    ]


### PR DESCRIPTION
## Summary
- Ingredient and unit dropdowns on recipe forms were empty because the database had no approved items
- Added a data migration that seeds 45 common cooking ingredients and 12 measurement units, all with `is_approved=True`

## Changes
- `0005_seed_ingredients_units.py`: reversible data migration seeding Ingredient and Unit tables
- `seed_test_db.py`: expanded ingredient/unit lists to match the migration for consistency

## Seeded data
**Ingredients (45):** Butter, Chicken, Cinnamon, Cream, Cumin, Eggplant, Eggs, Feta Cheese, Flour, Garlic, Ginger, Green Pepper, Ground Beef, Ground Lamb, Honey, Lamb, Lemon, Lentils, Mint, Mozzarella, Olive Oil, Onion, Oregano, Paprika, Parsley, Pasta, Pepper, Phyllo Dough, Pine Nuts, Pistachios, Potato, Red Pepper Flakes, Rice, Salt, Sesame Seeds, Sugar, Sumac, Tahini, Thyme, Tomato, Tomato Paste, Turmeric, Walnuts, Yogurt, Zucchini

**Units (12):** grams, kg, liters, ml, cups, tablespoons, teaspoons, pieces, cloves, pinch, bunch, slices

## Test plan
- [ ] Run `python manage.py migrate` — migration applies without errors
- [ ] `GET /api/ingredients/` returns non-empty list of approved ingredients
- [ ] `GET /api/units/` returns non-empty list of approved units
- [ ] Ingredient dropdown on recipe form shows suggestions
- [ ] Migration is reversible: `python manage.py migrate recipes 0004` removes seeded data

