### PR TITLE
feat(mobile): connect app to production API (genipe.app)

### DIFF
--- a/app/mobile/src/components/search/SearchResultCard.tsx
+++ b/app/mobile/src/components/search/SearchResultCard.tsx
@@ -1,18 +1,18 @@
 import React from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
-import type { MockSearchItem } from '../../mocks/searchResults';
+import type { SearchResultItem } from '../../services/searchService';
 import { shadows, tokens } from '../../theme';
 
 type Props = {
-  item: MockSearchItem;
+  item: SearchResultItem;
   onPress: () => void;
 };
 
-function kindLabel(kind: MockSearchItem['kind']) {
+function kindLabel(kind: SearchResultItem['kind']) {
   return kind === 'recipe' ? 'Recipe' : 'Story';
 }
 
-function thumbColor(kind: MockSearchItem['kind']) {
+function thumbColor(kind: SearchResultItem['kind']) {
   return kind === 'recipe' ? tokens.colors.surfaceDark : tokens.colors.accentGreen;
 }
 

--- a/app/mobile/src/config/apiBase.ts
+++ b/app/mobile/src/config/apiBase.ts
@@ -3,4 +3,4 @@
  * Set `EXPO_PUBLIC_API_URL` in `.env` for a real device hitting your machine (e.g. LAN IP).
  */
 export const API_BASE_URL =
-  process.env.EXPO_PUBLIC_API_URL ?? 'http://localhost:8000';
+  process.env.EXPO_PUBLIC_API_URL ?? 'https://genipe.app';

--- a/app/mobile/src/screens/HomeScreen.tsx
+++ b/app/mobile/src/screens/HomeScreen.tsx
@@ -1,10 +1,10 @@
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { FlatList, Image, Pressable, ScrollView, StyleSheet, Text, TextInput, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { shadows, tokens } from '../theme';
-import { listMockRecipes } from '../mocks/recipes';
-import { listMockStories } from '../mocks/stories';
+import { fetchRecipesList } from '../services/recipeService';
+import { apiGetJson } from '../services/httpClient';
 import type { RootStackParamList } from '../navigation/types';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Home'>;
@@ -12,8 +12,31 @@ type Props = NativeStackScreenProps<RootStackParamList, 'Home'>;
 export default function HomeScreen({ navigation }: Props) {
   const [query, setQuery] = useState('');
 
-  const stories = useMemo(() => listMockStories(), []);
-  const recipes = useMemo(() => listMockRecipes(), []);
+  const [stories, setStories] = useState<any[]>([]);
+  const [recipes, setRecipes] = useState<any[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const [storyData, recipeData] = await Promise.all([
+          apiGetJson<any[]>('/api/stories/'),
+          fetchRecipesList(),
+        ]);
+        if (cancelled) return;
+        setStories(Array.isArray(storyData) ? storyData : []);
+        setRecipes(Array.isArray(recipeData) ? recipeData : []);
+      } catch {
+        if (!cancelled) {
+          setStories([]);
+          setRecipes([]);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   return (
     <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
@@ -42,17 +65,16 @@ export default function HomeScreen({ navigation }: Props) {
         <View style={styles.section}>
           <View style={styles.sectionHeader}>
             <Text style={styles.sectionTitle}>Stories</Text>
-            <Text style={styles.sectionHint}>Mock feed</Text>
           </View>
           <FlatList
             data={stories}
             horizontal
-            keyExtractor={(item) => item.id}
+            keyExtractor={(item) => String(item.id)}
             showsHorizontalScrollIndicator={false}
             contentContainerStyle={styles.hList}
             renderItem={({ item }) => (
               <Pressable
-                onPress={() => navigation.navigate('StoryDetail', { id: item.id })}
+                onPress={() => navigation.navigate('StoryDetail', { id: String(item.id) })}
                 style={({ pressed }) => [styles.storyCard, pressed && styles.pressed]}
                 accessibilityRole="button"
                 accessibilityLabel={`Open story ${item.title}`}
@@ -80,17 +102,16 @@ export default function HomeScreen({ navigation }: Props) {
         <View style={styles.section}>
           <View style={styles.sectionHeader}>
             <Text style={styles.sectionTitle}>Recipes</Text>
-            <Text style={styles.sectionHint}>Mock feed</Text>
           </View>
           <FlatList
             data={recipes}
             horizontal
-            keyExtractor={(item) => item.id}
+            keyExtractor={(item) => String(item.id)}
             showsHorizontalScrollIndicator={false}
             contentContainerStyle={styles.hList}
             renderItem={({ item }) => (
               <Pressable
-                onPress={() => navigation.navigate('RecipeDetail', { id: item.id })}
+                onPress={() => navigation.navigate('RecipeDetail', { id: String(item.id) })}
                 style={({ pressed }) => [styles.recipeCard, pressed && styles.pressed]}
                 accessibilityRole="button"
                 accessibilityLabel={`Open recipe ${item.title}`}

--- a/app/mobile/src/screens/LoginScreen.tsx
+++ b/app/mobile/src/screens/LoginScreen.tsx
@@ -16,7 +16,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { useAuth } from '../context/AuthContext';
 import { validateLoginForm } from '../lib/authValidation';
 import type { RootStackParamList } from '../navigation/types';
-import { mockLoginRequest } from '../services/mockAuthService';
+import { loginRequest } from '../services/authService';
 import { shadows, tokens } from '../theme';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Login'>;
@@ -39,7 +39,7 @@ export default function LoginScreen({ navigation }: Props) {
     setApiError('');
     setSubmitting(true);
     try {
-      const data = await mockLoginRequest(email, password);
+      const data = await loginRequest(email, password);
       await login(data.user, data.access);
       navigation.dispatch(
         CommonActions.reset({

--- a/app/mobile/src/screens/RecipeCreateScreen.tsx
+++ b/app/mobile/src/screens/RecipeCreateScreen.tsx
@@ -14,7 +14,7 @@ import {
 import { recipeFormStyles as styles } from '../components/recipe/recipeFormStyles';
 import { useToast } from '../context/ToastContext';
 import type { RootStackParamList } from '../navigation/types';
-import { mockSubmitRecipeCreate } from '../services/mockRecipeCreate';
+import { apiPatchFormData, apiPostJson } from '../services/httpClient';
 import { tokens } from '../theme';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'RecipeCreate'>;
@@ -124,7 +124,28 @@ export default function RecipeCreateScreen(_props: Props) {
 
     void (async () => {
       try {
-        await mockSubmitRecipeCreate(payload);
+        // Same as web: JSON create, then multipart PATCH for video/thumbnail.
+        const created = await apiPostJson<{ id: number }>('/api/recipes/', {
+          title: 'Untitled recipe',
+          description: payload.description,
+          qa_enabled: payload.qa_enabled,
+          is_published: true,
+          ingredients_write: payload.ingredients.map((x) => ({
+            amount: x.amount,
+            ingredient: x.ingredient?.id ?? x.ingredient,
+            unit: x.unit?.id ?? x.unit,
+          })),
+        });
+        if (payload.video) {
+          const fd = new FormData();
+          // React Native file upload shape (not a web Blob).
+          fd.append('video', {
+            uri: payload.video.uri,
+            name: payload.video.fileName ?? 'recipe-video.mp4',
+            type: payload.video.mimeType ?? 'video/mp4',
+          } as any);
+          await apiPatchFormData(`/api/recipes/${created.id}/`, fd);
+        }
         showToast('Recipe published!', 'success');
       } catch {
         showToast('Failed to publish recipe. Please try again.', 'error');
@@ -144,8 +165,7 @@ export default function RecipeCreateScreen(_props: Props) {
           </Text>
           <Text style={styles.lead}>
             Create a recipe with a description, ingredients, and a video. Ingredient and unit
-            pickers use the same API paths as the web app when available; otherwise mock data
-            is used.
+            pickers load from the same API as the web app.
           </Text>
 
           <View style={styles.section}>
@@ -201,7 +221,7 @@ export default function RecipeCreateScreen(_props: Props) {
             accessibilityRole="button"
             accessibilityLabel="Submit recipe"
           >
-            <Text style={styles.primaryButtonText}>Submit (mock)</Text>
+            <Text style={styles.primaryButtonText}>Submit</Text>
           </Pressable>
 
           <View style={styles.summary}>

--- a/app/mobile/src/screens/RegisterScreen.tsx
+++ b/app/mobile/src/screens/RegisterScreen.tsx
@@ -16,7 +16,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { useAuth } from '../context/AuthContext';
 import { validateRegisterForm } from '../lib/authValidation';
 import type { RootStackParamList } from '../navigation/types';
-import { mockRegisterRequest } from '../services/mockAuthService';
+import { registerRequest } from '../services/authService';
 import { shadows, tokens } from '../theme';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Register'>;
@@ -40,7 +40,7 @@ export default function RegisterScreen({ navigation }: Props) {
     setApiError('');
     setSubmitting(true);
     try {
-      const data = await mockRegisterRequest(username, email, password);
+      const data = await registerRequest(username, email, password);
       await login(data.user, data.access);
       navigation.dispatch(
         CommonActions.reset({

--- a/app/mobile/src/screens/SearchScreen.tsx
+++ b/app/mobile/src/screens/SearchScreen.tsx
@@ -12,10 +12,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { EmptyState } from '../components/search/EmptyState';
 import { SearchResultCard } from '../components/search/SearchResultCard';
 import type { RootStackParamList } from '../navigation/types';
-import {
-  MOCK_SEARCH_RESULTS,
-  type MockSearchItem,
-} from '../mocks/searchResults';
+import { search, type SearchResultItem } from '../services/searchService';
 import { shadows, tokens } from '../theme';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Search'>;
@@ -26,24 +23,17 @@ const REGIONS: RegionOption[] = [
   { label: 'All regions', value: '' },
   { label: 'Anatolia', value: 'Anatolia' },
   { label: 'Aegean', value: 'Aegean' },
+  { label: 'Black Sea', value: 'Black Sea' },
+  { label: 'Marmara', value: 'Marmara' },
+  { label: 'Mediterranean', value: 'Mediterranean' },
 ];
-
-function filterItems(query: string, region: string): MockSearchItem[] {
-  const q = query.trim().toLowerCase();
-  const r = region.trim().toLowerCase();
-  return MOCK_SEARCH_RESULTS.filter((item) => {
-    const matchesQuery =
-      !q ||
-      item.title.toLowerCase().includes(q) ||
-      item.subtitle.toLowerCase().includes(q);
-    const matchesRegion = !r || (item.region ?? '').toLowerCase().includes(r);
-    return matchesQuery && matchesRegion;
-  });
-}
 
 export default function SearchScreen({ navigation, route }: Props) {
   const [query, setQuery] = useState('');
   const [region, setRegion] = useState('');
+  const [results, setResults] = useState<SearchResultItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     if (route.params?.query != null) setQuery(route.params.query);
@@ -51,14 +41,39 @@ export default function SearchScreen({ navigation, route }: Props) {
     // only initialize on first mount / param change
   }, [route.params?.query, route.params?.region]);
 
-  const data = useMemo(() => filterItems(query, region), [query, region]);
+  useEffect(() => {
+    const q = query.trim();
+    // Keep pristine state empty without calling backend.
+    if (!q && !region.trim()) {
+      setResults([]);
+      setError(null);
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    void (async () => {
+      try {
+        const data = await search(q, region.trim() || undefined);
+        if (!cancelled) setResults(data);
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : 'Search failed');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [query, region]);
 
   const selectedRegionLabel =
     REGIONS.find((r) => r.value === region)?.label ?? 'All regions';
 
   const isPristine = query.trim() === '' && region.trim() === '';
 
-  function onPressItem(item: MockSearchItem) {
+  function onPressItem(item: SearchResultItem) {
     if (item.kind === 'recipe') {
       navigation.navigate('RecipeDetail', { id: item.id });
     } else {
@@ -76,7 +91,7 @@ export default function SearchScreen({ navigation, route }: Props) {
         <TextInput
           value={query}
           onChangeText={setQuery}
-          placeholder="Filter mock results…"
+          placeholder="Search recipes and stories…"
           style={styles.input}
           accessibilityLabel="Search filter"
           autoCapitalize="none"
@@ -110,13 +125,26 @@ export default function SearchScreen({ navigation, route }: Props) {
         </View>
 
         <FlatList
-          data={data}
+          data={results}
           keyExtractor={(item) => item.key}
           numColumns={2}
           contentContainerStyle={styles.grid}
           columnWrapperStyle={styles.gridRow}
           ListEmptyComponent={
-            isPristine ? (
+            loading ? (
+              <EmptyState
+                title="Searching…"
+                message="Fetching results from the server."
+                glyph="…"
+              />
+            ) : error ? (
+              <EmptyState
+                title="Search failed"
+                message={error}
+                glyph="!"
+                actions={[{ label: 'Retry', onPress: () => setQuery((q) => q) }]}
+              />
+            ) : isPristine ? (
               <EmptyState
                 title="Start searching"
                 message="Type a keyword or pick a region to discover recipes and stories."

--- a/app/mobile/src/screens/StoryCreateScreen.tsx
+++ b/app/mobile/src/screens/StoryCreateScreen.tsx
@@ -10,7 +10,8 @@ import { useAuth } from '../context/AuthContext';
 import { useToast } from '../context/ToastContext';
 import type { RootStackParamList } from '../navigation/types';
 import { fetchRecipesList } from '../services/recipeService';
-import { mockSubmitStoryCreate, type StoryLanguage } from '../services/mockStoryService';
+import { apiPostJson } from '../services/httpClient';
+import type { StoryLanguage } from '../services/mockStoryService';
 import { tokens } from '../theme';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'StoryCreate'>;
@@ -68,14 +69,13 @@ export default function StoryCreateScreen({ navigation }: Props) {
     setSubmitting(true);
     void (async () => {
       try {
-        const created = await mockSubmitStoryCreate({
-          title,
-          body,
+        const created = await apiPostJson<{ id: string }>('/api/stories/', {
+          title: title.trim(),
+          body: body.trim(),
           language,
           is_published: true,
-          linked_recipe: linkedRecipe,
-          thumbnail: thumbnailUri,
-          author: user ? { username: user.username } : undefined,
+          linked_recipe: linkedRecipe ? linkedRecipe.id : null,
+          // thumbnail upload TODO (needs multipart)
         });
         showToast('Story published!', 'success');
         navigation.navigate('StoryDetail', { id: created.id });
@@ -201,7 +201,7 @@ export default function StoryCreateScreen({ navigation }: Props) {
             accessibilityRole="button"
             accessibilityLabel="Publish story"
           >
-            <Text style={form.primaryButtonText}>{submitting ? 'Publishing…' : 'Publish (mock)'}</Text>
+            <Text style={form.primaryButtonText}>{submitting ? 'Publishing…' : 'Publish'}</Text>
           </Pressable>
         </View>
       </ScrollView>

--- a/app/mobile/src/services/authService.ts
+++ b/app/mobile/src/services/authService.ts
@@ -1,0 +1,24 @@
+import type { AuthSuccess } from './mockAuthService';
+import { apiPostJson } from './httpClient';
+
+/**
+ * Real backend auth service.
+ * Mirrors web `authService.js` but uses the mobile fetch-based client.
+ *
+ * Endpoints:
+ * - POST /api/auth/login/
+ * - POST /api/auth/register/
+ */
+
+export async function loginRequest(email: string, password: string): Promise<AuthSuccess> {
+  return apiPostJson<AuthSuccess>('/api/auth/login/', { email, password });
+}
+
+export async function registerRequest(
+  username: string,
+  email: string,
+  password: string
+): Promise<AuthSuccess> {
+  return apiPostJson<AuthSuccess>('/api/auth/register/', { username, email, password });
+}
+

--- a/app/mobile/src/services/httpClient.ts
+++ b/app/mobile/src/services/httpClient.ts
@@ -3,6 +3,25 @@ import { API_BASE_URL } from '../config/apiBase';
 
 const TOKEN_KEY = 'token';
 
+async function readErrorMessage(res: Response): Promise<string> {
+  const contentType = res.headers.get('content-type') ?? '';
+  try {
+    if (contentType.includes('application/json')) {
+      const data = (await res.json()) as any;
+      const detail = typeof data?.detail === 'string' ? data.detail : null;
+      const nonField =
+        Array.isArray(data?.non_field_errors) && typeof data.non_field_errors[0] === 'string'
+          ? data.non_field_errors[0]
+          : null;
+      return detail || nonField || JSON.stringify(data);
+    }
+    const text = await res.text();
+    return text;
+  } catch {
+    return '';
+  }
+}
+
 async function authHeaders(): Promise<HeadersInit> {
   const token = await AsyncStorage.getItem(TOKEN_KEY);
   const headers: Record<string, string> = {
@@ -20,8 +39,8 @@ export async function apiGetJson<T>(path: string): Promise<T> {
     headers: await authHeaders(),
   });
   if (!res.ok) {
-    const text = await res.text();
-    throw new Error(text || `GET ${path} failed (${res.status})`);
+    const message = (await readErrorMessage(res)).trim();
+    throw new Error(message || `GET ${path} failed (${res.status})`);
   }
   return res.json() as Promise<T>;
 }
@@ -34,8 +53,8 @@ export async function apiPostJson<T>(path: string, body: object): Promise<T> {
     body: JSON.stringify(body),
   });
   if (!res.ok) {
-    const text = await res.text();
-    throw new Error(text || `POST ${path} failed (${res.status})`);
+    const message = (await readErrorMessage(res)).trim();
+    throw new Error(message || `POST ${path} failed (${res.status})`);
   }
   return res.json() as Promise<T>;
 }
@@ -54,7 +73,7 @@ export async function apiPatchFormData(path: string, formData: FormData): Promis
     body: formData,
   });
   if (!res.ok) {
-    const text = await res.text();
-    throw new Error(text || `PATCH ${path} failed (${res.status})`);
+    const message = (await readErrorMessage(res)).trim();
+    throw new Error(message || `PATCH ${path} failed (${res.status})`);
   }
 }

--- a/app/mobile/src/services/ingredientUnitService.ts
+++ b/app/mobile/src/services/ingredientUnitService.ts
@@ -1,49 +1,26 @@
 import type { CatalogItem } from '../types/catalog';
-import {
-  getMockIngredients,
-  getMockUnits,
-  mockCreateIngredient,
-  mockCreateUnit,
-} from '../mocks/catalogStore';
 import { apiGetJson, apiPostJson } from './httpClient';
 
 /**
  * Same endpoints as web `recipeService.js` (`/api/ingredients/`, `/api/units/`).
- * Falls back to in-memory mocks when the server is unavailable.
  */
 
 export async function fetchIngredients(): Promise<CatalogItem[]> {
-  try {
-    return await apiGetJson<CatalogItem[]>('/api/ingredients/');
-  } catch {
-    return getMockIngredients();
-  }
+  return apiGetJson<CatalogItem[]>('/api/ingredients/');
 }
 
 export async function fetchUnits(): Promise<CatalogItem[]> {
-  try {
-    return await apiGetJson<CatalogItem[]>('/api/units/');
-  } catch {
-    return getMockUnits();
-  }
+  return apiGetJson<CatalogItem[]>('/api/units/');
 }
 
 export async function submitIngredient(name: string): Promise<CatalogItem> {
   const trimmed = name.trim();
   if (!trimmed) throw new Error('Name is required');
-  try {
-    return await apiPostJson<CatalogItem>('/api/ingredients/', { name: trimmed });
-  } catch {
-    return mockCreateIngredient(trimmed);
-  }
+  return apiPostJson<CatalogItem>('/api/ingredients/', { name: trimmed });
 }
 
 export async function submitUnit(name: string): Promise<CatalogItem> {
   const trimmed = name.trim();
   if (!trimmed) throw new Error('Name is required');
-  try {
-    return await apiPostJson<CatalogItem>('/api/units/', { name: trimmed });
-  } catch {
-    return mockCreateUnit(trimmed);
-  }
+  return apiPostJson<CatalogItem>('/api/units/', { name: trimmed });
 }

--- a/app/mobile/src/services/recipeService.ts
+++ b/app/mobile/src/services/recipeService.ts
@@ -1,21 +1,12 @@
 import type { RecipeDetail } from '../types/recipe';
-import { getMockRecipeDetailById, listMockRecipes, type MockRecipeListItem } from '../mocks/recipes';
 import { apiGetJson, apiPatchFormData } from './httpClient';
-import { mockSubmitRecipeUpdate } from './mockRecipeCreate';
 
 /**
  * Same endpoint as web `fetchRecipe` in `recipeService.js`.
- * Falls back to mock detail when the request fails (offline / no backend).
  */
 export async function fetchRecipeById(id: string): Promise<RecipeDetail> {
-  try {
-    const data = await apiGetJson<RecipeDetail>(`/api/recipes/${id}/`);
-    return normalizeRecipeDetail(data);
-  } catch {
-    const mock = getMockRecipeDetailById(id);
-    if (!mock) throw new Error('Could not load recipe.');
-    return mock;
-  }
+  const data = await apiGetJson<RecipeDetail>(`/api/recipes/${id}/`);
+  return normalizeRecipeDetail(data);
 }
 
 function normalizeRecipeDetail(data: RecipeDetail): RecipeDetail {
@@ -26,28 +17,33 @@ function normalizeRecipeDetail(data: RecipeDetail): RecipeDetail {
 }
 
 /**
- * Same as web `updateRecipe` (`PATCH` + `FormData`). Falls back to mock when the request fails.
+ * Same as web `updateRecipe` (`PATCH` + `FormData`).
  */
 export async function updateRecipeById(id: string, formData: FormData): Promise<void> {
-  try {
-    await apiPatchFormData(`/api/recipes/${id}/`, formData);
-  } catch {
-    await mockSubmitRecipeUpdate(id);
-  }
+  await apiPatchFormData(`/api/recipes/${id}/`, formData);
 }
 
 /** Minimal list for story linking / pickers (web: GET `/api/recipes/`). */
-export async function fetchRecipesList(): Promise<MockRecipeListItem[]> {
-  try {
-    // We only need id/title/region/author for UI; backend may return more fields.
-    const data = await apiGetJson<any[]>(`/api/recipes/`);
-    return (Array.isArray(data) ? data : []).map((r) => ({
+export async function fetchRecipesList(): Promise<
+  { id: string; title: string; region?: string; author?: any }[]
+> {
+  // We only need id/title/region/author for UI; backend may return more fields.
+  const data = await apiGetJson<any[]>(`/api/recipes/`);
+  return (Array.isArray(data) ? data : []).map((r) => {
+    const reg = r.region;
+    const regionLabel =
+      reg == null
+        ? undefined
+        : typeof reg === 'string'
+          ? reg
+          : typeof reg === 'object' && reg && 'name' in reg && typeof (reg as { name: unknown }).name === 'string'
+            ? (reg as { name: string }).name
+            : undefined;
+    return {
       id: String(r.id),
       title: String(r.title ?? ''),
-      region: r.region ?? undefined,
+      region: regionLabel,
       author: r.author ?? undefined,
-    }));
-  } catch {
-    return listMockRecipes();
-  }
+    };
+  });
 }

--- a/app/mobile/src/services/searchService.ts
+++ b/app/mobile/src/services/searchService.ts
@@ -1,0 +1,59 @@
+import { apiGetJson } from './httpClient';
+
+export type SearchResultItem = {
+  key: string;
+  kind: 'recipe' | 'story';
+  id: string;
+  title: string;
+  subtitle: string;
+  region?: string;
+  thumbnail?: string | null;
+};
+
+type BackendSearchResponse = {
+  recipes?: Array<{
+    result_type: 'recipe';
+    id: number | string;
+    title: string;
+    image?: string | null;
+    region_tag?: string | null;
+  }>;
+  stories?: Array<{
+    result_type: 'story';
+    id: number | string;
+    title: string;
+    linked_recipe_id?: number | string | null;
+    region_tag?: string | null;
+  }>;
+  total_count?: number;
+};
+
+export async function search(q: string, region?: string): Promise<SearchResultItem[]> {
+  const params = new URLSearchParams();
+  params.set('q', q);
+  if (region) params.set('region', region);
+  const data = await apiGetJson<BackendSearchResponse>(`/api/search/?${params.toString()}`);
+
+  const recipes = (data.recipes ?? []).map((r) => ({
+    key: `recipe-${r.id}`,
+    kind: 'recipe' as const,
+    id: String(r.id),
+    title: String(r.title ?? ''),
+    subtitle: r.region_tag ? `Recipe · ${r.region_tag}` : 'Recipe',
+    region: r.region_tag ?? undefined,
+    thumbnail: r.image ?? null,
+  }));
+
+  const stories = (data.stories ?? []).map((s) => ({
+    key: `story-${s.id}`,
+    kind: 'story' as const,
+    id: String(s.id),
+    title: String(s.title ?? ''),
+    subtitle: 'Story',
+    region: s.region_tag ?? undefined,
+    thumbnail: null,
+  }));
+
+  return [...recipes, ...stories];
+}
+

--- a/app/mobile/src/services/storyService.ts
+++ b/app/mobile/src/services/storyService.ts
@@ -1,17 +1,10 @@
-import { getMockStoryById } from '../mocks/stories';
 import type { StoryDetail } from '../types/story';
 import { apiGetJson } from './httpClient';
 
-/** Same endpoint as web `fetchStory` (`GET /api/stories/:id/`), with mock fallback. */
+/** Same endpoint as web `fetchStory` (`GET /api/stories/:id/`). */
 export async function fetchStoryById(id: string): Promise<StoryDetail> {
-  try {
-    const data = await apiGetJson<StoryDetail>(`/api/stories/${id}/`);
-    return normalizeStoryDetail(data);
-  } catch {
-    const mock = getMockStoryById(id);
-    if (!mock) throw new Error('Could not load story.');
-    return mock;
-  }
+  const data = await apiGetJson<StoryDetail>(`/api/stories/${id}/`);
+  return normalizeStoryDetail(data);
 }
 
 function normalizeStoryDetail(data: StoryDetail): StoryDetail {


### PR DESCRIPTION
- Default API base to https://genipe.app with EXPO_PUBLIC_API_URL override
- Wire login/register to JWT auth endpoints; improve API error messages
- Replace mock fallbacks with real GET/POST for stories, recipes, search, units
- Recipe create: JSON POST then multipart PATCH for video (matches web)
- Home feed loads stories and recipes; fix region label and useEffect import
- Normalize recipe list region field when API returns nested objects