### PR TITLE
feat(mobile): contact-author button, inbox, and message thread screens

### DIFF
--- a/app/mobile/src/navigation/PublicStackNavigator.tsx
+++ b/app/mobile/src/navigation/PublicStackNavigator.tsx
@@ -1,6 +1,8 @@
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import HomeScreen from '../screens/HomeScreen';
+import InboxScreen from '../screens/InboxScreen';
 import LoginScreen from '../screens/LoginScreen';
+import MessageThreadScreen from '../screens/MessageThreadScreen';
 import RecipeCreateScreen from '../screens/RecipeCreateScreen';
 import RecipeDetailScreen from '../screens/RecipeDetailScreen';
 import RecipeEditScreen from '../screens/RecipeEditScreen';
@@ -74,6 +76,16 @@ export function PublicStackNavigator() {
         name="UserProfile"
         component={UserProfileScreen}
         options={{ title: 'Profile' }}
+      />
+      <Stack.Screen
+        name="Inbox"
+        component={InboxScreen}
+        options={{ title: 'Messages' }}
+      />
+      <Stack.Screen
+        name="MessageThread"
+        component={MessageThreadScreen}
+        options={{ title: 'Conversation' }}
       />
     </Stack.Navigator>
   );

--- a/app/mobile/src/navigation/types.ts
+++ b/app/mobile/src/navigation/types.ts
@@ -12,6 +12,12 @@ export type RootStackParamList = {
   /** Recipe authoring shell — ingredient/unit selection UI (full form later). */
   RecipeCreate: undefined;
   UserProfile: { userId: number | string; username?: string };
+  Inbox: undefined;
+  MessageThread: {
+    threadId?: number | string;
+    otherUserId?: number | string;
+    otherUsername?: string;
+  };
 };
 
 declare global {

--- a/app/mobile/src/screens/InboxScreen.tsx
+++ b/app/mobile/src/screens/InboxScreen.tsx
@@ -1,0 +1,205 @@
+import { useFocusEffect } from '@react-navigation/native';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { useCallback, useState } from 'react';
+import {
+  FlatList,
+  Pressable,
+  RefreshControl,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { ErrorView } from '../components/ui/ErrorView';
+import { LoadingView } from '../components/ui/LoadingView';
+import { useAuth } from '../context/AuthContext';
+import type { RootStackParamList } from '../navigation/types';
+import { fetchInbox, type ThreadSummary } from '../services/messagingService';
+import { shadows, tokens } from '../theme';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'Inbox'>;
+
+function formatTime(iso: string | null): string {
+  if (!iso) return '';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  const now = new Date();
+  const sameDay =
+    d.getFullYear() === now.getFullYear() &&
+    d.getMonth() === now.getMonth() &&
+    d.getDate() === now.getDate();
+  if (sameDay) {
+    return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  }
+  return d.toLocaleDateString();
+}
+
+export default function InboxScreen({ navigation }: Props) {
+  const { isAuthenticated, isReady } = useAuth();
+  const [threads, setThreads] = useState<ThreadSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async (mode: 'initial' | 'refresh') => {
+    if (mode === 'initial') setLoading(true);
+    if (mode === 'refresh') setRefreshing(true);
+    setError(null);
+    try {
+      const list = await fetchInbox();
+      setThreads(list);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not load messages.');
+      setThreads([]);
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, []);
+
+  useFocusEffect(
+    useCallback(() => {
+      if (!isReady) return;
+      if (!isAuthenticated) {
+        setLoading(false);
+        return;
+      }
+      void load('initial');
+    }, [isReady, isAuthenticated, load]),
+  );
+
+  if (!isReady || loading) {
+    return (
+      <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
+        <View style={styles.centered}>
+          <LoadingView message="Loading messages…" />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return (
+      <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
+        <View style={styles.padded}>
+          <Text style={styles.muted}>Log in to see your messages.</Text>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (error) {
+    return (
+      <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
+        <View style={styles.padded}>
+          <ErrorView message={error} onRetry={() => void load('initial')} />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
+      <FlatList
+        data={threads}
+        keyExtractor={(t) => String(t.id)}
+        contentContainerStyle={
+          threads.length === 0 ? styles.emptyContainer : styles.listContent
+        }
+        refreshControl={
+          <RefreshControl refreshing={refreshing} onRefresh={() => void load('refresh')} />
+        }
+        ListEmptyComponent={
+          <View>
+            <Text style={styles.emptyTitle}>No messages yet</Text>
+            <Text style={styles.muted}>
+              Open a recipe and tap an author to start a conversation.
+            </Text>
+          </View>
+        }
+        renderItem={({ item }) => (
+          <Pressable
+            onPress={() =>
+              navigation.navigate('MessageThread', {
+                threadId: item.id,
+                otherUserId: item.other_user_id ?? undefined,
+                otherUsername: item.other_username ?? undefined,
+              })
+            }
+            style={({ pressed }) => [styles.row, pressed && styles.pressed]}
+            accessibilityRole="button"
+            accessibilityLabel={`Open conversation with ${item.other_username ?? 'user'}`}
+          >
+            <View style={styles.rowHeader}>
+              <Text style={styles.rowTitle} numberOfLines={1}>
+                {item.other_username ?? `User #${item.other_user_id ?? '?'}`}
+              </Text>
+              <Text style={styles.rowTime}>{formatTime(item.last_message_at)}</Text>
+            </View>
+            <View style={styles.rowBody}>
+              <Text
+                style={[styles.preview, item.unread_count > 0 && styles.previewUnread]}
+                numberOfLines={1}
+              >
+                {item.last_message_preview || 'No messages yet'}
+              </Text>
+              {item.unread_count > 0 ? (
+                <View style={styles.badge} accessibilityLabel={`${item.unread_count} unread`}>
+                  <Text style={styles.badgeText}>{item.unread_count}</Text>
+                </View>
+              ) : null}
+            </View>
+          </Pressable>
+        )}
+      />
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: tokens.colors.bg },
+  centered: { flex: 1, justifyContent: 'center', alignItems: 'center', padding: 20 },
+  padded: { flex: 1, padding: 20, justifyContent: 'center' },
+  listContent: { padding: 16, gap: 10 },
+  emptyContainer: { flexGrow: 1, justifyContent: 'center', padding: 24 },
+  emptyTitle: {
+    fontSize: 20,
+    fontWeight: '800',
+    color: tokens.colors.text,
+    marginBottom: 8,
+    textAlign: 'center',
+    fontFamily: tokens.typography.display.fontFamily,
+  },
+  muted: {
+    fontSize: 14,
+    color: tokens.colors.textMuted,
+    textAlign: 'center',
+  },
+  row: {
+    paddingVertical: 12,
+    paddingHorizontal: 14,
+    borderWidth: 1,
+    borderColor: tokens.colors.border,
+    borderRadius: tokens.radius.lg,
+    backgroundColor: tokens.colors.surface,
+    gap: 6,
+    ...shadows.sm,
+  },
+  pressed: { opacity: 0.85 },
+  rowHeader: { flexDirection: 'row', justifyContent: 'space-between', gap: 12 },
+  rowTitle: { fontSize: 16, fontWeight: '800', color: tokens.colors.text, flexShrink: 1 },
+  rowTime: { fontSize: 12, color: tokens.colors.textMuted },
+  rowBody: { flexDirection: 'row', alignItems: 'center', gap: 8 },
+  preview: { flex: 1, fontSize: 14, color: tokens.colors.textMuted },
+  previewUnread: { color: tokens.colors.text, fontWeight: '700' },
+  badge: {
+    minWidth: 22,
+    height: 22,
+    paddingHorizontal: 7,
+    borderRadius: 999,
+    backgroundColor: tokens.colors.accentGreen,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  badgeText: { color: tokens.colors.textOnDark, fontSize: 12, fontWeight: '800' },
+});

--- a/app/mobile/src/screens/MessageThreadScreen.tsx
+++ b/app/mobile/src/screens/MessageThreadScreen.tsx
@@ -1,0 +1,317 @@
+import { useFocusEffect } from '@react-navigation/native';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  ActivityIndicator,
+  FlatList,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { ErrorView } from '../components/ui/ErrorView';
+import { LoadingView } from '../components/ui/LoadingView';
+import { useAuth } from '../context/AuthContext';
+import type { RootStackParamList } from '../navigation/types';
+import {
+  fetchThreadMessages,
+  markThreadRead,
+  openThreadWith,
+  sendMessage,
+  type Message,
+} from '../services/messagingService';
+import { shadows, tokens } from '../theme';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'MessageThread'>;
+
+function formatStamp(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+}
+
+export default function MessageThreadScreen({ route, navigation }: Props) {
+  const { threadId: paramThreadId, otherUserId, otherUsername } = route.params;
+  const { user, isAuthenticated, isReady } = useAuth();
+
+  const [threadId, setThreadId] = useState<number | null>(
+    paramThreadId != null ? Number(paramThreadId) : null,
+  );
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [sending, setSending] = useState(false);
+  const [draft, setDraft] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const listRef = useRef<FlatList<Message>>(null);
+  const myId = user?.id != null ? String(user.id) : null;
+
+  useEffect(() => {
+    navigation.setOptions({
+      title: otherUsername ?? 'Conversation',
+    });
+  }, [navigation, otherUsername]);
+
+  const ensureThread = useCallback(async (): Promise<number | null> => {
+    if (threadId != null) return threadId;
+    if (otherUserId == null) {
+      setError('Missing recipient.');
+      return null;
+    }
+    const t = await openThreadWith(otherUserId);
+    setThreadId(t.id);
+    return t.id;
+  }, [threadId, otherUserId]);
+
+  const load = useCallback(async () => {
+    setError(null);
+    try {
+      const id = await ensureThread();
+      if (id == null) {
+        setLoading(false);
+        return;
+      }
+      const list = await fetchThreadMessages(id);
+      setMessages(list);
+      try {
+        await markThreadRead(id);
+      } catch {
+        // best-effort; ignore
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not load conversation.');
+      setMessages([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [ensureThread]);
+
+  useFocusEffect(
+    useCallback(() => {
+      if (!isReady || !isAuthenticated) {
+        setLoading(false);
+        return;
+      }
+      setLoading(true);
+      void load();
+    }, [isReady, isAuthenticated, load]),
+  );
+
+  const handleSend = useCallback(async () => {
+    const text = draft.trim();
+    if (!text || sending) return;
+    setSending(true);
+    try {
+      const id = await ensureThread();
+      if (id == null) return;
+      const created = await sendMessage(id, text);
+      setMessages((prev) => [...prev, created]);
+      setDraft('');
+      requestAnimationFrame(() => {
+        listRef.current?.scrollToEnd({ animated: true });
+      });
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not send message.');
+    } finally {
+      setSending(false);
+    }
+  }, [draft, sending, ensureThread]);
+
+  if (!isReady || loading) {
+    return (
+      <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
+        <View style={styles.centered}>
+          <LoadingView message="Loading conversation…" />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return (
+      <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
+        <View style={styles.padded}>
+          <Text style={styles.muted}>Log in to view this conversation.</Text>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (error && messages.length === 0) {
+    return (
+      <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
+        <View style={styles.padded}>
+          <ErrorView message={error} onRetry={() => void load()} />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
+      <KeyboardAvoidingView
+        style={styles.flex}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        keyboardVerticalOffset={Platform.OS === 'ios' ? 80 : 0}
+      >
+        <FlatList
+          ref={listRef}
+          data={messages}
+          keyExtractor={(m) => String(m.id)}
+          contentContainerStyle={
+            messages.length === 0 ? styles.emptyContainer : styles.listContent
+          }
+          ListEmptyComponent={
+            <Text style={styles.muted}>Say hi — no messages yet.</Text>
+          }
+          onContentSizeChange={() => listRef.current?.scrollToEnd({ animated: false })}
+          renderItem={({ item }) => {
+            const mine = myId != null && String(item.sender) === myId;
+            return (
+              <View
+                style={[
+                  styles.bubbleRow,
+                  mine ? styles.bubbleRowMine : styles.bubbleRowTheirs,
+                ]}
+              >
+                <View
+                  style={[
+                    styles.bubble,
+                    mine ? styles.bubbleMine : styles.bubbleTheirs,
+                    item.is_deleted && styles.bubbleDeleted,
+                  ]}
+                >
+                  <Text
+                    style={[
+                      styles.bubbleText,
+                      mine ? styles.bubbleTextMine : styles.bubbleTextTheirs,
+                      item.is_deleted && styles.bubbleTextDeleted,
+                    ]}
+                  >
+                    {item.body}
+                  </Text>
+                  <Text
+                    style={[
+                      styles.stamp,
+                      mine ? styles.stampMine : styles.stampTheirs,
+                    ]}
+                  >
+                    {formatStamp(item.created_at)}
+                  </Text>
+                </View>
+              </View>
+            );
+          }}
+        />
+
+        <View style={styles.composer}>
+          <TextInput
+            style={styles.input}
+            value={draft}
+            onChangeText={setDraft}
+            placeholder="Write a message…"
+            placeholderTextColor={tokens.colors.textMuted}
+            multiline
+            editable={!sending}
+            accessibilityLabel="Message input"
+          />
+          <Pressable
+            onPress={() => void handleSend()}
+            disabled={sending || draft.trim().length === 0}
+            style={({ pressed }) => [
+              styles.sendBtn,
+              (sending || draft.trim().length === 0) && styles.sendBtnDisabled,
+              pressed && styles.pressed,
+            ]}
+            accessibilityRole="button"
+            accessibilityLabel="Send message"
+          >
+            {sending ? (
+              <ActivityIndicator color="#fff" />
+            ) : (
+              <Text style={styles.sendBtnText}>Send</Text>
+            )}
+          </Pressable>
+        </View>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: tokens.colors.bg },
+  flex: { flex: 1 },
+  centered: { flex: 1, justifyContent: 'center', alignItems: 'center', padding: 20 },
+  padded: { flex: 1, padding: 20, justifyContent: 'center' },
+  listContent: { padding: 16, gap: 8, paddingBottom: 24 },
+  emptyContainer: { flexGrow: 1, justifyContent: 'center', padding: 24 },
+  muted: { fontSize: 14, color: tokens.colors.textMuted, textAlign: 'center' },
+  bubbleRow: { flexDirection: 'row' },
+  bubbleRowMine: { justifyContent: 'flex-end' },
+  bubbleRowTheirs: { justifyContent: 'flex-start' },
+  bubble: {
+    maxWidth: '78%',
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    borderRadius: tokens.radius.lg,
+    ...shadows.sm,
+  },
+  bubbleMine: {
+    backgroundColor: tokens.colors.primary,
+    borderBottomRightRadius: 4,
+  },
+  bubbleTheirs: {
+    backgroundColor: tokens.colors.surface,
+    borderBottomLeftRadius: 4,
+    borderWidth: 1,
+    borderColor: tokens.colors.border,
+  },
+  bubbleDeleted: { opacity: 0.7 },
+  bubbleText: { fontSize: 15, lineHeight: 20 },
+  bubbleTextMine: { color: '#fff' },
+  bubbleTextTheirs: { color: tokens.colors.text },
+  bubbleTextDeleted: { fontStyle: 'italic' },
+  stamp: { marginTop: 4, fontSize: 10 },
+  stampMine: { color: 'rgba(255,255,255,0.8)', textAlign: 'right' },
+  stampTheirs: { color: tokens.colors.textMuted },
+  composer: {
+    flexDirection: 'row',
+    alignItems: 'flex-end',
+    padding: 10,
+    gap: 8,
+    borderTopWidth: 1,
+    borderTopColor: tokens.colors.border,
+    backgroundColor: tokens.colors.surface,
+  },
+  input: {
+    flex: 1,
+    minHeight: 40,
+    maxHeight: 120,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderWidth: 1,
+    borderColor: tokens.colors.border,
+    borderRadius: tokens.radius.lg,
+    color: tokens.colors.text,
+    backgroundColor: tokens.colors.bg,
+    fontSize: 15,
+  },
+  sendBtn: {
+    paddingHorizontal: 18,
+    paddingVertical: 10,
+    borderRadius: tokens.radius.pill,
+    backgroundColor: tokens.colors.accentGreen,
+    borderWidth: 2,
+    borderColor: tokens.colors.surfaceDark,
+    minWidth: 78,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  sendBtnDisabled: { opacity: 0.5 },
+  sendBtnText: { color: tokens.colors.textOnDark, fontWeight: '800', fontSize: 15 },
+  pressed: { opacity: 0.85 },
+});

--- a/app/mobile/src/screens/UserProfileScreen.tsx
+++ b/app/mobile/src/screens/UserProfileScreen.tsx
@@ -4,6 +4,7 @@ import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { ErrorView } from '../components/ui/ErrorView';
 import { LoadingView } from '../components/ui/LoadingView';
+import { useAuth } from '../context/AuthContext';
 import type { RootStackParamList } from '../navigation/types';
 import { apiGetJson } from '../services/httpClient';
 import { fetchRecipesList } from '../services/recipeService';
@@ -28,6 +29,8 @@ function authorIdOf(item: ListItem): string | null {
 export default function UserProfileScreen({ route, navigation }: Props) {
   const { userId, username } = route.params;
   const userIdStr = String(userId);
+  const { user, isAuthenticated } = useAuth();
+  const canMessage = isAuthenticated && user != null && String(user.id) !== userIdStr;
 
   const [recipes, setRecipes] = useState<ListItem[]>([]);
   const [stories, setStories] = useState<ListItem[]>([]);
@@ -105,6 +108,24 @@ export default function UserProfileScreen({ route, navigation }: Props) {
             {username ?? `User #${userIdStr}`}
           </Text>
         </View>
+
+        {canMessage ? (
+          <Pressable
+            onPress={() =>
+              navigation.navigate('MessageThread', {
+                otherUserId: userIdStr,
+                otherUsername: username,
+              })
+            }
+            style={({ pressed }) => [styles.messageBtn, pressed && styles.messageBtnPressed]}
+            accessibilityRole="button"
+            accessibilityLabel={`Message ${username ?? 'this user'}`}
+          >
+            <Text style={styles.messageBtnText}>
+              ✉  Message {username ?? 'this user'}
+            </Text>
+          </Pressable>
+        ) : null}
 
         <Text style={styles.sectionTitle}>Recipes by {username ?? 'this user'}</Text>
         {myRecipes.length === 0 ? (
@@ -191,6 +212,24 @@ const styles = StyleSheet.create({
     color: tokens.colors.text,
     fontFamily: tokens.typography.display.fontFamily,
     flexShrink: 1,
+  },
+  messageBtn: {
+    marginBottom: 22,
+    paddingVertical: 14,
+    paddingHorizontal: 16,
+    borderRadius: tokens.radius.pill,
+    backgroundColor: tokens.colors.accentGreen,
+    borderWidth: 2,
+    borderColor: tokens.colors.surfaceDark,
+    alignItems: 'center',
+    ...shadows.md,
+  },
+  messageBtnPressed: { opacity: 0.85 },
+  messageBtnText: {
+    color: tokens.colors.textOnDark,
+    fontSize: 16,
+    fontWeight: '800',
+    letterSpacing: 0.4,
   },
   sectionTitle: {
     marginTop: 8,

--- a/app/mobile/src/screens/tabs/ProfileTabScreen.tsx
+++ b/app/mobile/src/screens/tabs/ProfileTabScreen.tsx
@@ -23,12 +23,21 @@ export default function ProfileTabScreen() {
                 Signed in{user ? ` as ${user.username}` : ''}.
               </Text>
               <Pressable
-                onPress={() => void logout()}
+                onPress={() => navigation.navigate('Feed', { screen: 'Inbox' })}
                 style={({ pressed }) => [styles.primary, pressed && styles.pressed]}
+                accessibilityRole="button"
+                accessibilityLabel="Open messages"
+              >
+                <Text style={styles.primaryText}>Messages</Text>
+              </Pressable>
+              <View style={{ height: 12 }} />
+              <Pressable
+                onPress={() => void logout()}
+                style={({ pressed }) => [styles.secondary, pressed && styles.pressed]}
                 accessibilityRole="button"
                 accessibilityLabel="Log out"
               >
-                <Text style={styles.primaryText}>Log out</Text>
+                <Text style={styles.secondaryText}>Log out</Text>
               </Pressable>
             </>
           ) : (

--- a/app/mobile/src/services/messagingService.ts
+++ b/app/mobile/src/services/messagingService.ts
@@ -1,0 +1,55 @@
+import { apiGetJson, apiPostJson } from './httpClient';
+
+export type ThreadSummary = {
+  id: number;
+  other_user_id: number | null;
+  other_username: string | null;
+  last_message_at: string | null;
+  last_message_preview: string;
+  unread_count: number;
+  created_at: string;
+};
+
+export type Message = {
+  id: number;
+  thread: number;
+  sender: number;
+  sender_username: string;
+  body: string;
+  created_at: string;
+  is_deleted: boolean;
+  deleted_at: string | null;
+};
+
+export async function fetchInbox(): Promise<ThreadSummary[]> {
+  const data = await apiGetJson<ThreadSummary[] | { results: ThreadSummary[] }>(
+    '/api/threads/',
+  );
+  if (Array.isArray(data)) return data;
+  return Array.isArray(data?.results) ? data.results : [];
+}
+
+export async function openThreadWith(otherUserId: number | string): Promise<ThreadSummary> {
+  return apiPostJson<ThreadSummary>('/api/threads/', {
+    other_user_id: Number(otherUserId),
+  });
+}
+
+export async function fetchThreadMessages(threadId: number | string): Promise<Message[]> {
+  const data = await apiGetJson<Message[] | { results: Message[] }>(
+    `/api/threads/${threadId}/messages/`,
+  );
+  if (Array.isArray(data)) return data;
+  return Array.isArray(data?.results) ? data.results : [];
+}
+
+export async function sendMessage(
+  threadId: number | string,
+  body: string,
+): Promise<Message> {
+  return apiPostJson<Message>(`/api/threads/${threadId}/send/`, { body });
+}
+
+export async function markThreadRead(threadId: number | string): Promise<void> {
+  await apiPostJson(`/api/threads/${threadId}/read/`, {});
+}


### PR DESCRIPTION
## Summary
Closes #341 (M4-10 — Contact-author button & message screen, mobile).

Adds the mobile messaging UI to match the web flow shipped in #340:

- **`InboxScreen`** — thread list with last-message preview, unread badge, pull-to-refresh, and focus-refetch.
- **`MessageThreadScreen`** — conversation view with chat bubbles, read-receipt advance on focus, optimistic-append on send, KeyboardAvoidingView composer.
- **`messagingService`** — wraps the messaging API contract from #406 (`/api/threads/`, `/threads/<id>/send/`, `/threads/<id>/messages/`, `/threads/<id>/read/`).
- **`UserProfileScreen`** — full-width "Message" CTA below the header card, hidden when viewing your own profile.
- **`ProfileTabScreen`** — "Messages" entry button → Inbox.
- Navigation: registers `Inbox` and `MessageThread` routes in `PublicStackNavigator`.

## Out of scope (tracked separately)
- **Push notifications (FCM/APNs)** — depends on notification infra issue #M4-00 (#349). Live updates here are handled via focus-refetch + pull-to-refresh + `unread_count`; real push wiring will land with #349.
- **Send currently 404s on `main`** — backend messaging API (#339 / #406) merged into `feat/upvote-backend` but not yet on `main`. Tracked in #427. UI will start working end-to-end the moment #406 reaches `main`.

## Visual design
Message CTA, inbox unread badge, and Send button use `accentGreen` + `surfaceDark` outline so they remain visible on any palette (validated against current and in-flight palette swap in #418).

## Test plan
- [ ] `npx tsc --noEmit` passes (verified locally)
- [ ] Once #406 lands on `main`: log in, open another user's profile (e.g. via story author pill), tap **Message**, send a message — recipient sees thread with unread badge in their Inbox
- [ ] Pull-to-refresh on Inbox refetches
- [ ] Tapping a thread marks read and clears badge
- [ ] Soft-deleted messages render with `[deleted]` placeholder

## References
- Closes #341
- Depends on: #339, #406 (backend messaging)
- Related: #340 (web counterpart), #427 (send-404 follow-up), #349 (push infra)