### PR TITLE
feat(mobile): daily cultural content section on home

### DIFF
--- a/app/mobile/src/components/home/DailyCulturalSection.tsx
+++ b/app/mobile/src/components/home/DailyCulturalSection.tsx
@@ -1,0 +1,166 @@
+import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { FlatList, Pressable, StyleSheet, Text, View } from 'react-native';
+import { shadows, tokens } from '../../theme';
+import type { DailyCulturalCard, DailyCulturalKind } from '../../mocks/dailyCultural';
+import type { RootStackParamList } from '../../navigation/types';
+
+const KIND_LABEL: Record<DailyCulturalKind, string> = {
+  tradition: 'Tradition',
+  dish: 'Dish of the Day',
+  story: 'Story',
+  fact: 'Did you know',
+  holiday: 'Holiday',
+};
+
+type Props = { items: DailyCulturalCard[] };
+
+export function DailyCulturalSection({ items }: Props) {
+  const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+  if (!items || items.length === 0) return null;
+
+  const onCardPress = (card: DailyCulturalCard) => {
+    if (!card.link) return;
+    if (card.link.kind === 'recipe') {
+      navigation.navigate('RecipeDetail', { id: String(card.link.id) });
+    } else if (card.link.kind === 'story') {
+      navigation.navigate('StoryDetail', { id: String(card.link.id) });
+    }
+  };
+
+  return (
+    <View style={styles.section} accessibilityLabel="Today's cultural content">
+      <View style={styles.header}>
+        <View style={styles.todayBadge}>
+          <Text style={styles.todayText}>TODAY</Text>
+        </View>
+        <Text style={styles.heading}>From the kitchens</Text>
+      </View>
+      <FlatList
+        data={items}
+        horizontal
+        keyExtractor={(item) => item.id}
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={styles.list}
+        renderItem={({ item }) => {
+          const linkLabel =
+            item.link?.kind === 'recipe'
+              ? 'View recipe →'
+              : item.link?.kind === 'story'
+                ? 'Read story →'
+                : null;
+          return (
+            <Pressable
+              onPress={() => onCardPress(item)}
+              disabled={!item.link}
+              style={({ pressed }) => [styles.card, pressed && item.link ? styles.cardPressed : null]}
+              accessibilityRole={item.link ? 'button' : 'summary'}
+              accessibilityLabel={
+                item.link ? `${item.title} — ${linkLabel}` : item.title
+              }
+            >
+              <View style={styles.kindRow}>
+                <Text style={styles.kindLabel}>{KIND_LABEL[item.kind]}</Text>
+                {item.region ? <Text style={styles.region}>{item.region}</Text> : null}
+              </View>
+              <Text style={styles.title} numberOfLines={2}>
+                {item.title}
+              </Text>
+              <Text style={styles.body} numberOfLines={4}>
+                {item.body}
+              </Text>
+              {linkLabel ? (
+                <View style={styles.linkPill}>
+                  <Text style={styles.linkPillText}>{linkLabel}</Text>
+                </View>
+              ) : null}
+            </Pressable>
+          );
+        }}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  section: {
+    marginTop: 6,
+    marginBottom: 18,
+    paddingTop: 14,
+    paddingBottom: 14,
+    paddingLeft: 4,
+    borderRadius: tokens.radius.xl,
+    backgroundColor: tokens.colors.primarySubtle,
+    borderWidth: 1.5,
+    borderColor: tokens.colors.primaryBorder,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    paddingHorizontal: 14,
+    marginBottom: 10,
+  },
+  todayBadge: {
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    backgroundColor: tokens.colors.primary,
+    borderRadius: tokens.radius.pill,
+  },
+  todayText: {
+    color: tokens.colors.surface,
+    fontSize: 11,
+    fontWeight: '900',
+    letterSpacing: 1,
+  },
+  heading: {
+    fontSize: 18,
+    fontWeight: '800',
+    color: tokens.colors.text,
+    fontFamily: tokens.typography.display.fontFamily,
+  },
+  list: { gap: 12, paddingRight: 16, paddingLeft: 12 },
+  card: {
+    width: 280,
+    padding: 14,
+    backgroundColor: tokens.colors.surface,
+    borderRadius: tokens.radius.lg,
+    borderWidth: 1,
+    borderColor: tokens.colors.primaryBorder,
+    ...shadows.lg,
+  },
+  kindRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 8,
+  },
+  kindLabel: {
+    fontSize: 11,
+    fontWeight: '900',
+    color: tokens.colors.primary,
+    letterSpacing: 1,
+    textTransform: 'uppercase',
+  },
+  region: { fontSize: 11, color: tokens.colors.textMuted, fontWeight: '700' },
+  title: {
+    fontSize: 16,
+    fontWeight: '800',
+    color: tokens.colors.text,
+    marginBottom: 6,
+    fontFamily: tokens.typography.display.fontFamily,
+  },
+  body: { fontSize: 13, color: tokens.colors.text, lineHeight: 19 },
+  cardPressed: { opacity: 0.85 },
+  linkPill: {
+    alignSelf: 'flex-start',
+    marginTop: 12,
+    backgroundColor: tokens.colors.primarySubtle,
+    borderWidth: 1.5,
+    borderColor: tokens.colors.primaryBorder,
+    borderRadius: tokens.radius.pill,
+    paddingVertical: 4,
+    paddingHorizontal: 10,
+  },
+  linkPillText: { fontSize: 12, color: tokens.colors.primary, fontWeight: '800' },
+});

