### PR TITLE
feat(frontend): add web notification tray and device token registration

### DIFF
--- a/app/frontend/src/__tests__/AuthContext.test.jsx
+++ b/app/frontend/src/__tests__/AuthContext.test.jsx
@@ -2,8 +2,10 @@ import { render, screen, act, waitFor } from '@testing-library/react';
 import { useContext } from 'react';
 import { AuthProvider, AuthContext } from '../context/AuthContext';
 import * as authService from '../services/authService';
+import * as deviceTokenService from '../services/deviceTokenService';
 
 jest.mock('../services/authService');
+jest.mock('../services/deviceTokenService');
 
 function TestConsumer() {
   const { user, token, login, logout, loading } = useContext(AuthContext);
@@ -22,6 +24,7 @@ describe('AuthContext', () => {
   beforeEach(() => {
     localStorage.clear();
     authService.fetchMe.mockResolvedValue({ id: 1, username: 'restored-user' });
+    deviceTokenService.registerWebDeviceToken.mockResolvedValue({});
   });
 
   afterEach(() => { jest.clearAllMocks(); });
@@ -37,6 +40,7 @@ describe('AuthContext', () => {
     act(() => screen.getByText('login').click());
     expect(screen.getByTestId('user').textContent).toBe('alice');
     expect(screen.getByTestId('token').textContent).toBe('tok123');
+    expect(deviceTokenService.registerWebDeviceToken).toHaveBeenCalledTimes(1);
   });
 
   test('login() persists token to localStorage', () => {
@@ -78,6 +82,7 @@ describe('AuthContext', () => {
       expect(screen.getByTestId('user').textContent).toBe('restored-user')
     );
     expect(authService.fetchMe).toHaveBeenCalledTimes(1);
+    expect(deviceTokenService.registerWebDeviceToken).toHaveBeenCalledTimes(1);
   });
 
   test('loading is true while fetching and false after fetchMe resolves', async () => {

--- a/app/frontend/src/__tests__/Navbar.test.jsx
+++ b/app/frontend/src/__tests__/Navbar.test.jsx
@@ -1,13 +1,24 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { AuthContext } from '../context/AuthContext';
+import { NotificationContext } from '../context/NotificationContext';
 import Navbar from '../components/Navbar';
 
 function renderNavbar(user = null, logout = jest.fn()) {
   return render(
     <MemoryRouter>
       <AuthContext.Provider value={{ user, logout }}>
-        <Navbar />
+        <NotificationContext.Provider
+          value={{
+            notifications: [{ id: 1, message: 'test', isRead: false, createdAt: new Date().toISOString() }],
+            unreadCount: 1,
+            loading: false,
+            error: '',
+            markRead: jest.fn(),
+          }}
+        >
+          <Navbar />
+        </NotificationContext.Provider>
       </AuthContext.Provider>
     </MemoryRouter>
   );
@@ -33,6 +44,7 @@ describe('Navbar', () => {
   it('shows username and nav links when logged in', () => {
     renderNavbar({ username: 'alice', id: 1 });
     expect(screen.getByText('@alice')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /notifications/i })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /new recipe/i })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /new story/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /log out/i })).toBeInTheDocument();

--- a/app/frontend/src/__tests__/notificationService.test.js
+++ b/app/frontend/src/__tests__/notificationService.test.js
@@ -1,0 +1,59 @@
+import { fetchNotifications, markNotificationAsRead, registerDeviceToken } from '../services/notificationService';
+import { apiClient } from '../services/api';
+
+jest.mock('../services/api', () => ({
+  apiClient: {
+    get: jest.fn(),
+    post: jest.fn(),
+    patch: jest.fn(),
+  },
+}));
+
+describe('notificationService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('fetchNotifications handles paginated response', async () => {
+    apiClient.get.mockResolvedValueOnce({
+      data: {
+        results: [
+          { id: 1, message: 'hello', is_read: false, created_at: '2026-01-01T10:00:00Z' },
+        ],
+      },
+    });
+    const result = await fetchNotifications();
+    expect(apiClient.get).toHaveBeenCalledWith('/api/notifications/');
+    expect(result[0]).toEqual(expect.objectContaining({ id: 1, isRead: false, message: 'hello' }));
+  });
+
+  test('markNotificationAsRead prefers PATCH', async () => {
+    apiClient.patch.mockResolvedValueOnce({
+      data: { id: 4, message: 'updated', is_read: true, created_at: '2026-01-01T10:00:00Z' },
+    });
+    const updated = await markNotificationAsRead(4);
+    expect(apiClient.patch).toHaveBeenCalledWith('/api/notifications/4/read/');
+    expect(apiClient.post).not.toHaveBeenCalled();
+    expect(updated.isRead).toBe(true);
+  });
+
+  test('markNotificationAsRead falls back to POST if PATCH not allowed', async () => {
+    apiClient.patch.mockRejectedValueOnce({ response: { status: 405 } });
+    apiClient.post.mockResolvedValueOnce({
+      data: { id: 7, message: 'updated', is_read: true, created_at: '2026-01-01T10:00:00Z' },
+    });
+    const updated = await markNotificationAsRead(7);
+    expect(apiClient.post).toHaveBeenCalledWith('/api/notifications/7/read/');
+    expect(updated.isRead).toBe(true);
+  });
+
+  test('registerDeviceToken posts token payload', async () => {
+    apiClient.post.mockResolvedValueOnce({ data: { id: 9, token: 'web-token' } });
+    await registerDeviceToken('web-token');
+    expect(apiClient.post).toHaveBeenCalledWith('/api/notifications/tokens/', {
+      token: 'web-token',
+      platform: 'web',
+    });
+  });
+});
+

--- a/app/frontend/src/components/Navbar.jsx
+++ b/app/frontend/src/components/Navbar.jsx
@@ -1,6 +1,7 @@
 import { useContext } from 'react';
 import { Link, NavLink } from 'react-router-dom';
 import { AuthContext } from '../context/AuthContext';
+import NotificationTray from './NotificationTray';
 import './Navbar.css';
 
 export default function Navbar() {
@@ -18,6 +19,7 @@ export default function Navbar() {
           {user ? (
             <>
               <span className="navbar-username">@{user.username}</span>
+              <NotificationTray />
               <NavLink to="/inbox" className="navbar-link">Inbox</NavLink>
               <Link to="/recipes/new" className="btn btn-outline navbar-btn">
                 New Recipe

--- a/app/frontend/src/components/NotificationTray.css
+++ b/app/frontend/src/components/NotificationTray.css
@@ -1,0 +1,108 @@
+.notification-tray {
+  position: relative;
+}
+
+.notification-toggle {
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-alt);
+  color: var(--color-text);
+  border-radius: 999px;
+  width: 2.1rem;
+  height: 2.1rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  position: relative;
+}
+
+.notification-toggle:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.notification-badge {
+  position: absolute;
+  top: -0.35rem;
+  right: -0.35rem;
+  background: #d43b3b;
+  color: #fff;
+  border-radius: 999px;
+  min-width: 1.2rem;
+  height: 1.2rem;
+  padding: 0 0.25rem;
+  font-size: 0.72rem;
+  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.notification-panel {
+  position: absolute;
+  right: 0;
+  margin-top: 0.5rem;
+  width: min(92vw, 22rem);
+  max-height: 24rem;
+  overflow: auto;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  border-radius: 0.75rem;
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.16);
+  z-index: 60;
+}
+
+.notification-header {
+  border-bottom: 1px solid var(--color-border);
+  padding: 0.8rem 1rem;
+}
+
+.notification-header h2 {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.notification-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.notification-item {
+  display: block;
+  text-decoration: none;
+  color: var(--color-text);
+  padding: 0.85rem 1rem;
+  border-bottom: 1px solid var(--color-border-subtle);
+  background: #fff9ed;
+}
+
+.notification-item-read {
+  background: var(--color-surface);
+}
+
+.notification-item:hover {
+  text-decoration: none;
+  background: #fff4de;
+}
+
+.notification-message {
+  margin: 0 0 0.25rem 0;
+  font-size: 0.9rem;
+}
+
+.notification-time {
+  font-size: 0.78rem;
+  color: var(--color-text-muted);
+}
+
+.notification-status {
+  margin: 0;
+  padding: 0.85rem 1rem;
+  color: var(--color-text-muted);
+}
+
+.notification-error {
+  color: #9f2930;
+}
+

--- a/app/frontend/src/components/NotificationTray.jsx
+++ b/app/frontend/src/components/NotificationTray.jsx
@@ -1,0 +1,95 @@
+import { useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { NotificationContext } from '../context/NotificationContext';
+import './NotificationTray.css';
+
+function formatRelativeDate(isoDate) {
+  const date = new Date(isoDate);
+  const now = new Date();
+  const diffMinutes = Math.floor((now - date) / 60000);
+  if (diffMinutes < 1) return 'Just now';
+  if (diffMinutes < 60) return `${diffMinutes}m ago`;
+  const diffHours = Math.floor(diffMinutes / 60);
+  if (diffHours < 24) return `${diffHours}h ago`;
+  return date.toLocaleDateString([], { month: 'short', day: 'numeric' });
+}
+
+function getNotificationLink(notification) {
+  if (notification.recipeId) return `/recipes/${notification.recipeId}`;
+  return '/inbox';
+}
+
+function getNotificationText(notification) {
+  if (notification.message) return notification.message;
+  if (notification.recipeTitle) return `New activity on ${notification.recipeTitle}`;
+  return 'You have a new notification';
+}
+
+export default function NotificationTray() {
+  const { notifications, unreadCount, loading, error, markRead } = useContext(NotificationContext);
+  const [open, setOpen] = useState(false);
+  const trayRef = useRef(null);
+
+  useEffect(() => {
+    function onDocumentClick(event) {
+      if (!trayRef.current?.contains(event.target)) setOpen(false);
+    }
+    document.addEventListener('mousedown', onDocumentClick);
+    return () => document.removeEventListener('mousedown', onDocumentClick);
+  }, []);
+
+  const sortedNotifications = useMemo(
+    () => [...notifications].sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt)),
+    [notifications]
+  );
+
+  return (
+    <div className="notification-tray" ref={trayRef}>
+      <button
+        type="button"
+        className="notification-toggle"
+        aria-label="Notifications"
+        aria-expanded={open}
+        onClick={() => setOpen((prev) => !prev)}
+      >
+        <span aria-hidden="true">🔔</span>
+        {unreadCount > 0 && <span className="notification-badge">{unreadCount}</span>}
+      </button>
+
+      {open && (
+        <section className="notification-panel" aria-label="Notification list">
+          <header className="notification-header">
+            <h2>Notifications</h2>
+          </header>
+
+          {loading && <p className="notification-status">Loading…</p>}
+          {error && <p className="notification-status notification-error">{error}</p>}
+          {!loading && !error && sortedNotifications.length === 0 && (
+            <p className="notification-status">No notifications yet.</p>
+          )}
+
+          {!loading && !error && sortedNotifications.length > 0 && (
+            <ul className="notification-list">
+              {sortedNotifications.map((item) => (
+                <li key={item.id}>
+                  <Link
+                    to={getNotificationLink(item)}
+                    className={`notification-item ${item.isRead ? 'notification-item-read' : ''}`}
+                    onClick={() => {
+                      markRead(item.id);
+                      setOpen(false);
+                    }}
+                  >
+                    <p className="notification-message">{getNotificationText(item)}</p>
+                    <span className="notification-time">{formatRelativeDate(item.createdAt)}</span>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+      )}
+    </div>
+  );
+}
+

--- a/app/frontend/src/context/AuthContext.jsx
+++ b/app/frontend/src/context/AuthContext.jsx
@@ -1,5 +1,6 @@
 import { createContext, useState, useEffect } from 'react';
 import { fetchMe } from '../services/authService';
+import { registerWebDeviceToken } from '../services/deviceTokenService';
 
 export const AuthContext = createContext(null);
 
@@ -22,7 +23,10 @@ export function AuthProvider({ children }) {
       return;
     }
     fetchMe()
-      .then((userData) => { setUser(userData); })
+      .then((userData) => {
+        setUser(userData);
+        registerWebDeviceToken().catch(() => {});
+      })
       .catch(() => { logout(); })
       .finally(() => { setLoading(false); });
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -31,6 +35,7 @@ export function AuthProvider({ children }) {
   function login(userData, accessToken) {
     setUser(userData);
     setToken(accessToken);
+    registerWebDeviceToken().catch(() => {});
   }
 
   function logout() {

--- a/app/frontend/src/context/NotificationContext.jsx
+++ b/app/frontend/src/context/NotificationContext.jsx
@@ -1,0 +1,74 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { AuthContext } from './AuthContext';
+import { fetchNotifications, markNotificationAsRead } from '../services/notificationService';
+
+export const NotificationContext = createContext({
+  notifications: [],
+  unreadCount: 0,
+  loading: false,
+  error: '',
+  refreshNotifications: async () => {},
+  markRead: async () => {},
+});
+
+export function NotificationProvider({ children }) {
+  const { token } = useContext(AuthContext);
+  const [notifications, setNotifications] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const refreshNotifications = useCallback(async () => {
+    if (!token) {
+      setNotifications([]);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    setError('');
+    try {
+      const items = await fetchNotifications();
+      setNotifications(items);
+    } catch {
+      setError('Could not load notifications.');
+    } finally {
+      setLoading(false);
+    }
+  }, [token]);
+
+  useEffect(() => {
+    refreshNotifications();
+  }, [refreshNotifications]);
+
+  const markRead = useCallback(async (id) => {
+    const current = notifications.find((item) => item.id === id);
+    if (!current || current.isRead) return;
+    setNotifications((prev) => prev.map((n) => (n.id === id ? { ...n, isRead: true } : n)));
+    try {
+      const updated = await markNotificationAsRead(id);
+      if (updated) {
+        setNotifications((prev) => prev.map((n) => (n.id === id ? updated : n)));
+      }
+    } catch {
+      setNotifications((prev) => prev.map((n) => (n.id === id ? { ...n, isRead: false } : n)));
+    }
+  }, [notifications]);
+
+  const unreadCount = useMemo(
+    () => notifications.filter((n) => !n.isRead).length,
+    [notifications]
+  );
+
+  const value = useMemo(
+    () => ({
+      notifications,
+      unreadCount,
+      loading,
+      error,
+      refreshNotifications,
+      markRead,
+    }),
+    [notifications, unreadCount, loading, error, refreshNotifications, markRead]
+  );
+
+  return <NotificationContext.Provider value={value}>{children}</NotificationContext.Provider>;
+}

--- a/app/frontend/src/index.js
+++ b/app/frontend/src/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { AuthProvider } from './context/AuthContext';
+import { NotificationProvider } from './context/NotificationContext';
 import App from './App';
 import './index.css';
 
@@ -10,7 +11,9 @@ root.render(
   <React.StrictMode>
     <BrowserRouter>
       <AuthProvider>
-        <App />
+        <NotificationProvider>
+          <App />
+        </NotificationProvider>
       </AuthProvider>
     </BrowserRouter>
   </React.StrictMode>

--- a/app/frontend/src/services/deviceTokenService.js
+++ b/app/frontend/src/services/deviceTokenService.js
@@ -1,0 +1,24 @@
+import { registerDeviceToken } from './notificationService';
+
+const DEVICE_TOKEN_KEY = 'web_device_token';
+
+function buildWebToken() {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return `web-${crypto.randomUUID()}`;
+  }
+  return `web-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+export function getOrCreateWebDeviceToken() {
+  const existing = localStorage.getItem(DEVICE_TOKEN_KEY);
+  if (existing) return existing;
+  const token = buildWebToken();
+  localStorage.setItem(DEVICE_TOKEN_KEY, token);
+  return token;
+}
+
+export async function registerWebDeviceToken() {
+  const token = getOrCreateWebDeviceToken();
+  return registerDeviceToken(token, 'web');
+}
+

--- a/app/frontend/src/services/notificationService.js
+++ b/app/frontend/src/services/notificationService.js
@@ -1,0 +1,59 @@
+import { apiClient } from './api';
+
+const USE_MOCK = process.env.REACT_APP_USE_MOCK === 'true';
+
+const mockNotifications = [
+  {
+    id: 1,
+    type: 'recipe_question',
+    message: 'alice asked a question on your recipe.',
+    payload: { recipeId: 2, recipeTitle: 'Mercimek Corbasi' },
+    is_read: false,
+    created_at: new Date().toISOString(),
+  },
+];
+
+function normalize(notification) {
+  if (!notification) return null;
+  return {
+    id: notification.id,
+    type: notification.type || 'generic',
+    message: notification.message || '',
+    payload: notification.payload || null,
+    isRead: Boolean(notification.is_read ?? notification.isRead),
+    createdAt: notification.created_at || notification.createdAt || new Date().toISOString(),
+    actorUsername: notification.actor_username,
+    recipeId: notification.recipe,
+    recipeTitle: notification.recipe_title,
+  };
+}
+
+export async function fetchNotifications() {
+  if (USE_MOCK) return mockNotifications.map(normalize);
+  const response = await apiClient.get('/api/notifications/');
+  const list = Array.isArray(response.data?.results) ? response.data.results : response.data;
+  return Array.isArray(list) ? list.map(normalize) : [];
+}
+
+export async function markNotificationAsRead(notificationId) {
+  if (USE_MOCK) {
+    const item = mockNotifications.find((n) => n.id === notificationId);
+    return normalize({ ...item, is_read: true });
+  }
+  try {
+    const response = await apiClient.patch(`/api/notifications/${notificationId}/read/`);
+    return normalize(response.data);
+  } catch (err) {
+    if (err?.response?.status !== 405) throw err;
+    const response = await apiClient.post(`/api/notifications/${notificationId}/read/`);
+    return normalize(response.data);
+  }
+}
+
+export async function registerDeviceToken(token, platform = 'web') {
+  if (!token) return null;
+  if (USE_MOCK) return { id: 1, token, platform };
+  const response = await apiClient.post('/api/notifications/tokens/', { token, platform });
+  return response.data;
+}
+


### PR DESCRIPTION
## Description
This PR adds the web frontend layer for the notification backbone used by Q&A and messaging.

Implemented in this PR:
- Added notification API service integration:
  - `GET /api/notifications/` for in-app notification list
  - mark-as-read action with `PATCH /api/notifications/{id}/read/` and `POST` fallback for backend compatibility
  - `POST /api/notifications/tokens/` for device-token registration
- Added login/session-based web device-token registration flow
- Added global notification state management (`NotificationContext`)
- Added a web in-app notification tray in the navbar:
  - unread badge
  - notification list
  - mark as read on click
  - route navigation from notification item
- Wired providers into app root and integrated tray into existing navbar

## Motivation / Context
Q&A and messaging both depend on shared notification transport/storage behavior. This PR delivers the web client integration so backend-emitted notification events can be surfaced consistently in the web app, with read-state handling and token registration support.

## Scope
Frontend web only:
- services
- context/state
- navbar notification tray UI
- login token-registration flow
- tests

Out of scope:
- backend notification event emission logic
- mobile push delivery behavior
- infrastructure credential setup

## Testing
Executed:
- `npm test -- --watchAll=false --testPathPattern="AuthContext|Navbar|notificationService|LoginPage"`

Added/updated coverage:
- `notificationService` tests for list, read, and token registration calls
- `AuthContext` tests for device-token registration on login/session restore
- `Navbar` tests for notification tray visibility in authenticated state

## Acceptance Criteria Mapping
- In-app list endpoint integration on web: implemented
- Read-state update flow (`readAt` equivalent behavior): implemented via mark-as-read and unread count sync in UI state
- Device-token registration flow on login/re-login: implemented on web
- Token handling from environment-backed backend endpoints: supported by existing API base URL configuration

## Notes
- Mark-as-read uses `PATCH` first and falls back to `POST` to remain compatible with current backend action routing.
