### PR TITLE
feat(frontend): unit toggle UI on recipe detail page (#377)

### DIFF
--- a/app/frontend/src/mocks/recipes.js
+++ b/app/frontend/src/mocks/recipes.js
@@ -13,8 +13,8 @@ export const MOCK_RECIPES = {
     is_published: true,
     author: { id: 1, username: 'demo_chef' },
     ingredients: [
-      { ingredient: { id: 1, name: 'Tomato' }, amount: '400', unit: { id: 1, name: 'g' } },
-      { ingredient: { id: 2, name: 'Onion' }, amount: '1', unit: { id: 2, name: 'cup' } },
+      { ingredient: 1, ingredient_name: 'Tomato', amount: '400', unit_name: 'g', converted_amount: '14.1', converted_unit_name: 'oz' },
+      { ingredient: 2, ingredient_name: 'Onion', amount: '1', unit_name: 'cup', converted_amount: '240', converted_unit_name: 'ml' },
     ],
   },
   2: {
@@ -27,8 +27,8 @@ export const MOCK_RECIPES = {
     is_published: true,
     author: { id: 1, username: 'demo_chef' },
     ingredients: [
-      { ingredient: { id: 3, name: 'Olives' }, amount: '100', unit: { id: 1, name: 'g' } },
-      { ingredient: { id: 4, name: 'Olive oil' }, amount: '2', unit: { id: 6, name: 'tbsp' } },
+      { ingredient: 3, ingredient_name: 'Olives', amount: '100', unit_name: 'g', converted_amount: '3.5', converted_unit_name: 'oz' },
+      { ingredient: 4, ingredient_name: 'Olive oil', amount: '2', unit_name: 'tbsp', converted_amount: '30', converted_unit_name: 'ml' },
     ],
   },
 };

--- a/app/frontend/src/pages/RecipeDetailPage.css
+++ b/app/frontend/src/pages/RecipeDetailPage.css
@@ -68,9 +68,43 @@
   padding-top: 1.5rem;
 }
 
-.recipe-ingredients h2 {
-  font-size: 1.375rem;
+.ingredients-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   margin-bottom: 1rem;
+}
+
+.ingredients-header h2 {
+  font-size: 1.375rem;
+  margin: 0;
+}
+
+.unit-toggle {
+  display: flex;
+  border: 1.5px solid var(--color-border);
+  border-radius: var(--radius-pill);
+  overflow: hidden;
+}
+
+.unit-toggle-btn {
+  background: none;
+  border: none;
+  padding: 0.3rem 0.9rem;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+
+.unit-toggle-btn:hover {
+  color: var(--color-text);
+}
+
+.unit-toggle-btn.active {
+  background: var(--color-primary);
+  color: #fff;
 }
 
 .ingredients-list {

--- a/app/frontend/src/pages/RecipeDetailPage.jsx
+++ b/app/frontend/src/pages/RecipeDetailPage.jsx
@@ -14,6 +14,7 @@ export default function RecipeDetailPage() {
   const [regions, setRegions] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
+  const [useConverted, setUseConverted] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -93,14 +94,36 @@ export default function RecipeDetailPage() {
       )}
 
       <section className="recipe-ingredients">
-        <h2>Ingredients</h2>
+        <div className="ingredients-header">
+          <h2>Ingredients</h2>
+          {recipe.ingredients.some((ri) => ri.converted_amount) && (
+            <div className="unit-toggle" role="group" aria-label="Unit system">
+              <button
+                className={`unit-toggle-btn${!useConverted ? ' active' : ''}`}
+                onClick={() => setUseConverted(false)}
+              >
+                Original
+              </button>
+              <button
+                className={`unit-toggle-btn${useConverted ? ' active' : ''}`}
+                onClick={() => setUseConverted(true)}
+              >
+                Converted
+              </button>
+            </div>
+          )}
+        </div>
         <ul className="ingredients-list">
-          {recipe.ingredients.map((ri) => (
-            <li key={ri.ingredient} className="ingredient-item">
-              <span className="ingredient-name">{ri.ingredient_name}</span>
-              <span className="ingredient-amount">{ri.amount} {ri.unit_name}</span>
-            </li>
-          ))}
+          {recipe.ingredients.map((ri) => {
+            const amount = useConverted && ri.converted_amount ? ri.converted_amount : ri.amount;
+            const unit = useConverted && ri.converted_unit_name ? ri.converted_unit_name : ri.unit_name;
+            return (
+              <li key={ri.ingredient} className="ingredient-item">
+                <span className="ingredient-name">{ri.ingredient_name}</span>
+                <span className="ingredient-amount">{amount} {unit}</span>
+              </li>
+            );
+          })}
         </ul>
       </section>
 


### PR DESCRIPTION
## Summary
- Adds an **Original / Converted** pill toggle to the Ingredients section of the recipe detail page
- Toggle only appears when at least one ingredient has `converted_amount` data (from backend #M5-10)
- Mock data updated to flat format with `converted_amount` / `converted_unit_name` fields

## Note
> `feat/frontend/ingredient-check-substitution-shopping` also rewrites `RecipeDetailPage` and includes this toggle. If that branch is merged first, this PR can be closed.

## Test plan
- [ ] Visit `/recipes/1` in mock mode
- [ ] Verify Original/Converted toggle appears in Ingredients header
- [ ] Toggle switches all amounts (e.g. 400 g → 14.1 oz)
- [ ] Toggle absent when no converted data available