### PR TITLE
feat(mobile): story-centric feed & detail

### DIFF
--- a/app/mobile/src/components/home/StoryFeatureCard.tsx
+++ b/app/mobile/src/components/home/StoryFeatureCard.tsx
@@ -1,0 +1,127 @@
+import React from 'react';
+import { Image, Pressable, StyleSheet, Text, View } from 'react-native';
+import { shadows, tokens } from '../../theme';
+
+type Props = {
+  title: string;
+  body?: string | null;
+  image?: string | null;
+  authorUsername?: string | null;
+  recipeTitle?: string | null;
+  onPress: () => void;
+  onPressAuthor?: () => void;
+  onPressRecipe?: () => void;
+};
+
+export function StoryFeatureCard({
+  title,
+  body,
+  image,
+  authorUsername,
+  recipeTitle,
+  onPress,
+  onPressAuthor,
+  onPressRecipe,
+}: Props) {
+  return (
+    <Pressable
+      onPress={onPress}
+      style={({ pressed }) => [styles.card, pressed && styles.pressed]}
+      accessibilityRole="button"
+      accessibilityLabel={`Open story ${title}`}
+    >
+      {image ? (
+        <View style={styles.thumb}>
+          <Image source={{ uri: image }} style={styles.thumbImage} resizeMode="cover" />
+        </View>
+      ) : (
+        <View style={[styles.thumb, styles.thumbFallback]}>
+          <Text style={styles.thumbText}>S</Text>
+        </View>
+      )}
+      <View style={styles.body}>
+        <Text style={styles.title} numberOfLines={2}>
+          {title}
+        </Text>
+        {body ? (
+          <Text style={styles.excerpt} numberOfLines={3}>
+            {body}
+          </Text>
+        ) : null}
+        <View style={styles.metaRow}>
+          {authorUsername ? (
+            <Pressable
+              onPress={onPressAuthor}
+              disabled={!onPressAuthor}
+              style={({ pressed }) => [styles.pill, pressed && styles.pressed]}
+              accessibilityRole="link"
+              accessibilityLabel={`Open profile of ${authorUsername}`}
+              hitSlop={6}
+            >
+              <Text style={styles.pillText}>By {authorUsername}</Text>
+            </Pressable>
+          ) : null}
+          {recipeTitle && onPressRecipe ? (
+            <Pressable
+              onPress={onPressRecipe}
+              style={({ pressed }) => [styles.recipePill, pressed && styles.pressed]}
+              accessibilityRole="link"
+              accessibilityLabel={`Open linked recipe ${recipeTitle}`}
+              hitSlop={6}
+            >
+              <Text style={styles.recipePillText} numberOfLines={1}>
+                Recipe: {recipeTitle}
+              </Text>
+            </Pressable>
+          ) : null}
+        </View>
+      </View>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    borderWidth: 1,
+    borderColor: tokens.colors.border,
+    borderRadius: tokens.radius.xl,
+    backgroundColor: tokens.colors.surface,
+    overflow: 'hidden',
+    ...shadows.lg,
+  },
+  pressed: { opacity: 0.9 },
+  thumb: {
+    width: '100%',
+    height: 160,
+    backgroundColor: tokens.colors.accentGreen,
+  },
+  thumbFallback: { alignItems: 'center', justifyContent: 'center' },
+  thumbImage: { width: '100%', height: '100%' },
+  thumbText: { color: tokens.colors.textOnDark, fontSize: 36, fontWeight: '900' },
+  body: { padding: 14, gap: 8 },
+  title: {
+    fontSize: 18,
+    fontWeight: '800',
+    color: tokens.colors.text,
+    fontFamily: tokens.typography.display.fontFamily,
+  },
+  excerpt: { fontSize: 14, color: tokens.colors.textMuted, lineHeight: 20 },
+  metaRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 8, marginTop: 4 },
+  pill: {
+    backgroundColor: tokens.colors.primarySubtle,
+    borderWidth: 1.5,
+    borderColor: tokens.colors.primaryBorder,
+    borderRadius: tokens.radius.pill,
+    paddingVertical: 4,
+    paddingHorizontal: 10,
+  },
+  pillText: { fontSize: 12, color: tokens.colors.primary, fontWeight: '800' },
+  recipePill: {
+    backgroundColor: tokens.colors.surfaceDark,
+    borderRadius: tokens.radius.pill,
+    paddingVertical: 4,
+    paddingHorizontal: 10,
+    maxWidth: '70%',
+  },
+  recipePillText: { fontSize: 12, color: tokens.colors.textOnDark, fontWeight: '800' },
+});

