### PR TITLE
fix(mobile): persist all recipe ingredients on edit (JSON PATCH)

### DIFF
--- a/app/mobile/src/components/recipe/buildRecipeUpdateFormData.ts
+++ b/app/mobile/src/components/recipe/buildRecipeUpdateFormData.ts
@@ -1,38 +1,47 @@
 import type { AuthoringIngredientRow } from './recipeFormState';
 import type { LocalVideoSelection } from './RecipeVideoSection';
 
-/** Mirrors web `RecipeEditPage` `FormData` assembly (`PATCH /api/recipes/:id/`). */
-export function buildRecipeUpdateFormData(input: {
+/**
+ * JSON body for PATCH /api/recipes/:id/ — matches web `RecipeEditPage` payload shape.
+ * DRF does not reliably accept `ingredients_write` lists via multipart; use JSON for fields + rows.
+ */
+export function buildRecipePatchJsonBody(input: {
   title: string;
   description: string;
   region: string;
   qaEnabled: boolean;
-  localVideo: LocalVideoSelection | null;
   rows: AuthoringIngredientRow[];
-}): FormData {
-  const fd = new FormData();
-  fd.append('title', input.title.trim());
-  fd.append('description', input.description.trim());
-  fd.append('region', input.region.trim());
-  fd.append('qa_enabled', String(input.qaEnabled));
-  fd.append('is_published', 'true');
-
-  if (input.localVideo) {
-    fd.append('video', {
-      uri: input.localVideo.uri,
-      name: input.localVideo.fileName ?? 'video.mp4',
-      type: input.localVideo.mimeType ?? 'video/mp4',
-    } as unknown as Blob);
-  }
-
+}): Record<string, unknown> {
   const validRows = input.rows.filter(
     (r) => r.ingredient.id != null && r.amount.trim() !== '' && r.unit.id != null,
   );
-  validRows.forEach((r, i) => {
-    fd.append(`ingredients[${i}][ingredient]`, String(r.ingredient.id));
-    fd.append(`ingredients[${i}][amount]`, r.amount.trim());
-    fd.append(`ingredients[${i}][unit]`, String(r.unit.id));
-  });
+  const regionTrim = input.region.trim();
+  const regionNum = regionTrim ? Number(regionTrim) : NaN;
 
+  return {
+    title: input.title.trim(),
+    description: input.description.trim(),
+    region: regionTrim && Number.isFinite(regionNum) ? regionNum : null,
+    qa_enabled: input.qaEnabled,
+    is_published: true,
+    ingredients_write: validRows.map((r) => ({
+      ingredient: r.ingredient.id,
+      amount: r.amount.trim(),
+      unit: r.unit.id,
+    })),
+  };
+}
+
+/** Multipart PATCH with only a new video file (after JSON patch saved other fields). */
+export function buildRecipeVideoOnlyFormData(localVideo: LocalVideoSelection): FormData {
+  const fd = new FormData();
+  fd.append(
+    'video',
+    {
+      uri: localVideo.uri,
+      name: localVideo.fileName ?? 'video.mp4',
+      type: localVideo.mimeType ?? 'video/mp4',
+    } as unknown as Blob,
+  );
   return fd;
 }

--- a/app/mobile/src/components/recipe/recipeFormState.ts
+++ b/app/mobile/src/components/recipe/recipeFormState.ts
@@ -25,7 +25,7 @@ export function authoringRowsFromRecipe(
 ): AuthoringIngredientRow[] {
   if (!ingredients?.length) return [makeEmptyIngredientRow()];
   return ingredients.map((ri, i) => ({
-    key: `row-loaded-${ri.ingredient.id}-${i}`,
+    key: `row-loaded-${ri.lineId ?? ri.ingredient.id}-${i}`,
     amount: String(ri.amount),
     ingredient: { id: ri.ingredient.id, name: ri.ingredient.name },
     unit: { id: ri.unit.id ?? null, name: ri.unit.name },

--- a/app/mobile/src/screens/RecipeDetailScreen.tsx
+++ b/app/mobile/src/screens/RecipeDetailScreen.tsx
@@ -132,7 +132,7 @@ export default function RecipeDetailScreen({ route, navigation }: Props) {
           <View style={styles.list}>
             {ingredients.map((ri, index) => (
               <View
-                key={`${ri.ingredient.id}-${index}`}
+                key={ri.lineId != null ? `ing-line-${ri.lineId}` : `ing-line-${index}-${ri.ingredient.id}`}
                 style={styles.ingredientRow}
               >
                 <Text style={styles.ingredientName}>{ri.ingredient.name}</Text>

--- a/app/mobile/src/screens/RecipeEditScreen.tsx
+++ b/app/mobile/src/screens/RecipeEditScreen.tsx
@@ -3,7 +3,10 @@ import * as ImagePicker from 'expo-image-picker';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Pressable, ScrollView, Switch, Text, TextInput, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { buildRecipeUpdateFormData } from '../components/recipe/buildRecipeUpdateFormData';
+import {
+  buildRecipePatchJsonBody,
+  buildRecipeVideoOnlyFormData,
+} from '../components/recipe/buildRecipeUpdateFormData';
 import { InlineFieldError } from '../components/recipe/InlineFieldError';
 import { RecipeIngredientRowsSection } from '../components/recipe/RecipeIngredientRowsSection';
 import { RecipeVideoSection } from '../components/recipe/RecipeVideoSection';
@@ -19,7 +22,7 @@ import { LoadingView } from '../components/ui/LoadingView';
 import { useAuth } from '../context/AuthContext';
 import { useToast } from '../context/ToastContext';
 import type { RootStackParamList } from '../navigation/types';
-import { fetchRecipeById, updateRecipeById } from '../services/recipeService';
+import { fetchRecipeById, patchRecipeJson, updateRecipeById } from '../services/recipeService';
 import type { RecipeDetail } from '../types/recipe';
 import { isRecipeAuthor } from '../utils/recipeAuthor';
 
@@ -145,18 +148,20 @@ export default function RecipeEditScreen({ route, navigation }: Props) {
     setAttemptedSubmit(true);
     if (!isValid) return;
 
-    const fd = buildRecipeUpdateFormData({
+    const jsonBody = buildRecipePatchJsonBody({
       title,
       description,
       region,
       qaEnabled,
-      localVideo,
       rows,
     });
 
     void (async () => {
       try {
-        await updateRecipeById(id, fd);
+        await patchRecipeJson(id, jsonBody);
+        if (localVideo) {
+          await updateRecipeById(id, buildRecipeVideoOnlyFormData(localVideo));
+        }
         showToast('Recipe updated!', 'success');
         setTimeout(() => navigation.navigate('RecipeDetail', { id }), 1500);
       } catch {

--- a/app/mobile/src/services/recipeService.ts
+++ b/app/mobile/src/services/recipeService.ts
@@ -1,6 +1,6 @@
 import type { RecipeDetail, RecipeIngredientRow } from '../types/recipe';
 import { parseAuthorId } from '../utils/parseAuthorId';
-import { apiGetJson, apiPatchFormData } from './httpClient';
+import { apiGetJson, apiPatchFormData, apiPatchJson } from './httpClient';
 
 /**
  * Same endpoint as web `fetchRecipe` in `recipeService.js`.
@@ -45,7 +45,18 @@ function normalizeRecipeIngredients(raw: unknown): RecipeIngredientRow[] {
     const amount: string | number =
       typeof amt === 'string' || typeof amt === 'number' ? amt : amt != null ? String(amt) : '';
 
+    const lid = row.id;
+    const lineIdParsed =
+      typeof lid === 'number'
+        ? lid
+        : typeof lid === 'string' && lid !== ''
+          ? Number(lid)
+          : undefined;
+    const lineId =
+      lineIdParsed != null && Number.isFinite(lineIdParsed) ? lineIdParsed : undefined;
+
     return {
+      lineId,
       ingredient,
       amount,
       unit: unitObj,
@@ -77,9 +88,12 @@ function normalizeRecipeDetail(data: RecipeDetail & Record<string, unknown>): Re
   };
 }
 
-/**
- * Same as web `updateRecipe` (`PATCH` + `FormData`).
- */
+/** PATCH recipe fields as JSON (e.g. `ingredients_write`) — same as web non-file update. */
+export async function patchRecipeJson(id: string, body: Record<string, unknown>): Promise<void> {
+  await apiPatchJson(`/api/recipes/${id}/`, body);
+}
+
+/** PATCH multipart only — use for file fields (e.g. new video) after JSON patch when needed. */
 export async function updateRecipeById(id: string, formData: FormData): Promise<void> {
   await apiPatchFormData(`/api/recipes/${id}/`, formData);
 }

--- a/app/mobile/src/types/recipe.ts
+++ b/app/mobile/src/types/recipe.ts
@@ -2,6 +2,8 @@
  * Single-recipe payload from GET `/api/recipes/:id/` (see web `RecipeDetailPage.jsx`).
  */
 export type RecipeIngredientRow = {
+  /** Join-table PK from GET /api/recipes/:id/ (`RecipeIngredient.id`) — stable list keys. */
+  lineId?: number;
   ingredient: { id: number; name: string };
   amount: string | number;
   unit: { id?: number; name: string };


### PR DESCRIPTION
- Send ingredients_write via JSON PATCH like web; DRF multipart does not nest lists reliably
- Follow with multipart PATCH only when replacing video
- Preserve RecipeIngredient line id as lineId for stable detail list keys
