### PR TITLE
fix(frontend): display author username on recipe detail page (#296)

### DIFF
--- a/app/frontend/src/__tests__/RecipeDetailPage.test.jsx
+++ b/app/frontend/src/__tests__/RecipeDetailPage.test.jsx
@@ -93,6 +93,13 @@ describe('RecipeDetailPage', () => {
     expect(screen.queryByRole('link', { name: /edit/i })).not.toBeInTheDocument();
   });
 
+  it('displays author username', async () => {
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByText(/by eren/i)).toBeInTheDocument()
+    );
+  });
+
   it('shows Edit button when logged-in user is the author', async () => {
     renderPage('1', { id: 3, username: 'eren' });
     await waitFor(() => screen.getByText('Baklava'));

--- a/app/frontend/src/pages/RecipeDetailPage.jsx
+++ b/app/frontend/src/pages/RecipeDetailPage.jsx
@@ -36,6 +36,9 @@ export default function RecipeDetailPage() {
         <div>
           {regionName && <span className="recipe-region-tag">{regionName}</span>}
           <h1 className="recipe-title">{recipe.title}</h1>
+          {recipe.author_username && (
+            <p className="recipe-author">By {recipe.author_username}</p>
+          )}
         </div>
         {isAuthor && (
           <Link to={`/recipes/${recipe.id}/edit`} className="btn btn-outline btn-sm">


### PR DESCRIPTION
## Summary                                                                                                                                                                                               
                                                                                                                                                                                                           
  - Added "By {author_username}" attribution line below the recipe title on the recipe detail page                                                                                                         
  - Uses `recipe.author_username` field already returned by the API — no backend changes needed                                                                                                            
  - Visible to both authenticated and unauthenticated viewers                                                                                                                                              
                                                                                                                                                                                                           
  ## Test Plan                                                                                                                                                                                             
                                                                                                                                                                                                           
  - [ ] Run `npm test -- --watchAll=false --testPathPattern="RecipeDetailPage"` — all 9 tests must pass                                                                                                    
  - [ ] Visit any recipe detail page (`/recipes/:id`) — verify "By {username}" appears below the title                                                                                                     
  - [ ] Verify the author line appears when logged out (unauthenticated viewer)                                                                                                                            
                                                                                                                                                                                                           
  Closes #296                       