### PR TITLE
feat(frontend): map discovery page with region content panel (#382)

### DIFF
--- a/app/frontend/package-lock.json
+++ b/app/frontend/package-lock.json
@@ -13,8 +13,10 @@
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^13.5.0",
         "axios": "^1.14.0",
+        "leaflet": "^1.9.4",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
+        "react-leaflet": "^5.0.0",
         "react-router-dom": "^6.30.3",
         "react-scripts": "5.0.1",
         "web-vitals": "^2.1.4"
@@ -2985,6 +2987,17 @@
         "webpack-plugin-serve": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@react-leaflet/core": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-3.0.0.tgz",
+      "integrity": "sha512-3EWmekh4Nz+pGcr+xjf0KNyYfC3U2JjnkWsh0zcqaexYqmmB5ZhH37kz41JXGmKzpaMZCnPofBBm64i+YrEvGQ==",
+      "license": "Hippocratic-2.1",
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
       }
     },
     "node_modules/@remix-run/router": {
@@ -11022,6 +11035,12 @@
         "shell-quote": "^1.8.3"
       }
     },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -13801,6 +13820,20 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "license": "MIT"
     },
+    "node_modules/react-leaflet": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-5.0.0.tgz",
+      "integrity": "sha512-CWbTpr5vcHw5bt9i4zSlPEVQdTVcML390TjeDG0cK59z1ylexpqC6M1PJFjV8jD7CF+ACBFsLIDs6DRMoLEofw==",
+      "license": "Hippocratic-2.1",
+      "dependencies": {
+        "@react-leaflet/core": "^3.0.0"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
@@ -15672,23 +15705,6 @@
         "yaml": {
           "optional": true
         }
-      }
-    },
-    "node_modules/tailwindcss/node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/tapable": {

--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -8,8 +8,10 @@
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^13.5.0",
     "axios": "^1.14.0",
+    "leaflet": "^1.9.4",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "react-leaflet": "^5.0.0",
     "react-router-dom": "^6.30.3",
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.4"
@@ -24,6 +26,11 @@
     "extends": [
       "react-app",
       "react-app/jest"
+    ]
+  },
+  "jest": {
+    "transformIgnorePatterns": [
+      "/node_modules/(?!(react-leaflet|@react-leaflet|leaflet)/)/"
     ]
   },
   "browserslist": {

--- a/app/frontend/src/App.js
+++ b/app/frontend/src/App.js
@@ -16,6 +16,7 @@ import StoryEditPage from './pages/StoryEditPage';
 import InboxPage from './pages/InboxPage';
 import ThreadPage from './pages/ThreadPage';
 import OnboardingPage from './pages/OnboardingPage';
+import MapPage from './pages/MapPage';
 import NotFoundPage from './pages/NotFoundPage';
 
 export default function App() {
@@ -30,6 +31,7 @@ export default function App() {
           <Route path="/search" element={<SearchPage />} />
           <Route path="/recipes" element={<RecipeListPage />} />
           <Route path="/stories" element={<StoryListPage />} />
+          <Route path="/map" element={<MapPage />} />
 
           <Route
             path="/recipes/new"

--- a/app/frontend/src/components/Navbar.jsx
+++ b/app/frontend/src/components/Navbar.jsx
@@ -14,6 +14,7 @@ export default function Navbar() {
         <div className="navbar-browse-links">
           <NavLink to="/recipes" className="navbar-link">Recipes</NavLink>
           <NavLink to="/stories" className="navbar-link">Stories</NavLink>
+          <NavLink to="/map" className="navbar-link">Map</NavLink>
         </div>
         <div className="navbar-links">
           {user ? (

--- a/app/frontend/src/mocks/mapRegions.js
+++ b/app/frontend/src/mocks/mapRegions.js
@@ -1,0 +1,84 @@
+export const MOCK_MAP_REGIONS = [
+  {
+    id: 1,
+    name: 'Anatolia',
+    lat: 39.0,
+    lng: 35.0,
+    description: 'The heartland of Anatolian cuisine — rich stews, lamb dishes, and ancient grain breads.',
+    featured_recipes: [
+      { id: 1, title: 'Anatolian Lamb Stew', author_username: 'chef_ayse' },
+      { id: 3, title: 'Tarhana Soup', author_username: 'demo_chef' },
+    ],
+    featured_stories: [
+      { id: 1, title: 'The bread ovens of Konya', author_username: 'demo_chef' },
+    ],
+  },
+  {
+    id: 2,
+    name: 'Aegean',
+    lat: 38.4,
+    lng: 27.2,
+    description: 'Olive groves, wild herbs, and seafood define the light Mediterranean flavors of the Aegean coast.',
+    featured_recipes: [
+      { id: 2, title: 'Aegean Herb Salad', author_username: 'demo_chef' },
+      { id: 4, title: 'Zeytinyağlı Enginar', author_username: 'chef_ayse' },
+    ],
+    featured_stories: [
+      { id: 2, title: 'Olive harvest in Ayvalık', author_username: 'chef_ayse' },
+    ],
+  },
+  {
+    id: 3,
+    name: 'Mediterranean',
+    lat: 36.8,
+    lng: 32.0,
+    description: 'Sun-drenched vegetables, citrus, and the freshest fish from the southern shores.',
+    featured_recipes: [
+      { id: 5, title: 'Stuffed Peppers with Pine Nuts', author_username: 'demo_chef' },
+    ],
+    featured_stories: [
+      { id: 3, title: 'A season in Antalya\'s bazaars', author_username: 'demo_chef' },
+    ],
+  },
+  {
+    id: 4,
+    name: 'Black Sea',
+    lat: 41.2,
+    lng: 37.5,
+    description: 'Hamsi, corn bread, and lush green vegetables from the misty northern coast.',
+    featured_recipes: [
+      { id: 6, title: 'Hamsi Pilav', author_username: 'chef_musa' },
+      { id: 7, title: 'Mısır Ekmeği', author_username: 'chef_musa' },
+    ],
+    featured_stories: [
+      { id: 4, title: 'Anchovy season on the Black Sea', author_username: 'chef_musa' },
+    ],
+  },
+  {
+    id: 5,
+    name: 'Marmara',
+    lat: 40.7,
+    lng: 28.5,
+    description: 'Istanbul and its surrounds bring together diverse culinary traditions from across the empire.',
+    featured_recipes: [
+      { id: 8, title: 'İstanbul-style Börek', author_username: 'demo_chef' },
+    ],
+    featured_stories: [
+      { id: 5, title: 'The spice markets of the Grand Bazaar', author_username: 'demo_chef' },
+    ],
+  },
+  {
+    id: 6,
+    name: 'Southeast Anatolia',
+    lat: 37.2,
+    lng: 40.0,
+    description: 'Spiced meats, crispy lahmacun, and the world-famous pistachios of Gaziantep.',
+    featured_recipes: [
+      { id: 9, title: 'Gaziantep Lahmacun', author_username: 'chef_ayse' },
+      { id: 10, title: 'Katmer with Cream', author_username: 'chef_ayse' },
+    ],
+    featured_stories: [
+      { id: 6, title: 'Baklava masters of Gaziantep', author_username: 'chef_ayse' },
+    ],
+  },
+];

--- a/app/frontend/src/pages/MapPage.css
+++ b/app/frontend/src/pages/MapPage.css
@@ -1,0 +1,166 @@
+.map-page {
+  background: var(--color-surface);
+  border-radius: var(--radius-xl);
+  padding: 2.5rem 3rem;
+}
+
+.map-page-header {
+  margin-bottom: 1.75rem;
+}
+
+.map-page-header h1 {
+  font-size: clamp(1.75rem, 3vw, 2.5rem);
+  color: var(--color-text);
+}
+
+.map-page-subtitle {
+  margin-top: 0.4rem;
+  color: var(--color-text-muted);
+  font-size: 1rem;
+}
+
+/* ── Split layout ────────────────── */
+.map-layout {
+  display: grid;
+  grid-template-columns: 1fr 300px;
+  gap: 1.5rem;
+  align-items: start;
+}
+
+@media (max-width: 700px) {
+  .map-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ── Map ─────────────────────────── */
+.map-container-wrap {
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  box-shadow: var(--shadow-md);
+  height: 420px;
+}
+
+.leaflet-map {
+  width: 100%;
+  height: 100%;
+}
+
+.map-loading {
+  height: 420px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-muted);
+  background: var(--color-border);
+}
+
+/* ── Side panel ──────────────────── */
+.map-panel {
+  background: var(--color-surface);
+  border: 1.5px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: 1.5rem;
+  min-height: 420px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.map-panel-title {
+  font-size: 1.375rem;
+  color: var(--color-text);
+}
+
+.map-panel-desc {
+  font-size: 0.9375rem;
+  color: var(--color-text-muted);
+  line-height: 1.6;
+}
+
+.map-panel-section h3 {
+  font-size: 0.8125rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--color-primary);
+  margin-bottom: 0.5rem;
+}
+
+.map-content-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.map-content-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: var(--radius-md);
+  background: var(--color-primary-subtle);
+  text-decoration: none;
+  transition: background 0.15s;
+}
+
+.map-content-item:hover {
+  background: var(--color-primary-tint);
+  text-decoration: none;
+}
+
+.map-content-title {
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: var(--color-text);
+}
+
+.map-content-author {
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+}
+
+.map-panel-cta {
+  margin-top: auto;
+  text-align: center;
+  text-decoration: none;
+}
+
+.map-panel-empty {
+  color: var(--color-text-muted);
+  font-size: 0.9375rem;
+  margin: auto 0;
+  text-align: center;
+}
+
+/* ── Region chip row ─────────────── */
+.map-region-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 1.5rem;
+}
+
+.map-region-chip {
+  background: none;
+  border: 1.5px solid var(--color-border);
+  border-radius: var(--radius-pill);
+  padding: 0.35rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s, background 0.15s;
+}
+
+.map-region-chip:hover {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+}
+
+.map-region-chip.active {
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+  color: #fff;
+}

--- a/app/frontend/src/pages/MapPage.jsx
+++ b/app/frontend/src/pages/MapPage.jsx
@@ -1,0 +1,131 @@
+import { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import { MapContainer, TileLayer, CircleMarker, Tooltip } from 'react-leaflet';
+import 'leaflet/dist/leaflet.css';
+import { fetchMapRegions } from '../services/mapService';
+import './MapPage.css';
+
+export default function MapPage() {
+  const [regions, setRegions] = useState([]);
+  const [selected, setSelected] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetchMapRegions()
+      .then((data) => {
+        setRegions(data);
+        if (data.length > 0) setSelected(data[0]);
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  return (
+    <div className="map-page">
+      <div className="map-page-header">
+        <h1>Discover by Region</h1>
+        <p className="map-page-subtitle">
+          Explore recipes and stories from culinary regions around Turkey and beyond.
+        </p>
+      </div>
+
+      <div className="map-layout">
+        <div className="map-container-wrap">
+          {!loading && (
+            <MapContainer
+              center={[39.0, 35.0]}
+              zoom={5}
+              className="leaflet-map"
+              scrollWheelZoom={false}
+            >
+              <TileLayer
+                url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+                attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+              />
+              {regions.map((region) => (
+                <CircleMarker
+                  key={region.id}
+                  center={[region.lat, region.lng]}
+                  radius={selected?.id === region.id ? 16 : 11}
+                  pathOptions={{
+                    color: selected?.id === region.id ? '#A3401A' : '#C4521E',
+                    fillColor: selected?.id === region.id ? '#C4521E' : '#FAF7EF',
+                    fillOpacity: selected?.id === region.id ? 0.9 : 0.7,
+                    weight: 2,
+                  }}
+                  eventHandlers={{ click: () => setSelected(region) }}
+                >
+                  <Tooltip direction="top" offset={[0, -8]} opacity={0.95}>
+                    {region.name}
+                  </Tooltip>
+                </CircleMarker>
+              ))}
+            </MapContainer>
+          )}
+          {loading && <div className="map-loading">Loading map…</div>}
+        </div>
+
+        <aside className="map-panel">
+          {selected ? (
+            <>
+              <h2 className="map-panel-title">{selected.name}</h2>
+              <p className="map-panel-desc">{selected.description}</p>
+
+              {selected.featured_recipes?.length > 0 && (
+                <section className="map-panel-section">
+                  <h3>Recipes</h3>
+                  <ul className="map-content-list">
+                    {selected.featured_recipes.map((r) => (
+                      <li key={r.id}>
+                        <Link to={`/recipes/${r.id}`} className="map-content-item">
+                          <span className="map-content-title">{r.title}</span>
+                          <span className="map-content-author">@{r.author_username}</span>
+                        </Link>
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+              )}
+
+              {selected.featured_stories?.length > 0 && (
+                <section className="map-panel-section">
+                  <h3>Stories</h3>
+                  <ul className="map-content-list">
+                    {selected.featured_stories.map((s) => (
+                      <li key={s.id}>
+                        <Link to={`/stories/${s.id}`} className="map-content-item">
+                          <span className="map-content-title">{s.title}</span>
+                          <span className="map-content-author">@{s.author_username}</span>
+                        </Link>
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+              )}
+
+              <Link
+                to={`/search?region=${selected.id}`}
+                className="btn btn-primary btn-sm map-panel-cta"
+              >
+                See all from {selected.name}
+              </Link>
+            </>
+          ) : (
+            <p className="map-panel-empty">Select a region on the map to explore its food culture.</p>
+          )}
+        </aside>
+      </div>
+
+      <div className="map-region-chips">
+        {regions.map((region) => (
+          <button
+            key={region.id}
+            className={`map-region-chip${selected?.id === region.id ? ' active' : ''}`}
+            onClick={() => setSelected(region)}
+          >
+            {region.name}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/frontend/src/services/mapService.js
+++ b/app/frontend/src/services/mapService.js
@@ -1,0 +1,10 @@
+import { apiClient } from './api';
+import { MOCK_MAP_REGIONS } from '../mocks/mapRegions';
+
+const USE_MOCK = process.env.REACT_APP_USE_MOCK === 'true';
+
+export async function fetchMapRegions() {
+  if (USE_MOCK) return MOCK_MAP_REGIONS;
+  const response = await apiClient.get('/api/regions/map/');
+  return response.data;
+}


### PR DESCRIPTION
## Summary
- New `/map` route with interactive Leaflet map of Turkey's culinary regions
- Clicking a region marker surfaces featured recipes and stories in a side panel
- Region chip row below map for alternative navigation
- `mapService.js` + `mapRegions.js` mock; wires to `/api/regions/map/` when backend #M5-15 is ready
- Jest `transformIgnorePatterns` updated for `react-leaflet` ESM compatibility
- "Map" link added to navbar

## Test plan
- [ ] Visit `/map` in mock mode
- [ ] Six region markers visible on Turkey map
- [ ] Clicking a marker updates the side panel with that region's content
- [ ] Chip row selects same region
- [ ] "See all" links to `/search?region=<id>`