### PR TITLE
fix(mobile): handle paginated recipes list response

### DIFF
--- a/app/mobile/src/services/recipeService.ts
+++ b/app/mobile/src/services/recipeService.ts
@@ -110,8 +110,13 @@ export async function fetchRecipesList(): Promise<
     image?: string | null;
   }[]
 > {
-  const data = await apiGetJson<any[]>(`/api/recipes/`);
-  return (Array.isArray(data) ? data : []).map((r) => {
+  const data = await apiGetJson<any>(`/api/recipes/`);
+  const list: any[] = Array.isArray(data)
+    ? data
+    : data && Array.isArray(data.results)
+      ? data.results
+      : [];
+  return list.map((r) => {
     const reg = r.region;
     const regionLabel =
       reg == null


### PR DESCRIPTION
## Summary
`fetchRecipesList` was returning empty after the recipes endpoint switched to a paginated `{ count, next, previous, results }` payload (introduced with the comment-API merge). It used `apiGetJson<any[]>` and `Array.isArray(data) ? data : []`, so the new shape collapsed to `[]` and broke the home recipes list, story-link picker, and profile recipe list.

Now accepts both flat array and paginated payload — falls back to `data.results` when present.

Closes #413

## Test plan
- [ ] Home shows recipes again under "More recipes"
- [ ] Story create/edit recipe picker populates
- [ ] UserProfile recipe tab populates
- [ ] No regression when backend returns a flat array