### PR TITLE
fix(frontend): show region name instead of ID on recipe list cards (#…

### DIFF
--- a/app/backend/apps/recipes/serializers.py
+++ b/app/backend/apps/recipes/serializers.py
@@ -74,6 +74,7 @@ class RecipeIngredientWriteSerializer(serializers.Serializer):
 
 class RecipeSerializer(serializers.ModelSerializer):
     author_username = serializers.ReadOnlyField(source='author.username')
+    region_name = serializers.ReadOnlyField(source='region.name')
     ingredients = RecipeIngredientSerializer(source='recipe_ingredients', many=True, read_only=True)
     ingredients_write = RecipeIngredientWriteSerializer(many=True, write_only=True, required=False)
 
@@ -81,7 +82,7 @@ class RecipeSerializer(serializers.ModelSerializer):
         model = Recipe
         fields = [
             'id', 'title', 'description', 'image', 'video',
-            'region', 'author', 'author_username', 'qa_enabled',
+            'region', 'region_name', 'author', 'author_username', 'qa_enabled',
             'is_published', 'created_at', 'updated_at',
             'ingredients', 'ingredients_write'
         ]

--- a/app/frontend/src/__tests__/RecipeListPage.test.jsx
+++ b/app/frontend/src/__tests__/RecipeListPage.test.jsx
@@ -6,8 +6,8 @@ import * as recipeService from '../services/recipeService';
 jest.mock('../services/recipeService');
 
 const mockRecipes = [
-  { id: 1, title: 'Baklava', region: 'Aegean', image: null, author_username: 'eren' },
-  { id: 2, title: 'Manti', region: 'Central Anatolia', image: null, author_username: 'ahmet' },
+  { id: 1, title: 'Baklava', region: 1, region_name: 'Aegean', image: null, author_username: 'eren' },
+  { id: 2, title: 'Manti', region: 2, region_name: 'Central Anatolia', image: null, author_username: 'ahmet' },
 ];
 
 function renderPage() {
@@ -61,9 +61,27 @@ describe('RecipeListPage', () => {
     );
   });
 
+  it('displays region name (not ID) on recipe cards', async () => {
+    recipeService.fetchRecipes.mockResolvedValue(mockRecipes);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('Aegean')).toBeInTheDocument();
+      expect(screen.queryByText('1')).not.toBeInTheDocument();
+    });
+  });
+
+  it('does not show region tag when region_name is absent', async () => {
+    recipeService.fetchRecipes.mockResolvedValue([
+      { id: 1, title: 'Baklava', region: null, region_name: null, image: null, author_username: 'eren' },
+    ]);
+    renderPage();
+    await waitFor(() => screen.getByText('Baklava'));
+    expect(screen.queryByRole('generic', { name: /region/i })).not.toBeInTheDocument();
+  });
+
   it('renders recipe image when image is present', async () => {
     recipeService.fetchRecipes.mockResolvedValue([
-      { id: 1, title: 'Baklava', region: 'Aegean', image: 'http://example.com/img.jpg', author_username: 'eren' },
+      { id: 1, title: 'Baklava', region: 1, region_name: 'Aegean', image: 'http://example.com/img.jpg', author_username: 'eren' },
     ]);
     renderPage();
     await waitFor(() => {

--- a/app/frontend/src/pages/RecipeListPage.jsx
+++ b/app/frontend/src/pages/RecipeListPage.jsx
@@ -36,8 +36,8 @@ export default function RecipeListPage() {
               }
             </div>
             <div className="recipe-browse-body">
-              {recipe.region && (
-                <span className="recipe-browse-region">{recipe.region}</span>
+              {recipe.region_name && (
+                <span className="recipe-browse-region">{recipe.region_name}</span>
               )}
               <h2 className="recipe-browse-title">
                 <Link to={`/recipes/${recipe.id}`} className="recipe-browse-link">{recipe.title}</Link>


### PR DESCRIPTION
## Summary                                                                                                                                                                                               
                                                                                                                                                                                                           
  - Added `region_name` read-only field to `RecipeSerializer` (backend) sourced from `region.name`                                                                                                         
  - Recipe list cards (`/recipes`) now display the region name string (e.g. "Aegean") instead of the integer FK ID                                                                                         
  - Cards with no region render cleanly with no empty tag                                                                                                                                                  
                                                                                                                                                                                                           
  ## Changes                                                                                                                                                                                               
                                                                                                                                                                                                           
  - `app/backend/apps/recipes/serializers.py` — added `region_name = serializers.ReadOnlyField(source='region.name')` to `RecipeSerializer`                                                            
  - `app/frontend/src/pages/RecipeListPage.jsx` — changed `recipe.region` → `recipe.region_name`
  - `app/frontend/src/__tests__/RecipeListPage.test.jsx` — updated mocks to include `region_name`, added 2 new tests                                                                                       
                                                                                                                                                                                                           
  ## Test Plan                                                                                                                                                                                             
                                                                                                                                                                                                           
  - [ ] Run `npm test -- --watchAll=false --testPathPattern="RecipeListPage"` — all 8 tests must pass                                                                                                      
  - [ ] Visit `/recipes` — verify region tags show names like "Aegean" not "1" or "2"                                                                                                                      
  - [ ] Verify recipes without a region show no region tag                                                                                                                                                 
                                                                                                                                                                                                           
  Closes #294                                                                        