--- a/app/mobile/src/components/recipe/LinkedStoryPreviewCard.tsx
+++ b/app/mobile/src/components/recipe/LinkedStoryPreviewCard.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { Image, Pressable, StyleSheet, Text, View } from 'react-native';
+import { shadows, tokens } from '../../theme';
+
+type Props = {
+  title: string;
+  excerpt?: string | null;
+  image?: string | null;
+  authorUsername?: string | null;
+  onPress: () => void;
+};
+
+export function LinkedStoryPreviewCard({ title, excerpt, image, authorUsername, onPress }: Props) {
+  return (
+    <Pressable
+      onPress={onPress}
+      style={({ pressed }) => [styles.card, pressed && styles.pressed]}
+      accessibilityRole="button"
+      accessibilityLabel={`Open story ${title}`}
+    >
+      {image ? (
+        <View style={styles.thumb}>
+          <Image source={{ uri: image }} style={styles.thumbImage} resizeMode="cover" />
+        </View>
+      ) : (
+        <View style={[styles.thumb, styles.thumbFallback]}>
+          <Text style={styles.thumbText}>S</Text>
+        </View>
+      )}
+      <View style={styles.body}>
+        <Text style={styles.title} numberOfLines={2}>
+          {title}
+        </Text>
+        {excerpt ? (
+          <Text style={styles.excerpt} numberOfLines={2}>
+            {excerpt}
+          </Text>
+        ) : null}
+        {authorUsername ? (
+          <Text style={styles.author} numberOfLines={1}>
+            By {authorUsername}
+          </Text>
+        ) : null}
+      </View>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    borderWidth: 1,
+    borderColor: tokens.colors.border,
+    borderRadius: tokens.radius.xl,
+    backgroundColor: tokens.colors.surface,
+    overflow: 'hidden',
+    flexDirection: 'row',
+    ...shadows.md,
+  },
+  pressed: { opacity: 0.9 },
+  thumb: {
+    width: 86,
+    backgroundColor: tokens.colors.accentGreen,
+  },
+  thumbFallback: { alignItems: 'center', justifyContent: 'center' },
+  thumbImage: { width: '100%', height: '100%' },
+  thumbText: { color: tokens.colors.textOnDark, fontSize: 22, fontWeight: '900' },
+  body: { flex: 1, padding: 12, gap: 6 },
+  title: {
+    fontSize: 15,
+    fontWeight: '800',
+    color: tokens.colors.text,
+    fontFamily: tokens.typography.display.fontFamily,
+  },
+  excerpt: { fontSize: 13, color: tokens.colors.textMuted, lineHeight: 18 },
+  author: { fontSize: 12, color: tokens.colors.primary, fontWeight: '800' },
+});

--- a/app/mobile/src/screens/HomeScreen.tsx
+++ b/app/mobile/src/screens/HomeScreen.tsx
@@ -7,6 +7,7 @@ import { fetchRecipesList } from '../services/recipeService';
 import { apiGetJson } from '../services/httpClient';
 import { fetchDailyCultural } from '../services/dailyCulturalService';
 import { DailyCulturalSection } from '../components/home/DailyCulturalSection';
