### PR TITLE
feat(mobile): profile navigation from cards

### DIFF
--- a/app/mobile/src/navigation/PublicStackNavigator.tsx
+++ b/app/mobile/src/navigation/PublicStackNavigator.tsx
@@ -9,6 +9,7 @@ import SearchScreen from '../screens/SearchScreen';
 import StoryCreateScreen from '../screens/StoryCreateScreen';
 import StoryDetailScreen from '../screens/StoryDetailScreen';
 import StoryEditScreen from '../screens/StoryEditScreen';
+import UserProfileScreen from '../screens/UserProfileScreen';
 import type { RootStackParamList } from './types';
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
@@ -68,6 +69,11 @@ export function PublicStackNavigator() {
         name="StoryEdit"
         component={StoryEditScreen}
         options={{ title: 'Edit story' }}
+      />
+      <Stack.Screen
+        name="UserProfile"
+        component={UserProfileScreen}
+        options={{ title: 'Profile' }}
       />
     </Stack.Navigator>
   );

--- a/app/mobile/src/navigation/types.ts
+++ b/app/mobile/src/navigation/types.ts
@@ -11,6 +11,7 @@ export type RootStackParamList = {
   StoryEdit: { id: string };
   /** Recipe authoring shell — ingredient/unit selection UI (full form later). */
   RecipeCreate: undefined;
+  UserProfile: { userId: number | string; username?: string };
 };
 
 declare global {

--- a/app/mobile/src/screens/HomeScreen.tsx
+++ b/app/mobile/src/screens/HomeScreen.tsx
@@ -80,30 +80,57 @@ export default function HomeScreen({ navigation }: Props) {
             keyExtractor={(item) => String(item.id)}
             showsHorizontalScrollIndicator={false}
             contentContainerStyle={styles.hList}
-            renderItem={({ item }) => (
-              <Pressable
-                onPress={() => navigation.navigate('StoryDetail', { id: String(item.id) })}
-                style={({ pressed }) => [styles.storyCard, pressed && styles.pressed]}
-                accessibilityRole="button"
-                accessibilityLabel={`Open story ${item.title}`}
-              >
-                {item.image ? (
-                  <View style={styles.storyThumb}>
-                    <Image source={{ uri: item.image }} style={styles.storyThumbImage} resizeMode="cover" />
-                  </View>
-                ) : (
-                  <View style={styles.storyThumb}>
-                    <Text style={styles.thumbText}>S</Text>
-                  </View>
-                )}
-                <Text style={styles.cardTitle} numberOfLines={2}>
-                  {item.title}
-                </Text>
-                <Text style={styles.cardMeta} numberOfLines={1}>
-                  {item.author?.username ? `By ${item.author.username}` : 'Story'}
-                </Text>
-              </Pressable>
-            )}
+            renderItem={({ item }) => {
+              const authorId =
+                typeof item.author === 'object' && item.author
+                  ? item.author.id
+                  : item.author;
+              const authorUsername =
+                typeof item.author === 'object' && item.author
+                  ? item.author.username
+                  : item.author_username;
+              return (
+                <Pressable
+                  onPress={() => navigation.navigate('StoryDetail', { id: String(item.id) })}
+                  style={({ pressed }) => [styles.storyCard, pressed && styles.pressed]}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Open story ${item.title}`}
+                >
+                  {item.image ? (
+                    <View style={styles.storyThumb}>
+                      <Image source={{ uri: item.image }} style={styles.storyThumbImage} resizeMode="cover" />
+                    </View>
+                  ) : (
+                    <View style={styles.storyThumb}>
+                      <Text style={styles.thumbText}>S</Text>
+                    </View>
+                  )}
+                  <Text style={styles.cardTitle} numberOfLines={2}>
+                    {item.title}
+                  </Text>
+                  {authorId != null && authorUsername ? (
+                    <Pressable
+                      onPress={() =>
+                        navigation.navigate('UserProfile', {
+                          userId: authorId,
+                          username: authorUsername,
+                        })
+                      }
+                      style={({ pressed }) => [styles.authorPress, pressed && styles.pressed]}
+                      accessibilityRole="link"
+                      accessibilityLabel={`Open profile of ${authorUsername}`}
+                      hitSlop={6}
+                    >
+                      <Text style={styles.authorLink} numberOfLines={1}>
+                        By {authorUsername}
+                      </Text>
+                    </Pressable>
+                  ) : (
+                    <Text style={styles.cardMeta} numberOfLines={1}>Story</Text>
+                  )}
+                </Pressable>
+              );
+            }}
           />
         </View>
 
@@ -117,36 +144,68 @@ export default function HomeScreen({ navigation }: Props) {
             keyExtractor={(item) => String(item.id)}
             showsHorizontalScrollIndicator={false}
             contentContainerStyle={styles.hList}
-            renderItem={({ item }) => (
-              <Pressable
-                onPress={() => navigation.navigate('RecipeDetail', { id: String(item.id) })}
-                style={({ pressed }) => [styles.recipeCard, pressed && styles.pressed]}
-                accessibilityRole="button"
-                accessibilityLabel={`Open recipe ${item.title}`}
-              >
-                {item.image ? (
-                  <View style={styles.recipeThumb}>
-                    <Image
-                      source={{ uri: item.image }}
-                      style={styles.recipeThumbImage}
-                      resizeMode="cover"
-                    />
-                  </View>
-                ) : (
-                  <View style={styles.recipeThumb}>
-                    <Text style={styles.thumbText}>R</Text>
-                  </View>
-                )}
-                <Text style={styles.cardTitle} numberOfLines={2}>
-                  {item.title}
-                </Text>
-                <View style={styles.tag}>
-                  <Text style={styles.tagText} numberOfLines={1}>
-                    {item.region ?? 'Recipe'}
+            renderItem={({ item }) => {
+              const authorId =
+                typeof item.author === 'object' && item.author
+                  ? item.author.id
+                  : item.author;
+              const authorUsername =
+                typeof item.author === 'object' && item.author
+                  ? item.author.username
+                  : item.author_username;
+              const regionName =
+                typeof item.region === 'object' && item.region
+                  ? item.region.name
+                  : item.region_name ?? (typeof item.region === 'string' ? item.region : null);
+              return (
+                <Pressable
+                  onPress={() => navigation.navigate('RecipeDetail', { id: String(item.id) })}
+                  style={({ pressed }) => [styles.recipeCard, pressed && styles.pressed]}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Open recipe ${item.title}`}
+                >
+                  {item.image ? (
+                    <View style={styles.recipeThumb}>
+                      <Image
+                        source={{ uri: item.image }}
+                        style={styles.recipeThumbImage}
+                        resizeMode="cover"
+                      />
+                    </View>
+                  ) : (
+                    <View style={styles.recipeThumb}>
+                      <Text style={styles.thumbText}>R</Text>
+                    </View>
+                  )}
+                  <Text style={styles.cardTitle} numberOfLines={2}>
+                    {item.title}
                   </Text>
-                </View>
-              </Pressable>
-            )}
+                  {authorId != null && authorUsername ? (
+                    <Pressable
+                      onPress={() =>
+                        navigation.navigate('UserProfile', {
+                          userId: authorId,
+                          username: authorUsername,
+                        })
+                      }
+                      style={({ pressed }) => [styles.authorPress, pressed && styles.pressed]}
+                      accessibilityRole="link"
+                      accessibilityLabel={`Open profile of ${authorUsername}`}
+                      hitSlop={6}
+                    >
+                      <Text style={styles.authorLink} numberOfLines={1}>
+                        By {authorUsername}
+                      </Text>
+                    </Pressable>
+                  ) : null}
+                  <View style={styles.tag}>
+                    <Text style={styles.tagText} numberOfLines={1}>
+                      {regionName ?? 'Recipe'}
+                    </Text>
+                  </View>
+                </Pressable>
+              );
+            }}
           />
         </View>
       </ScrollView>