--- a/app/mobile/src/mocks/dailyCultural.ts
+++ b/app/mobile/src/mocks/dailyCultural.ts
@@ -1,0 +1,55 @@
+export type DailyCulturalKind = 'tradition' | 'dish' | 'story' | 'fact' | 'holiday';
+
+export type DailyCulturalLink =
+  | { kind: 'story'; id: string | number }
+  | { kind: 'recipe'; id: string | number };
+
+export type DailyCulturalCard = {
+  id: string;
+  kind: DailyCulturalKind;
+  title: string;
+  body: string;
+  region?: string;
+  link?: DailyCulturalLink;
+};
+
+export const MOCK_DAILY_CULTURAL: DailyCulturalCard[] = [
+  {
+    id: 'dc-tradition-1',
+    kind: 'tradition',
+    title: 'Sunday Börek Mornings',
+    body: 'In Aegean homes, Sunday breakfast often starts with the smell of phyllo baking before sunrise. Grandmothers roll dough by hand, layer by layer, while the rest of the family wakes to the scent.',
+    region: 'Aegean',
+    link: { kind: 'story', id: 2 },
+  },
+  {
+    id: 'dc-dish-1',
+    kind: 'dish',
+    title: 'Dish of the Day: Mansaf',
+    body: 'A Levantine festive dish — lamb slow-cooked in fermented yogurt sauce, served over saffron rice. Eaten standing, with the right hand, around a single shared platter.',
+    region: 'Levantine',
+    link: { kind: 'recipe', id: 12 },
+  },
+  {
+    id: 'dc-fact-1',
+    kind: 'fact',
+    title: 'Why Lentil Soup is Healing',
+    body: 'Across Anatolia and the Middle East, lentil soup is the first food offered to a guest with a cold or to a recovering relative. The tradition predates modern medicine by centuries.',
+    region: 'Anatolian',
+    link: { kind: 'recipe', id: 2 },
+  },
+  {
+    id: 'dc-tradition-2',
+    kind: 'tradition',
+    title: 'The Coffee Reading',
+    body: 'After Turkish coffee, the cup is flipped onto its saucer and the grounds are read. It is half ritual, half conversation starter — and almost never taken too seriously.',
+    region: 'Marmara',
+  },
+  {
+    id: 'dc-holiday-1',
+    kind: 'holiday',
+    title: 'Aşure Day',
+    body: 'A pudding made of forty ingredients — wheat, beans, dried fruits, nuts — shared with neighbors on the 10th of Muharram. Tradition says one bowl should never be eaten alone.',
+    region: 'Anatolian',
+  },
+];

