### PR TITLE
fix/backend/add serialized token refresh to eliminate auth race conditions (#394)

### DIFF
--- a/app/backend/apps/common/middleware.py
+++ b/app/backend/apps/common/middleware.py
@@ -22,6 +22,7 @@ class JWTAuthenticationMiddleware(MiddlewareMixin):
     EXEMPT_POST_PATHS = [
         '/api/auth/register/',
         '/api/auth/login/',
+        '/api/auth/refresh/',
     ]
 
     def process_request(self, request):

--- a/app/backend/apps/users/tests.py
+++ b/app/backend/apps/users/tests.py
@@ -194,6 +194,60 @@ class JWTValidationTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
 
+class TokenRefreshRaceConditionTest(APITestCase):
+    """Regression tests for Issue #394 – authentication race conditions."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            email='refresh@example.com', username='refreshuser', password='StrongPass123!'
+        )
+        response = self.client.post(
+            '/api/auth/login/', {"email": "refresh@example.com", "password": "StrongPass123!"}
+        )
+        self.access = response.data['access']
+        self.refresh = response.data['refresh']
+
+    def test_refresh_returns_new_tokens(self):
+        response = self.client.post('/api/auth/refresh/', {"refresh": self.refresh})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn('access', response.data)
+        self.assertIn('refresh', response.data)
+        self.assertNotEqual(response.data['access'], self.access)
+
+    def test_refresh_missing_token_returns_400(self):
+        response = self.client.post('/api/auth/refresh/', {})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_refresh_invalid_token_returns_401(self):
+        response = self.client.post('/api/auth/refresh/', {"refresh": "notavalidtoken"})
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_refresh_token_cannot_be_reused(self):
+        """Regression: same refresh token used twice must be rejected (simulates race condition outcome)."""
+        r1 = self.client.post('/api/auth/refresh/', {"refresh": self.refresh})
+        self.assertEqual(r1.status_code, status.HTTP_200_OK)
+        r2 = self.client.post('/api/auth/refresh/', {"refresh": self.refresh})
+        self.assertEqual(r2.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_new_refresh_token_is_usable(self):
+        r1 = self.client.post('/api/auth/refresh/', {"refresh": self.refresh})
+        self.assertEqual(r1.status_code, status.HTTP_200_OK)
+        r2 = self.client.post('/api/auth/refresh/', {"refresh": r1.data['refresh']})
+        self.assertEqual(r2.status_code, status.HTTP_200_OK)
+
+    def test_old_access_token_still_valid_after_refresh(self):
+        self.client.post('/api/auth/refresh/', {"refresh": self.refresh})
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {self.access}')
+        response = self.client.get('/api/users/me/')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_logged_out_refresh_token_cannot_be_refreshed(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {self.access}')
+        self.client.post('/api/auth/logout/', {"refresh": self.refresh})
+        response = self.client.post('/api/auth/refresh/', {"refresh": self.refresh})
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+
 class CulturalOnboardingTest(APITestCase):
     """Tests for cultural onboarding profile fields (M4-12 / #343)."""
 

--- a/app/backend/apps/users/urls.py
+++ b/app/backend/apps/users/urls.py
@@ -1,9 +1,10 @@
 from django.urls import path
-from .views import RegisterView, LoginView, LogoutView, MeView
+from .views import RegisterView, LoginView, LogoutView, MeView, TokenRefreshView
 
 urlpatterns = [
     path('auth/register/', RegisterView.as_view(), name='register'),
     path('auth/login/', LoginView.as_view(), name='login'),
+    path('auth/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
     path('auth/logout/', LogoutView.as_view(), name='logout'),
     path('users/me/', MeView.as_view(), name='me'),
 ]

--- a/app/backend/apps/users/views.py
+++ b/app/backend/apps/users/views.py
@@ -1,8 +1,11 @@
-from django.contrib.auth import authenticate
+from django.contrib.auth import authenticate, get_user_model
+from django.db import transaction
 from rest_framework import status, permissions
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework_simplejwt.tokens import RefreshToken
+from rest_framework_simplejwt.exceptions import TokenError
+from rest_framework_simplejwt.token_blacklist.models import OutstandingToken, BlacklistedToken
 from .serializers import (
     RegisterSerializer,
     LoginSerializer,
@@ -44,6 +47,45 @@ class LoginView(APIView):
                 **tokens
             }, status=status.HTTP_200_OK)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+class TokenRefreshView(APIView):
+    permission_classes = [permissions.AllowAny]
+
+    def post(self, request):
+        raw_token = request.data.get("refresh")
+        if not raw_token:
+            return Response({"detail": "Refresh token required."}, status=status.HTTP_400_BAD_REQUEST)
+
+        try:
+            token = RefreshToken(raw_token)
+        except TokenError as e:
+            return Response({"detail": str(e)}, status=status.HTTP_401_UNAUTHORIZED)
+
+        try:
+            with transaction.atomic():
+                jti = token["jti"]
+                try:
+                    outstanding = OutstandingToken.objects.select_for_update().get(jti=jti)
+                except OutstandingToken.DoesNotExist:
+                    return Response({"detail": "Token not found."}, status=status.HTTP_401_UNAUTHORIZED)
+
+                if BlacklistedToken.objects.filter(token=outstanding).exists():
+                    return Response(
+                        {"detail": "Token has already been used or revoked."},
+                        status=status.HTTP_401_UNAUTHORIZED,
+                    )
+
+                BlacklistedToken.objects.create(token=outstanding)
+                user = get_user_model().objects.get(id=token["user_id"])
+                new_refresh = RefreshToken.for_user(user)
+        except Exception:
+            return Response({"detail": "Token refresh failed."}, status=status.HTTP_400_BAD_REQUEST)
+
+        return Response(
+            {"access": str(new_refresh.access_token), "refresh": str(new_refresh)},
+            status=status.HTTP_200_OK,
+        )
+
 
 class LogoutView(APIView):
     permission_classes = [permissions.IsAuthenticated]


### PR DESCRIPTION
## Summary

- Closes #394
- Adds `POST /api/auth/refresh/` endpoint — was missing entirely, making token rotation impossible without re-login
- Uses `select_for_update()` inside `transaction.atomic()` to serialize concurrent refresh requests on the same token, eliminating the double-blacklist race condition observed in the demo
- Exempts `/api/auth/refresh/` from the middleware write-guard (`EXEMPT_POST_PATHS`)

## Changes

| File | Change |
|---|---|
| `apps/users/views.py` | New `TokenRefreshView` with atomic lock |
| `apps/users/urls.py` | Register `/api/auth/refresh/` |
| `apps/common/middleware.py` | Exempt refresh endpoint |
| `apps/users/tests.py` | 7 regression tests for race condition scenarios |

## Test plan

- [x] All 44 existing + new tests pass (`python manage.py test apps.users`)
- [x] `test_refresh_token_cannot_be_reused` — same token used twice returns 401
- [x] `test_new_refresh_token_is_usable` — rotated token works normally
- [x] `test_old_access_token_still_valid_after_refresh` — access token not invalidated early
- [x] `test_logged_out_refresh_token_cannot_be_refreshed` — logout blacklists the refresh token