### PR TITLE
feat(mobile): unit toggle on recipe detail

### DIFF
--- a/app/mobile/src/screens/RecipeDetailScreen.tsx
+++ b/app/mobile/src/screens/RecipeDetailScreen.tsx
@@ -10,6 +10,7 @@ import type { RootStackParamList } from '../navigation/types';
 import { fetchRecipeById } from '../services/recipeService';
 import type { RecipeDetail } from '../types/recipe';
 import { isRecipeAuthor } from '../utils/recipeAuthor';
+import { convertIngredient } from '../utils/unitConversion';
 import { shadows, tokens } from '../theme';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'RecipeDetail'>;
@@ -21,6 +22,7 @@ export default function RecipeDetailScreen({ route, navigation }: Props) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [reloadToken, setReloadToken] = useState(0);
+  const [showConverted, setShowConverted] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -132,27 +134,62 @@ export default function RecipeDetailScreen({ route, navigation }: Props) {
             <Text style={styles.muted}>No description.</Text>
           )}
 
-          <Text style={styles.sectionTitle}>Ingredients</Text>
+          <View style={styles.ingredientsHeader}>
+            <Text style={styles.sectionTitle}>Ingredients</Text>
+            {ingredients.length > 0 ? (
+              <View style={styles.unitToggle} accessibilityRole="tablist">
+                <Pressable
+                  onPress={() => setShowConverted(false)}
+                  style={[styles.unitToggleBtn, !showConverted && styles.unitToggleBtnActive]}
+                  accessibilityRole="tab"
+                  accessibilityState={{ selected: !showConverted }}
+                  accessibilityLabel="Show original units"
+                >
+                  <Text style={[styles.unitToggleText, !showConverted && styles.unitToggleTextActive]}>
+                    Original
+                  </Text>
+                </Pressable>
+                <Pressable
+                  onPress={() => setShowConverted(true)}
+                  style={[styles.unitToggleBtn, showConverted && styles.unitToggleBtnActive]}
+                  accessibilityRole="tab"
+                  accessibilityState={{ selected: showConverted }}
+                  accessibilityLabel="Show converted units"
+                >
+                  <Text style={[styles.unitToggleText, showConverted && styles.unitToggleTextActive]}>
+                    Converted
+                  </Text>
+                </Pressable>
+              </View>
+            ) : null}
+          </View>
           {ingredients.length === 0 ? (
             <Text style={styles.muted}>No ingredients listed.</Text>
           ) : (
             <View style={styles.list}>
-              {ingredients.map((ri, index) => (
-                <View
-                  key={
-                    ri.lineId != null
-                      ? `ing-line-${ri.lineId}`
-                      : `ing-line-${index}-${ri.ingredient.id}`
-                  }
-                  style={styles.ingredientRow}
-                >
-                  <Text style={styles.ingredientName}>{ri.ingredient.name}</Text>
-                  <Text style={styles.ingredientAmount}>
-                    {' — '}
-                    {String(ri.amount)} {ri.unit.name}
-                  </Text>
-                </View>
-              ))}
+              {ingredients.map((ri, index) => {
+                const converted = showConverted
+                  ? convertIngredient(ri.amount, ri.unit.name)
+                  : null;
+                const displayAmount = converted ? converted.amount : String(ri.amount);
+                const displayUnit = converted ? converted.unit : ri.unit.name;
+                return (
+                  <View
+                    key={
+                      ri.lineId != null
+                        ? `ing-line-${ri.lineId}`
+                        : `ing-line-${index}-${ri.ingredient.id}`
+                    }
+                    style={styles.ingredientRow}
+                  >
+                    <Text style={styles.ingredientName}>{ri.ingredient.name}</Text>
+                    <Text style={styles.ingredientAmount}>
+                      {' — '}
+                      {displayAmount} {displayUnit}
+                    </Text>
+                  </View>
+                );
+              })}
             </View>
           )}
         </View>
@@ -229,13 +266,42 @@ const styles = StyleSheet.create({
     lineHeight: 24,
   },
   muted: { marginTop: 12, fontSize: 15, color: tokens.colors.textMuted },
-  sectionTitle: {
+  ingredientsHeader: {
     marginTop: 24,
+    marginBottom: 10,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 12,
+  },
+  sectionTitle: {
     fontSize: 18,
     fontWeight: '700',
     color: tokens.colors.text,
-    marginBottom: 10,
     fontFamily: tokens.typography.display.fontFamily,
+  },
+  unitToggle: {
+    flexDirection: 'row',
+    borderWidth: 1,
+    borderColor: tokens.colors.border,
+    borderRadius: tokens.radius.lg,
+    overflow: 'hidden',
+    backgroundColor: tokens.colors.surface,
+  },
+  unitToggleBtn: {
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+  },
+  unitToggleBtnActive: {
+    backgroundColor: tokens.colors.primary,
+  },
+  unitToggleText: {
+    fontSize: 13,
+    fontWeight: '700',
+    color: tokens.colors.textMuted,
+  },
+  unitToggleTextActive: {
+    color: tokens.colors.surface,
   },
   list: { gap: 0 },
   ingredientRow: {

--- a/app/mobile/src/utils/unitConversion.ts
+++ b/app/mobile/src/utils/unitConversion.ts
@@ -1,0 +1,31 @@
+type ConversionPair = { to: string; factor: number };
+
+const CONVERSIONS: Record<string, ConversionPair> = {
+  grams: { to: 'oz', factor: 0.035274 },
+  kg: { to: 'lb', factor: 2.20462 },
+  ml: { to: 'fl oz', factor: 0.033814 },
+  liters: { to: 'qt', factor: 1.05669 },
+  cups: { to: 'ml', factor: 236.588 },
+  tablespoons: { to: 'ml', factor: 14.787 },
+  teaspoons: { to: 'ml', factor: 4.929 },
+};
+
+export type ConvertedAmount = { amount: string; unit: string };
+
+export function convertIngredient(
+  amount: string | number,
+  unitName: string,
+): ConvertedAmount | null {
+  const pair = CONVERSIONS[unitName];
+  if (!pair) return null;
+  const numeric = typeof amount === 'number' ? amount : parseFloat(amount);
+  if (Number.isNaN(numeric)) return null;
+  const converted = numeric * pair.factor;
+  return { amount: formatAmount(converted), unit: pair.to };
+}
+
+function formatAmount(n: number): string {
+  if (n >= 100) return n.toFixed(0);
+  if (n >= 10) return n.toFixed(1);
+  return n.toFixed(2);
+}


### PR DESCRIPTION
Adds Original/Converted toggle on the recipe detail Ingredients section. Client-side conversion covers g↔oz, kg↔lb, ml↔fl oz, liters↔qt, cups→ml, tbsp→ml, tsp→ml. Units without a mapping (units, pieces, cloves, pinch, bunch, slices) stay unchanged.

Backend `/convert` API (#376) is not ready; conversion is local for now and can be swapped to that endpoint later.

Closes #378