--- a/app/mobile/src/screens/HomeScreen.tsx
+++ b/app/mobile/src/screens/HomeScreen.tsx
@@ -5,6 +5,9 @@ import { useEffect, useMemo, useState } from 'react';
 import { shadows, tokens } from '../theme';
 import { fetchRecipesList } from '../services/recipeService';
 import { apiGetJson } from '../services/httpClient';
+import { fetchDailyCultural } from '../services/dailyCulturalService';
+import { DailyCulturalSection } from '../components/home/DailyCulturalSection';
+import type { DailyCulturalCard } from '../mocks/dailyCultural';
 import type { RootStackParamList } from '../navigation/types';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Home'>;
@@ -14,24 +17,28 @@ export default function HomeScreen({ navigation }: Props) {
 
   const [stories, setStories] = useState<any[]>([]);
   const [recipes, setRecipes] = useState<any[]>([]);
+  const [daily, setDaily] = useState<DailyCulturalCard[]>([]);
   const [loadError, setLoadError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
     void (async () => {
       try {
-        const [storyData, recipeData] = await Promise.all([
+        const [storyData, recipeData, dailyData] = await Promise.all([
           apiGetJson<any[]>('/api/stories/'),
           fetchRecipesList(),
+          fetchDailyCultural(),
         ]);
         if (cancelled) return;
         setStories(Array.isArray(storyData) ? storyData : []);
         setRecipes(Array.isArray(recipeData) ? recipeData : []);
+        setDaily(Array.isArray(dailyData) ? dailyData : []);
         setLoadError(null);
       } catch (e) {
         if (!cancelled) {
           setStories([]);
           setRecipes([]);
+          setDaily([]);
           setLoadError(e instanceof Error ? e.message : 'Could not load feed.');
         }
       }
@@ -69,6 +76,8 @@ export default function HomeScreen({ navigation }: Props) {
             onSubmitEditing={() => navigation.navigate('Search', { query: query.trim() })}
           />
         </View>
+
+        <DailyCulturalSection items={daily} />
 
         <View style={styles.section}>
           <View style={styles.sectionHeader}>

--- a/app/mobile/src/services/dailyCulturalService.ts
+++ b/app/mobile/src/services/dailyCulturalService.ts
@@ -1,0 +1,16 @@
+import { apiGetJson } from './httpClient';
+import { MOCK_DAILY_CULTURAL, type DailyCulturalCard } from '../mocks/dailyCultural';
+
+/**
+ * Backend `#348` — `GET /api/cultural-content/daily/` is not implemented yet.
+ * Falls back to mock data so the UI is testable now. Swap is one-line when API ships.
+ */
+export async function fetchDailyCultural(): Promise<DailyCulturalCard[]> {
+  try {
+    const data = await apiGetJson<DailyCulturalCard[]>('/api/cultural-content/daily/');
+    if (Array.isArray(data) && data.length > 0) return data;
+    return MOCK_DAILY_CULTURAL;
+  } catch {
+    return MOCK_DAILY_CULTURAL;
+  }
+}


### PR DESCRIPTION
Adds a "From the kitchens" section at the top of Home, between the search bar and the Stories carousel. Visually distinguished with a TODAY badge, primary-tinted background, and a horizontal carousel of cultural content cards (tradition, dish of the day, fact, holiday).

Cards optionally link to a recipe or story via `link: { kind: 'recipe' | 'story', id }` — tap shows a "View recipe →" / "Read story →" pill that navigates to the corresponding detail screen. Cards without a link are read-only summaries.

Backend `/api/cultural-content/daily/` (#348) is not implemented yet; service falls back to local mock data (`src/mocks/dailyCultural.ts`) so swap is one-line when the API ships.

Closes #350