+import { StoryFeatureCard } from '../components/home/StoryFeatureCard';
 import type { DailyCulturalCard } from '../mocks/dailyCultural';
 import type { RootStackParamList } from '../navigation/types';
 
@@ -82,70 +83,67 @@ export default function HomeScreen({ navigation }: Props) {
         <View style={styles.section}>
           <View style={styles.sectionHeader}>
             <Text style={styles.sectionTitle}>Stories</Text>
+            <Text style={styles.sectionHint}>Voices from the kitchen</Text>
           </View>
-          <FlatList
-            data={stories}
-            horizontal
-            keyExtractor={(item) => String(item.id)}
-            showsHorizontalScrollIndicator={false}
-            contentContainerStyle={styles.hList}
-            renderItem={({ item }) => {
-              const authorId =
-                typeof item.author === 'object' && item.author
-                  ? item.author.id
-                  : item.author;
-              const authorUsername =
-                typeof item.author === 'object' && item.author
-                  ? item.author.username
-                  : item.author_username;
-              return (
-                <Pressable
-                  onPress={() => navigation.navigate('StoryDetail', { id: String(item.id) })}
-                  style={({ pressed }) => [styles.storyCard, pressed && styles.pressed]}
-                  accessibilityRole="button"
-                  accessibilityLabel={`Open story ${item.title}`}
-                >
-                  {item.image ? (
-                    <View style={styles.storyThumb}>
-                      <Image source={{ uri: item.image }} style={styles.storyThumbImage} resizeMode="cover" />
-                    </View>
-                  ) : (
-                    <View style={styles.storyThumb}>
-                      <Text style={styles.thumbText}>S</Text>
-                    </View>
-                  )}
-                  <Text style={styles.cardTitle} numberOfLines={2}>
-                    {item.title}
-                  </Text>
-                  {authorId != null && authorUsername ? (
-                    <Pressable
-                      onPress={() =>
-                        navigation.navigate('UserProfile', {
-                          userId: authorId,
-                          username: authorUsername,
-                        })
-                      }
-                      style={({ pressed }) => [styles.authorPress, pressed && styles.pressed]}
-                      accessibilityRole="link"
-                      accessibilityLabel={`Open profile of ${authorUsername}`}
-                      hitSlop={6}
-                    >
-                      <Text style={styles.authorLink} numberOfLines={1}>
-                        By {authorUsername}
-                      </Text>
-                    </Pressable>
-                  ) : (
-                    <Text style={styles.cardMeta} numberOfLines={1}>Story</Text>
-                  )}
-                </Pressable>
-              );
-            }}
-          />
+          {stories.length === 0 ? (
+            <Text style={styles.emptyHint}>No stories yet. Be the first to share one.</Text>
+          ) : (
+            <View style={styles.storyList}>
+              {stories.map((item) => {
+                const authorId =
+                  typeof item.author === 'object' && item.author
+                    ? item.author.id
+                    : item.author;
+                const authorUsername =
+                  typeof item.author === 'object' && item.author
+                    ? item.author.username
+                    : item.author_username;
+                const linkedRecipeRaw = item.linked_recipe;
+                const linkedRecipeId =
+                  linkedRecipeRaw == null
+                    ? null
+                    : typeof linkedRecipeRaw === 'object' && 'id' in linkedRecipeRaw
+                      ? String(linkedRecipeRaw.id)
+                      : String(linkedRecipeRaw);
+                const linkedRecipeTitle =
+                  typeof item.recipe_title === 'string'
+                    ? item.recipe_title
+                    : typeof linkedRecipeRaw === 'object' && linkedRecipeRaw?.title
+                      ? String(linkedRecipeRaw.title)
+                      : null;
+                return (
+                  <StoryFeatureCard
+                    key={String(item.id)}
+                    title={item.title}
+                    body={item.body}
+                    image={item.image}
+                    authorUsername={authorUsername ?? null}
+                    recipeTitle={linkedRecipeId ? linkedRecipeTitle : null}
+                    onPress={() => navigation.navigate('StoryDetail', { id: String(item.id) })}
+                    onPressAuthor={
+                      authorId != null && authorUsername
+                        ? () =>
+                            navigation.navigate('UserProfile', {
+                              userId: authorId,
+                              username: authorUsername,
+                            })
+                        : undefined
+                    }
+                    onPressRecipe={
+                      linkedRecipeId
+                        ? () => navigation.navigate('RecipeDetail', { id: linkedRecipeId })
+                        : undefined
+                    }
+                  />
+                );
+              })}
+            </View>
+          )}
         </View>
 
         <View style={styles.section}>
           <View style={styles.sectionHeader}>
-            <Text style={styles.sectionTitle}>Recipes</Text>
+            <Text style={styles.sectionSubTitle}>More recipes</Text>
           </View>
           <FlatList
             data={recipes}
@@ -262,8 +260,11 @@ const styles = StyleSheet.create({
   },
   section: { marginTop: 10, marginBottom: 18 },
   sectionHeader: { flexDirection: 'row', alignItems: 'baseline', gap: 10, marginBottom: 10 },
-  sectionTitle: { fontSize: 18, fontWeight: '800', color: tokens.colors.surface },
+  sectionTitle: { fontSize: 22, fontWeight: '800', color: tokens.colors.surface, fontFamily: tokens.typography.display.fontFamily },
+  sectionSubTitle: { fontSize: 15, fontWeight: '800', color: tokens.colors.surface },
   sectionHint: { fontSize: 13, color: tokens.colors.primaryTint, fontWeight: '800' },
+  storyList: { gap: 14 },
+  emptyHint: { fontSize: 13, color: tokens.colors.textMuted, fontStyle: 'italic' },
   hList: { gap: 12, paddingRight: 16 },
   storyCard: {
     width: 180,

--- a/app/mobile/src/screens/RecipeDetailScreen.tsx
+++ b/app/mobile/src/screens/RecipeDetailScreen.tsx
@@ -6,8 +6,10 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { useAuth } from '../context/AuthContext';
 import { ErrorView } from '../components/ui/ErrorView';
 import { LoadingView } from '../components/ui/LoadingView';
+import { LinkedStoryPreviewCard } from '../components/recipe/LinkedStoryPreviewCard';
 import type { RootStackParamList } from '../navigation/types';
 import { fetchRecipeById } from '../services/recipeService';
+import { fetchStoriesForRecipe, type StoryListItem } from '../services/storyService';
 import type { RecipeDetail } from '../types/recipe';
 import { isRecipeAuthor } from '../utils/recipeAuthor';
 import { convertIngredient } from '../utils/unitConversion';
@@ -23,6 +25,7 @@ export default function RecipeDetailScreen({ route, navigation }: Props) {
   const [error, setError] = useState<string | null>(null);
   const [reloadToken, setReloadToken] = useState(0);
   const [showConverted, setShowConverted] = useState(false);
+  const [linkedStories, setLinkedStories] = useState<StoryListItem[]>([]);
 
   useEffect(() => {
     let cancelled = false;
@@ -40,6 +43,20 @@ export default function RecipeDetailScreen({ route, navigation }: Props) {
       })
       .finally(() => {
         if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [id, reloadToken]);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchStoriesForRecipe(id)
+      .then((items) => {
+        if (!cancelled) setLinkedStories(items);
+      })
+      .catch(() => {
+        if (!cancelled) setLinkedStories([]);
       });
     return () => {
       cancelled = true;
@@ -207,6 +224,26 @@ export default function RecipeDetailScreen({ route, navigation }: Props) {
               })}
             </View>
           )}
+
+          <View style={styles.storiesSection}>
+            <Text style={styles.sectionTitle}>Stories about this recipe</Text>
+            {linkedStories.length === 0 ? (
+              <Text style={styles.muted}>No stories linked to this recipe yet.</Text>
+            ) : (
+              <View style={styles.storyList}>
+                {linkedStories.map((s) => (
+                  <LinkedStoryPreviewCard
+                    key={s.id}
+                    title={s.title}
+                    excerpt={s.body}
+                    image={s.image}
+                    authorUsername={s.authorUsername}
+                    onPress={() => navigation.navigate('StoryDetail', { id: s.id })}
+                  />
+                ))}
+              </View>
+            )}
+          </View>
         </View>
       </ScrollView>
     </SafeAreaView>
@@ -340,4 +377,6 @@ const styles = StyleSheet.create({
   },
   ingredientName: { fontSize: 16, color: tokens.colors.text, fontWeight: '700' },
   ingredientAmount: { fontSize: 16, color: tokens.colors.text },
+  storiesSection: { marginTop: 28, paddingTop: 16, borderTopWidth: 1, borderTopColor: tokens.colors.primaryTint, gap: 12 },
+  storyList: { gap: 10 },
 });

--- a/app/mobile/src/services/storyService.ts
+++ b/app/mobile/src/services/storyService.ts
@@ -8,6 +8,47 @@ export async function fetchStoryById(id: string): Promise<StoryDetail> {
   return normalizeStoryDetail(data);
 }
 
+export type StoryListItem = {
+  id: string;
+  title: string;
+  body: string;
+  image: string | null;
+  authorUsername: string | null;
+  linkedRecipeId: string | null;
+};
+
+function pickListItem(raw: any): StoryListItem {
+  const linkedRaw = raw?.linked_recipe;
+  const linkedRecipeId =
+    linkedRaw == null
+      ? null
+      : typeof linkedRaw === 'object' && 'id' in linkedRaw
+        ? String(linkedRaw.id)
+        : String(linkedRaw);
+  const authorUsername =
+    typeof raw?.author_username === 'string'
+      ? raw.author_username
+      : typeof raw?.author === 'object' && raw?.author?.username
+        ? String(raw.author.username)
+        : null;
+  return {
+    id: String(raw?.id ?? ''),
+    title: typeof raw?.title === 'string' ? raw.title : '',
+    body: typeof raw?.body === 'string' ? raw.body : '',
+    image: typeof raw?.image === 'string' ? raw.image : null,
+    authorUsername,
+    linkedRecipeId,
+  };
+}
+
+/** Stories where `linked_recipe` matches the given recipe id. Filters client-side. */
+export async function fetchStoriesForRecipe(recipeId: string | number): Promise<StoryListItem[]> {
+  const list = await apiGetJson<any[]>(`/api/stories/`);
+  if (!Array.isArray(list)) return [];
+  const target = String(recipeId);
+  return list.map(pickListItem).filter((s) => s.linkedRecipeId === target);
+}
+
 function normalizeStoryDetail(data: StoryDetail & Record<string, unknown>): StoryDetail {
   const authorId = parseAuthorId(data.author);
   const author =


### PR DESCRIPTION
## Summary
- Home feed leads with stories as large vertical cards (image + excerpt + author + linked recipe pill); recipes demoted to a secondary "More recipes" row.
- Recipe detail gets a new "Stories about this recipe" section listing every story whose `linked_recipe` points to this recipe, each navigating to StoryDetail.
- Story cards expose a direct shortcut pill to the linked recipe, so users can jump to the recipe without opening the story first.

Aligns with the Culture First pivot — stories are the primary surface, recipes support them, navigation is bidirectional.

Closes #380

## Test plan
- [ ] Home feed shows stories as large vertical cards above a smaller "More recipes" row
- [ ] Tapping a story opens StoryDetail; tapping the "Recipe: ..." pill on a story card jumps directly to RecipeDetail
- [ ] StoryDetail's "Linked Recipe" card still navigates to RecipeDetail (regression)
- [ ] RecipeDetail shows a "Stories about this recipe" section listing linked stories; tapping one opens StoryDetail
- [ ] Author pills on home story cards navigate to UserProfile