### PR TITLE
feat(frontend): contact-author button and message screen (#340)

### DIFF
--- a/app/frontend/src/App.js
+++ b/app/frontend/src/App.js
@@ -13,6 +13,8 @@ import StoryListPage from './pages/StoryListPage';
 import StoryDetailPage from './pages/StoryDetailPage';
 import StoryCreatePage from './pages/StoryCreatePage';
 import StoryEditPage from './pages/StoryEditPage';
+import InboxPage from './pages/InboxPage';
+import ThreadPage from './pages/ThreadPage';
 import NotFoundPage from './pages/NotFoundPage';
 
 export default function App() {
@@ -47,6 +49,16 @@ export default function App() {
 
           <Route path="/recipes/:id" element={<RecipeDetailPage />} />
           <Route path="/stories/:id" element={<StoryDetailPage />} />
+
+          <Route
+            path="/inbox"
+            element={<ProtectedRoute><InboxPage /></ProtectedRoute>}
+          />
+          <Route
+            path="/inbox/:threadId"
+            element={<ProtectedRoute><ThreadPage /></ProtectedRoute>}
+          />
+
           <Route path="*" element={<NotFoundPage />} />
         </Routes>
       </div>

--- a/app/frontend/src/components/Navbar.jsx
+++ b/app/frontend/src/components/Navbar.jsx
@@ -18,6 +18,7 @@ export default function Navbar() {
           {user ? (
             <>
               <span className="navbar-username">@{user.username}</span>
+              <NavLink to="/inbox" className="navbar-link">Inbox</NavLink>
               <Link to="/recipes/new" className="btn btn-outline navbar-btn">
                 New Recipe
               </Link>

--- a/app/frontend/src/mocks/messages.js
+++ b/app/frontend/src/mocks/messages.js
@@ -1,0 +1,98 @@
+export const MOCK_THREADS = [
+  {
+    id: 1,
+    otherUser: { id: 2, username: 'chef_maria' },
+    recipe: { id: 1, title: 'Turkish Baklava' },
+    lastMessage: {
+      body: 'Thanks for the kind words! Let me know how it turns out.',
+      createdAt: '2026-04-28T10:00:00Z',
+      senderId: 2,
+    },
+    unreadCount: 1,
+  },
+  {
+    id: 2,
+    otherUser: { id: 3, username: 'spice_master' },
+    recipe: { id: 2, title: 'Lamb Tagine' },
+    lastMessage: {
+      body: 'You can substitute ras el hanout with garam masala in a pinch.',
+      createdAt: '2026-04-26T15:30:00Z',
+      senderId: 3,
+    },
+    unreadCount: 0,
+  },
+];
+
+export const MOCK_MESSAGES = {
+  1: [
+    {
+      id: 1,
+      threadId: 1,
+      sender: { id: 1, username: 'daglar' },
+      body: 'Hi! I loved your baklava recipe — the walnut-to-pistachio ratio is perfect. Any tips on getting the syrup to soak evenly?',
+      createdAt: '2026-04-27T09:00:00Z',
+    },
+    {
+      id: 2,
+      threadId: 1,
+      sender: { id: 2, username: 'chef_maria' },
+      body: 'Thanks for the kind words! Let me know how it turns out.',
+      createdAt: '2026-04-28T10:00:00Z',
+    },
+  ],
+  2: [
+    {
+      id: 3,
+      threadId: 2,
+      sender: { id: 1, username: 'daglar' },
+      body: "Love the tagine recipe! I can't find ras el hanout locally — is there a good substitute?",
+      createdAt: '2026-04-25T11:00:00Z',
+    },
+    {
+      id: 4,
+      threadId: 2,
+      sender: { id: 3, username: 'spice_master' },
+      body: 'You can substitute ras el hanout with garam masala in a pinch.',
+      createdAt: '2026-04-26T15:30:00Z',
+    },
+  ],
+};
+
+let nextThreadId = 3;
+let nextMessageId = 5;
+
+export function mockCreateThread({ toUserId, toUsername, recipeId, recipeTitle, body }) {
+  const newThread = {
+    id: nextThreadId++,
+    otherUser: { id: toUserId, username: toUsername },
+    recipe: { id: recipeId, title: recipeTitle },
+    lastMessage: { body, createdAt: new Date().toISOString(), senderId: 1 },
+    unreadCount: 0,
+  };
+  MOCK_THREADS.unshift(newThread);
+  MOCK_MESSAGES[newThread.id] = [
+    {
+      id: nextMessageId++,
+      threadId: newThread.id,
+      sender: { id: 1, username: 'daglar' },
+      body,
+      createdAt: new Date().toISOString(),
+    },
+  ];
+  return newThread;
+}
+
+export function mockSendMessage(threadId, body) {
+  const msg = {
+    id: nextMessageId++,
+    threadId,
+    sender: { id: 1, username: 'daglar' },
+    body,
+    createdAt: new Date().toISOString(),
+  };
+  if (!MOCK_MESSAGES[threadId]) MOCK_MESSAGES[threadId] = [];
+  MOCK_MESSAGES[threadId].push(msg);
+  const thread = MOCK_THREADS.find((t) => t.id === threadId);
+  if (thread) thread.lastMessage = { body, createdAt: msg.createdAt, senderId: 1 };
+  return msg;
+}

--- a/app/frontend/src/pages/InboxPage.css
+++ b/app/frontend/src/pages/InboxPage.css
@@ -1,0 +1,177 @@
+.inbox-page {
+  max-width: 680px;
+  margin: 0 auto;
+}
+
+.inbox-title {
+  font-size: clamp(1.5rem, 3vw, 2rem);
+  font-weight: 900;
+  color: var(--color-text);
+  margin-bottom: 1.5rem;
+}
+
+/* Compose */
+.inbox-compose {
+  background: var(--color-surface);
+  border: 1.5px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: 1.25rem 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.compose-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.875rem;
+}
+
+.compose-label {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.compose-recipient {
+  font-weight: 600;
+  color: var(--color-primary);
+}
+
+.compose-recipe {
+  font-size: 0.9rem;
+  color: var(--color-text-muted);
+}
+
+.compose-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.compose-textarea {
+  resize: vertical;
+  min-height: 100px;
+}
+
+.compose-error {
+  color: var(--color-error);
+  font-size: 0.875rem;
+}
+
+.compose-actions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+/* Empty state */
+.inbox-empty {
+  color: var(--color-text-muted);
+  text-align: center;
+  padding: 3rem 1rem;
+}
+
+/* Thread list */
+.thread-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  border: 1.5px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.thread-row {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
+  text-decoration: none;
+  color: inherit;
+  background: var(--color-surface);
+  border-bottom: 1px solid var(--color-border);
+  transition: background 0.15s ease;
+}
+
+.thread-list li:last-child .thread-row {
+  border-bottom: none;
+}
+
+.thread-row:hover {
+  background: var(--color-primary-tint);
+}
+
+.thread-avatar {
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  background: var(--color-primary);
+  color: #fff;
+  font-weight: 700;
+  font-size: 1.125rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.thread-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.thread-header-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-bottom: 0.2rem;
+}
+
+.thread-username {
+  font-weight: 600;
+  color: var(--color-text);
+  font-size: 0.9375rem;
+}
+
+.thread-date {
+  font-size: 0.8125rem;
+  color: var(--color-text-muted);
+  flex-shrink: 0;
+}
+
+.thread-recipe-context {
+  font-size: 0.8rem;
+  color: var(--color-primary);
+  font-weight: 500;
+  display: block;
+  margin-bottom: 0.2rem;
+}
+
+.thread-preview {
+  font-size: 0.875rem;
+  color: var(--color-text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin: 0;
+}
+
+.thread-unread {
+  background: var(--color-primary);
+  color: #fff;
+  font-size: 0.75rem;
+  font-weight: 700;
+  border-radius: var(--radius-pill);
+  min-width: 20px;
+  height: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 0.375rem;
+  flex-shrink: 0;
+}

--- a/app/frontend/src/pages/InboxPage.jsx
+++ b/app/frontend/src/pages/InboxPage.jsx
@@ -1,0 +1,150 @@
+import { useState, useEffect, useContext } from 'react';
+import { useNavigate, useSearchParams, Link } from 'react-router-dom';
+import { AuthContext } from '../context/AuthContext';
+import { fetchThreads, createThread } from '../services/messageService';
+import './InboxPage.css';
+
+function formatDate(iso) {
+  const d = new Date(iso);
+  const now = new Date();
+  const diffDays = Math.floor((now - d) / 86400000);
+  if (diffDays === 0) return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  if (diffDays === 1) return 'Yesterday';
+  return d.toLocaleDateString([], { month: 'short', day: 'numeric' });
+}
+
+export default function InboxPage() {
+  const { user } = useContext(AuthContext);
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+
+  const isCompose = searchParams.get('compose') === 'true';
+  const toUserId = Number(searchParams.get('to'));
+  const toUsername = searchParams.get('toUsername') || '';
+  const recipeId = Number(searchParams.get('recipeId'));
+  const recipeTitle = searchParams.get('recipeTitle') || '';
+
+  const [threads, setThreads] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  const [composeBody, setComposeBody] = useState('');
+  const [sending, setSending] = useState(false);
+  const [composeError, setComposeError] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchThreads()
+      .then((data) => { if (!cancelled) setThreads(data); })
+      .catch(() => { if (!cancelled) setError('Could not load inbox.'); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, []);
+
+  async function handleSend(e) {
+    e.preventDefault();
+    if (!composeBody.trim()) return;
+    setSending(true);
+    setComposeError('');
+    try {
+      const thread = await createThread({
+        toUserId,
+        toUsername,
+        recipeId,
+        recipeTitle,
+        body: composeBody.trim(),
+      });
+      navigate(`/inbox/${thread.id}`);
+    } catch {
+      setComposeError('Failed to send message. Please try again.');
+      setSending(false);
+    }
+  }
+
+  return (
+    <main className="page-card inbox-page">
+      <h1 className="inbox-title">Inbox</h1>
+
+      {isCompose && (
+        <section className="inbox-compose">
+          <div className="compose-meta">
+            <span className="compose-label">To:</span>
+            <span className="compose-recipient">@{toUsername}</span>
+            {recipeTitle && (
+              <>
+                <span className="compose-label">Re:</span>
+                <span className="compose-recipe">{recipeTitle}</span>
+              </>
+            )}
+          </div>
+          <form onSubmit={handleSend} className="compose-form">
+            <textarea
+              className="compose-textarea"
+              placeholder="Write your message…"
+              value={composeBody}
+              onChange={(e) => setComposeBody(e.target.value)}
+              rows={4}
+              required
+            />
+            {composeError && <p className="compose-error">{composeError}</p>}
+            <div className="compose-actions">
+              <button
+                type="button"
+                className="btn btn-outline btn-sm"
+                onClick={() => navigate('/inbox')}
+              >
+                Cancel
+              </button>
+              <button type="submit" className="btn btn-primary btn-sm" disabled={sending}>
+                {sending ? 'Sending…' : 'Send'}
+              </button>
+            </div>
+          </form>
+        </section>
+      )}
+
+      {loading && <p className="page-status">Loading…</p>}
+      {error && <p className="page-status page-error">{error}</p>}
+
+      {!loading && !error && threads.length === 0 && !isCompose && (
+        <p className="inbox-empty">No messages yet. Contact a recipe author to start a conversation.</p>
+      )}
+
+      {threads.length > 0 && (
+        <ul className="thread-list">
+          {threads.map((thread) => (
+            <li key={thread.id}>
+              <Link to={`/inbox/${thread.id}`} className="thread-row">
+                <div className="thread-avatar" aria-hidden="true">
+                  {thread.otherUser.username[0].toUpperCase()}
+                </div>
+                <div className="thread-info">
+                  <div className="thread-header-row">
+                    <span className="thread-username">@{thread.otherUser.username}</span>
+                    {thread.lastMessage && (
+                      <span className="thread-date">
+                        {formatDate(thread.lastMessage.createdAt)}
+                      </span>
+                    )}
+                  </div>
+                  {thread.recipe && (
+                    <span className="thread-recipe-context">Re: {thread.recipe.title}</span>
+                  )}
+                  {thread.lastMessage && (
+                    <p className="thread-preview">
+                      {thread.lastMessage.senderId === user?.id ? 'You: ' : ''}
+                      {thread.lastMessage.body}
+                    </p>
+                  )}
+                </div>
+                {thread.unreadCount > 0 && (
+                  <span className="thread-unread">{thread.unreadCount}</span>
+                )}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+  );
+}

--- a/app/frontend/src/pages/RecipeDetailPage.css
+++ b/app/frontend/src/pages/RecipeDetailPage.css
@@ -16,6 +16,13 @@
   margin-bottom: 1.5rem;
 }
 
+.recipe-detail-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
 .recipe-region-tag {
   display: inline-block;
   font-size: 0.8125rem;

--- a/app/frontend/src/pages/RecipeDetailPage.jsx
+++ b/app/frontend/src/pages/RecipeDetailPage.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useContext } from 'react';
-import { useParams, Link } from 'react-router-dom';
+import { useParams, Link, useNavigate } from 'react-router-dom';
 import { AuthContext } from '../context/AuthContext';
 import { fetchRecipe } from '../services/recipeService';
 import { fetchRegions } from '../services/searchService';
@@ -8,6 +8,7 @@ import './RecipeDetailPage.css';
 export default function RecipeDetailPage() {
   const { id } = useParams();
   const { user } = useContext(AuthContext);
+  const navigate = useNavigate();
   const [recipe, setRecipe] = useState(null);
   const [regions, setRegions] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -40,11 +41,26 @@ export default function RecipeDetailPage() {
             <p className="recipe-author">By {recipe.author_username}</p>
           )}
         </div>
-        {isAuthor && (
-          <Link to={`/recipes/${recipe.id}/edit`} className="btn btn-outline btn-sm">
-            Edit
-          </Link>
-        )}
+        <div className="recipe-detail-actions">
+          {isAuthor && (
+            <Link to={`/recipes/${recipe.id}/edit`} className="btn btn-outline btn-sm">
+              Edit
+            </Link>
+          )}
+          {user && !isAuthor && recipe.author_username && (
+            <button
+              className="btn btn-outline btn-sm"
+              onClick={() =>
+                navigate(
+                  `/inbox?compose=true&to=${recipe.author}&toUsername=${recipe.author_username}` +
+                  `&recipeId=${recipe.id}&recipeTitle=${encodeURIComponent(recipe.title)}`
+                )
+              }
+            >
+              Message @{recipe.author_username}
+            </button>
+          )}
+        </div>
       </div>
 
       {recipe.image && (

--- a/app/frontend/src/pages/ThreadPage.css
+++ b/app/frontend/src/pages/ThreadPage.css
@@ -1,0 +1,171 @@
+.thread-page {
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - 64px);
+  max-width: 680px;
+  margin: 0 auto;
+  background: var(--color-surface);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-lg);
+  overflow: hidden;
+}
+
+/* Top bar */
+.thread-topbar {
+  padding: 0.875rem 1.5rem;
+  border-bottom: 1.5px solid var(--color-border);
+  background: var(--color-surface);
+}
+
+.thread-back {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--color-primary);
+  text-decoration: none;
+  transition: opacity 0.15s;
+}
+
+.thread-back:hover {
+  opacity: 0.75;
+}
+
+/* Messages area */
+.thread-messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1.25rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+/* Day divider */
+.thread-day-divider {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin: 1rem 0 0.5rem;
+  color: var(--color-text-muted);
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.thread-day-divider::before,
+.thread-day-divider::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--color-border);
+}
+
+/* Bubble rows */
+.bubble-row {
+  display: flex;
+  align-items: flex-end;
+  gap: 0.5rem;
+  margin-bottom: 0.375rem;
+}
+
+.bubble-row.mine {
+  flex-direction: row-reverse;
+}
+
+.bubble-avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: var(--color-accent-green);
+  color: #fff;
+  font-weight: 700;
+  font-size: 0.875rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.bubble-wrap {
+  display: flex;
+  flex-direction: column;
+  max-width: 68%;
+}
+
+.bubble-row.mine .bubble-wrap {
+  align-items: flex-end;
+}
+
+.bubble-sender {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  margin-bottom: 0.2rem;
+  padding-left: 0.25rem;
+}
+
+.bubble {
+  padding: 0.625rem 0.875rem;
+  border-radius: var(--radius-lg);
+  font-size: 0.9375rem;
+  line-height: 1.55;
+  word-break: break-word;
+}
+
+.bubble-mine {
+  background: var(--color-primary);
+  color: #fff;
+  border-bottom-right-radius: var(--radius-sm);
+}
+
+.bubble-theirs {
+  background: var(--color-border);
+  color: var(--color-text);
+  border-bottom-left-radius: var(--radius-sm);
+}
+
+.bubble-time {
+  font-size: 0.7rem;
+  color: var(--color-text-muted);
+  margin-top: 0.2rem;
+  padding: 0 0.25rem;
+}
+
+/* Send bar */
+.thread-send-bar {
+  display: flex;
+  align-items: flex-end;
+  gap: 0.75rem;
+  padding: 0.875rem 1.25rem;
+  border-top: 1.5px solid var(--color-border);
+  background: var(--color-surface);
+}
+
+.send-input {
+  flex: 1;
+  resize: none;
+  min-height: 42px;
+  max-height: 120px;
+  overflow-y: auto;
+  padding: 0.6rem 0.875rem;
+  border-radius: var(--radius-md);
+  font-family: var(--font-body);
+  font-size: 0.9375rem;
+  line-height: 1.5;
+}
+
+.send-btn {
+  flex-shrink: 0;
+  align-self: flex-end;
+}
+
+@media (max-width: 640px) {
+  .thread-page {
+    height: calc(100vh - 56px);
+    border-radius: 0;
+  }
+
+  .bubble-wrap {
+    max-width: 82%;
+  }
+}

--- a/app/frontend/src/pages/ThreadPage.jsx
+++ b/app/frontend/src/pages/ThreadPage.jsx
@@ -1,0 +1,125 @@
+import { useState, useEffect, useContext, useRef } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { AuthContext } from '../context/AuthContext';
+import { fetchMessages, sendMessage } from '../services/messageService';
+import './ThreadPage.css';
+
+function formatTime(iso) {
+  return new Date(iso).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+}
+
+function formatDay(iso) {
+  return new Date(iso).toLocaleDateString([], {
+    weekday: 'short', month: 'short', day: 'numeric',
+  });
+}
+
+export default function ThreadPage() {
+  const { threadId } = useParams();
+  const { user } = useContext(AuthContext);
+  const bottomRef = useRef(null);
+
+  const [messages, setMessages] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [body, setBody] = useState('');
+  const [sending, setSending] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchMessages(threadId)
+      .then((data) => { if (!cancelled) setMessages(data); })
+      .catch(() => { if (!cancelled) setError('Could not load messages.'); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [threadId]);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
+  async function handleSend(e) {
+    e.preventDefault();
+    if (!body.trim() || sending) return;
+    setSending(true);
+    try {
+      const msg = await sendMessage(threadId, body.trim());
+      setMessages((prev) => [...prev, msg]);
+      setBody('');
+    } finally {
+      setSending(false);
+    }
+  }
+
+  function handleKeyDown(e) {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSend(e);
+    }
+  }
+
+  const groupedByDay = messages.reduce((acc, msg) => {
+    const day = new Date(msg.createdAt).toDateString();
+    if (!acc[day]) acc[day] = [];
+    acc[day].push(msg);
+    return acc;
+  }, {});
+
+  return (
+    <main className="thread-page">
+      <div className="thread-topbar">
+        <Link to="/inbox" className="thread-back">← Inbox</Link>
+      </div>
+
+      <div className="thread-messages">
+        {loading && <p className="page-status">Loading…</p>}
+        {error && <p className="page-status page-error">{error}</p>}
+
+        {Object.entries(groupedByDay).map(([day, msgs]) => (
+          <div key={day}>
+            <div className="thread-day-divider">
+              <span>{formatDay(msgs[0].createdAt)}</span>
+            </div>
+            {msgs.map((msg) => {
+              const isMine = user && msg.sender.id === user.id;
+              return (
+                <div key={msg.id} className={`bubble-row ${isMine ? 'mine' : 'theirs'}`}>
+                  {!isMine && (
+                    <div className="bubble-avatar" aria-hidden="true">
+                      {msg.sender.username[0].toUpperCase()}
+                    </div>
+                  )}
+                  <div className="bubble-wrap">
+                    {!isMine && (
+                      <span className="bubble-sender">@{msg.sender.username}</span>
+                    )}
+                    <div className={`bubble ${isMine ? 'bubble-mine' : 'bubble-theirs'}`}>
+                      {msg.body}
+                    </div>
+                    <span className="bubble-time">{formatTime(msg.createdAt)}</span>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        ))}
+        <div ref={bottomRef} />
+      </div>
+
+      <form className="thread-send-bar" onSubmit={handleSend}>
+        <textarea
+          className="send-input"
+          placeholder="Write a message… (Enter to send)"
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          onKeyDown={handleKeyDown}
+          rows={1}
+          required
+        />
+        <button type="submit" className="btn btn-primary send-btn" disabled={sending || !body.trim()}>
+          Send
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/app/frontend/src/services/messageService.js
+++ b/app/frontend/src/services/messageService.js
@@ -1,4 +1,4 @@
-import apiClient from './api';
+import { apiClient } from './api';
 import {
   MOCK_THREADS,
   MOCK_MESSAGES,

--- a/app/frontend/src/services/messageService.js
+++ b/app/frontend/src/services/messageService.js
@@ -1,0 +1,37 @@
+import apiClient from './api';
+import {
+  MOCK_THREADS,
+  MOCK_MESSAGES,
+  mockCreateThread,
+  mockSendMessage,
+} from '../mocks/messages';
+
+const USE_MOCK = process.env.REACT_APP_USE_MOCK === 'true';
+
+export async function fetchThreads() {
+  if (USE_MOCK) return [...MOCK_THREADS];
+  const res = await apiClient.get('/api/messages/threads/');
+  return res.data;
+}
+
+export async function fetchMessages(threadId) {
+  if (USE_MOCK) return [...(MOCK_MESSAGES[Number(threadId)] || [])];
+  const res = await apiClient.get(`/api/messages/threads/${threadId}/`);
+  return res.data;
+}
+
+export async function sendMessage(threadId, body) {
+  if (USE_MOCK) return mockSendMessage(Number(threadId), body);
+  const res = await apiClient.post('/api/messages/', { thread: threadId, body });
+  return res.data;
+}
+
+export async function createThread({ toUserId, toUsername, recipeId, recipeTitle, body }) {
+  if (USE_MOCK) return mockCreateThread({ toUserId, toUsername, recipeId, recipeTitle, body });
+  const res = await apiClient.post('/api/messages/threads/', {
+    recipient: toUserId,
+    recipe: recipeId,
+    body,
+  });
+  return res.data;
+}


### PR DESCRIPTION
## Summary
- Adds **Message @author** button on recipe detail page (visible to logged-in non-authors)
- Adds **Inbox** page (`/inbox`) — thread list with compose flow pre-filled from recipe context
- Adds **Thread** page (`/inbox/:threadId`) — bubble-style message view with send bar
- Adds **Inbox** nav link in Navbar for logged-in users
- All API calls are mock-first behind `REACT_APP_USE_MOCK` — ready to swap when M4-08 lands

## Test plan
- [ ] Log in → navigate to any recipe → "Message @author" button is visible (not shown on own recipes)
- [ ] Click button → `/inbox` opens with compose form pre-filled with author + recipe title
- [ ] Send message → redirects to thread view at `/inbox/:threadId`
- [ ] Thread view shows bubbles, Enter or Send button sends a new message
- [ ] Navbar "Inbox" link → shows thread list with unread badge
- [ ] Logged-out users cannot access `/inbox` or `/inbox/:threadId` (redirected by ProtectedRoute)

## Notes
Depends on M4-08 (messaging API). Service layer in `messageService.js` has real endpoint targets already wired — just needs the backend to go live.

Closes #340