@@ -235,6 +294,19 @@ const styles = StyleSheet.create({
   thumbText: { color: tokens.colors.textOnDark, fontSize: 24, fontWeight: '900' },
   cardTitle: { paddingHorizontal: 12, paddingTop: 10, fontSize: 15, fontWeight: '800', color: tokens.colors.text },
   cardMeta: { paddingHorizontal: 12, paddingBottom: 12, paddingTop: 6, fontSize: 13, color: tokens.colors.textMuted },
+  authorPress: {
+    alignSelf: 'flex-start',
+    marginLeft: 12,
+    marginTop: 6,
+    marginBottom: 12,
+    backgroundColor: tokens.colors.primarySubtle,
+    borderWidth: 1.5,
+    borderColor: tokens.colors.primaryBorder,
+    borderRadius: tokens.radius.pill,
+    paddingVertical: 4,
+    paddingHorizontal: 10,
+  },
+  authorLink: { fontSize: 12, color: tokens.colors.primary, fontWeight: '800' },
   tag: {
     alignSelf: 'flex-start',
     marginLeft: 12,

--- a/app/mobile/src/screens/RecipeDetailScreen.tsx
+++ b/app/mobile/src/screens/RecipeDetailScreen.tsx
@@ -69,6 +69,11 @@ export default function RecipeDetailScreen({ route, navigation }: Props) {
 
   const ingredients = recipe.ingredients ?? [];
 
+  const authorObj =
+    recipe.author && typeof recipe.author === 'object' && recipe.author.username && recipe.author.id != null
+      ? recipe.author
+      : null;
+
   /** Hide Edit until session is restored from storage (avoids flash for signed-in authors). */
   const canEdit = isReady && isAuthenticated && isRecipeAuthor(user, recipe);
 
@@ -80,13 +85,23 @@ export default function RecipeDetailScreen({ route, navigation }: Props) {
             {recipe.title}
           </Text>
           {recipe.region ? <Text style={styles.meta}>{recipe.region}</Text> : null}
-          {recipe.author ? (
-            <Text style={styles.author}>
-              By{' '}
-              {typeof recipe.author === 'object' && recipe.author.username
-                ? recipe.author.username
-                : 'Author'}
-            </Text>
+          {authorObj ? (
+            <Pressable
+              onPress={() =>
+                navigation.navigate('UserProfile', {
+                  userId: authorObj.id,
+                  username: authorObj.username,
+                })
+              }
+              style={({ pressed }) => [styles.authorPill, pressed && { opacity: 0.85 }]}
+              accessibilityRole="link"
+              accessibilityLabel={`Open profile of ${authorObj.username}`}
+              hitSlop={6}
+            >
+              <Text style={styles.authorPillText}>By {authorObj.username}</Text>
+            </Pressable>
+          ) : recipe.author ? (
+            <Text style={styles.author}>By Author</Text>
           ) : null}
 
           {typeof recipe.qa_enabled === 'boolean' ? (
@@ -187,6 +202,17 @@ const styles = StyleSheet.create({
   },
   meta: { fontSize: 14, color: tokens.colors.textMuted, marginTop: 6 },
   author: { fontSize: 14, color: tokens.colors.textMuted, marginTop: 4 },
+  authorPill: {
+    alignSelf: 'flex-start',
+    marginTop: 8,
+    backgroundColor: tokens.colors.primarySubtle,
+    borderWidth: 1.5,
+    borderColor: tokens.colors.primaryBorder,
+    borderRadius: tokens.radius.pill,
+    paddingVertical: 4,
+    paddingHorizontal: 10,
+  },
+  authorPillText: { fontSize: 12, color: tokens.colors.primary, fontWeight: '800' },
   qaMeta: { fontSize: 13, color: tokens.colors.textMuted, marginTop: 6 },
   editLink: {
     alignSelf: 'flex-start',

--- a/app/mobile/src/screens/StoryDetailScreen.tsx
+++ b/app/mobile/src/screens/StoryDetailScreen.tsx
@@ -69,6 +69,11 @@ export default function StoryDetailScreen({ route, navigation }: Props) {
 
   const canEdit = isReady && isAuthenticated && isStoryAuthor(user, story);
 
+  const authorObj =
+    story.author && typeof story.author === 'object' && story.author.username && story.author.id != null
+      ? story.author
+      : null;
+
   return (
     <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
       <ScrollView contentContainerStyle={styles.padded}>
@@ -81,13 +86,23 @@ export default function StoryDetailScreen({ route, navigation }: Props) {
           <Text style={styles.title} accessibilityRole="header">
             {story.title}
           </Text>
-          {story.author ? (
-            <Text style={styles.meta}>
-              By{' '}
-              {typeof story.author === 'object' && story.author.username
-                ? story.author.username
-                : 'Author'}
-            </Text>
+          {authorObj ? (
+            <Pressable
+              onPress={() =>
+                navigation.navigate('UserProfile', {
+                  userId: authorObj.id as number,
+                  username: authorObj.username,
+                })
+              }
+              style={({ pressed }) => [styles.authorPill, pressed && { opacity: 0.85 }]}
+              accessibilityRole="link"
+              accessibilityLabel={`Open profile of ${authorObj.username}`}
+              hitSlop={6}
+            >
+              <Text style={styles.authorPillText}>By {authorObj.username}</Text>
+            </Pressable>
+          ) : story.author ? (
+            <Text style={styles.meta}>By Author</Text>
           ) : null}
           {canEdit ? (
             <Pressable
@@ -153,6 +168,17 @@ const styles = StyleSheet.create({
   thumb: { width: '100%', height: '100%' },
   title: { fontSize: 24, fontWeight: '800', color: tokens.colors.text, fontFamily: tokens.typography.display.fontFamily },
   meta: { fontSize: 14, color: tokens.colors.textMuted, marginTop: 8 },
+  authorPill: {
+    alignSelf: 'flex-start',
+    marginTop: 8,
+    backgroundColor: tokens.colors.primarySubtle,
+    borderWidth: 1.5,
+    borderColor: tokens.colors.primaryBorder,
+    borderRadius: tokens.radius.pill,
+    paddingVertical: 4,
+    paddingHorizontal: 10,
+  },
+  authorPillText: { fontSize: 12, color: tokens.colors.primary, fontWeight: '800' },
   body: { fontSize: 16, marginTop: 16, lineHeight: 24, color: tokens.colors.text },
   linked: { marginTop: 28, paddingTop: 16, borderTopWidth: 1, borderTopColor: tokens.colors.primaryTint },
   linkedHeading: { fontSize: 18, fontWeight: '800', marginBottom: 10, color: tokens.colors.text, fontFamily: tokens.typography.display.fontFamily },

--- a/app/mobile/src/screens/UserProfileScreen.tsx
+++ b/app/mobile/src/screens/UserProfileScreen.tsx
@@ -1,0 +1,222 @@
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { useEffect, useMemo, useState } from 'react';
+import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { ErrorView } from '../components/ui/ErrorView';
+import { LoadingView } from '../components/ui/LoadingView';
+import type { RootStackParamList } from '../navigation/types';
+import { apiGetJson } from '../services/httpClient';
+import { fetchRecipesList } from '../services/recipeService';
+import { shadows, tokens } from '../theme';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'UserProfile'>;
+
+type ListItem = {
+  id: number | string;
+  title: string;
+  region?: string | null;
+  author?: { id?: number | string; username?: string } | number | string | null;
+};
+
+function authorIdOf(item: ListItem): string | null {
+  const a = item.author;
+  if (!a) return null;
+  if (typeof a === 'object') return a.id != null ? String(a.id) : null;
+  return String(a);
+}
+
+export default function UserProfileScreen({ route, navigation }: Props) {
+  const { userId, username } = route.params;
+  const userIdStr = String(userId);
+
+  const [recipes, setRecipes] = useState<ListItem[]>([]);
+  const [stories, setStories] = useState<ListItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadToken, setReloadToken] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    void (async () => {
+      try {
+        const [recipeList, storyList] = await Promise.all([
+          fetchRecipesList(),
+          apiGetJson<ListItem[]>('/api/stories/'),
+        ]);
+        if (cancelled) return;
+        setRecipes(Array.isArray(recipeList) ? recipeList : []);
+        setStories(Array.isArray(storyList) ? storyList : []);
+      } catch (e) {
+        if (!cancelled) {
+          setRecipes([]);
+          setStories([]);
+          setError(e instanceof Error ? e.message : 'Could not load profile.');
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [reloadToken]);
+
+  const myRecipes = useMemo(
+    () => recipes.filter((r) => authorIdOf(r) === userIdStr),
+    [recipes, userIdStr],
+  );
+  const myStories = useMemo(
+    () => stories.filter((s) => authorIdOf(s) === userIdStr),
+    [stories, userIdStr],
+  );
+
+  const initial = (username ?? 'U').slice(0, 1).toUpperCase();
+
+  if (loading) {
+    return (
+      <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
+        <View style={styles.centered}>
+          <LoadingView message="Loading profile…" />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (error) {
+    return (
+      <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
+        <View style={styles.padded}>
+          <ErrorView message={error} onRetry={() => setReloadToken((t) => t + 1)} />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
+      <ScrollView contentContainerStyle={styles.scroll}>
+        <View style={styles.headerCard}>
+          <View style={styles.avatar} accessibilityLabel="User avatar">
+            <Text style={styles.avatarText}>{initial}</Text>
+          </View>
+          <Text style={styles.username} accessibilityRole="header">
+            {username ?? `User #${userIdStr}`}
+          </Text>
+        </View>
+
+        <Text style={styles.sectionTitle}>Recipes by {username ?? 'this user'}</Text>
+        {myRecipes.length === 0 ? (
+          <Text style={styles.muted}>No recipes yet.</Text>
+        ) : (
+          <View style={styles.list}>
+            {myRecipes.map((r) => (
+              <Pressable
+                key={`r-${r.id}`}
+                onPress={() => navigation.navigate('RecipeDetail', { id: String(r.id) })}
+                style={({ pressed }) => [styles.row, pressed && styles.pressed]}
+                accessibilityRole="button"
+                accessibilityLabel={`Open recipe ${r.title}`}
+              >
+                <Text style={styles.rowTitle} numberOfLines={1}>
+                  {r.title}
+                </Text>
+                {r.region ? <Text style={styles.rowMeta}>{r.region}</Text> : null}
+              </Pressable>
+            ))}
+          </View>
+        )}
+
+        <Text style={styles.sectionTitle}>Stories by {username ?? 'this user'}</Text>
+        {myStories.length === 0 ? (
+          <Text style={styles.muted}>No stories yet.</Text>
+        ) : (
+          <View style={styles.list}>
+            {myStories.map((s) => (
+              <Pressable
+                key={`s-${s.id}`}
+                onPress={() => navigation.navigate('StoryDetail', { id: String(s.id) })}
+                style={({ pressed }) => [styles.row, pressed && styles.pressed]}
+                accessibilityRole="button"
+                accessibilityLabel={`Open story ${s.title}`}
+              >
+                <Text style={styles.rowTitle} numberOfLines={1}>
+                  {s.title}
+                </Text>
+              </Pressable>
+            ))}
+          </View>
+        )}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: tokens.colors.bg },
+  scroll: { padding: 20, paddingBottom: 32 },
+  centered: { flex: 1, justifyContent: 'center', alignItems: 'center', padding: 20 },
+  padded: { flex: 1, padding: 20, justifyContent: 'center' },
+  headerCard: {
+    borderWidth: 1,
+    borderColor: tokens.colors.border,
+    borderRadius: tokens.radius.xl,
+    backgroundColor: tokens.colors.surface,
+    padding: 16,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 14,
+    marginBottom: 22,
+    ...shadows.lg,
+  },
+  avatar: {
+    width: 56,
+    height: 56,
+    borderRadius: 999,
+    backgroundColor: tokens.colors.primarySubtle,
+    borderWidth: 2,
+    borderColor: tokens.colors.primaryBorder,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  avatarText: {
+    fontSize: 22,
+    fontWeight: '900',
+    color: tokens.colors.primary,
+  },
+  username: {
+    fontSize: 22,
+    fontWeight: '800',
+    color: tokens.colors.text,
+    fontFamily: tokens.typography.display.fontFamily,
+    flexShrink: 1,
+  },
+  sectionTitle: {
+    marginTop: 8,
+    marginBottom: 10,
+    fontSize: 18,
+    fontWeight: '700',
+    color: tokens.colors.surface,
+    fontFamily: tokens.typography.display.fontFamily,
+  },
+  muted: {
+    fontSize: 14,
+    color: tokens.colors.textMuted,
+    fontStyle: 'italic',
+    marginBottom: 18,
+  },
+  list: { gap: 8, marginBottom: 18 },
+  row: {
+    paddingVertical: 12,
+    paddingHorizontal: 14,
+    borderWidth: 1,
+    borderColor: tokens.colors.border,
+    borderRadius: tokens.radius.lg,
+    backgroundColor: tokens.colors.surface,
+    ...shadows.sm,
+  },
+  pressed: { opacity: 0.85 },
+  rowTitle: { fontSize: 15, fontWeight: '700', color: tokens.colors.text },
+  rowMeta: { marginTop: 4, fontSize: 12, color: tokens.colors.textMuted },
+});

--- a/app/mobile/src/services/recipeService.ts
+++ b/app/mobile/src/services/recipeService.ts
@@ -101,25 +101,36 @@ export async function updateRecipeById(id: string, formData: FormData): Promise<
 
 /** Minimal list for story linking / pickers (web: GET `/api/recipes/`). */
 export async function fetchRecipesList(): Promise<
-  { id: string; title: string; region?: string; author?: any; image?: string | null }[]
+  {
+    id: string;
+    title: string;
+    region?: string;
+    author?: any;
+    author_username?: string;
+    image?: string | null;
+  }[]
 > {
-  // We only need id/title/region/author for UI; backend may return more fields.
   const data = await apiGetJson<any[]>(`/api/recipes/`);
   return (Array.isArray(data) ? data : []).map((r) => {
     const reg = r.region;
     const regionLabel =
       reg == null
-        ? undefined
+        ? typeof r.region_name === 'string'
+          ? r.region_name
+          : undefined
         : typeof reg === 'string'
           ? reg
           : typeof reg === 'object' && reg && 'name' in reg && typeof (reg as { name: unknown }).name === 'string'
             ? (reg as { name: string }).name
-            : undefined;
+            : typeof r.region_name === 'string'
+              ? r.region_name
+              : undefined;
     return {
       id: String(r.id),
       title: String(r.title ?? ''),
       region: regionLabel,
       author: r.author ?? undefined,
+      author_username: typeof r.author_username === 'string' ? r.author_username : undefined,
       image: typeof r.image === 'string' ? r.image : null,
     };
   });


### PR DESCRIPTION
Adds tappable author pill on home recipe + story cards, recipe detail and story detail. Tap opens a new UserProfileScreen showing the author's published recipes and stories (filtered client-side from existing list endpoints since /api/users/<id>/ doesn't exist yet).

Also fixes fetchRecipesList to surface author_username and region_name from the flat DRF list response.

Closes #351