### PR TITLE
feat(frontend): region-adaptive theming on map page (#384)

### DIFF
--- a/app/frontend/src/data/regionThemes.js
+++ b/app/frontend/src/data/regionThemes.js
@@ -1,0 +1,62 @@
+// Per-region CSS variable overrides applied to the map page when a region is focused.
+// Variables are scoped to .map-page via inline style; they do not affect global tokens.
+export const REGION_THEMES = {
+  Anatolia: {
+    label: 'Anatolia',
+    '--rt-primary':       '#C4521E',
+    '--rt-primary-hover': '#A3401A',
+    '--rt-primary-tint':  'rgba(196, 82, 30, 0.10)',
+    '--rt-surface':       '#FAF7EF',
+    '--rt-accent-bar':    'linear-gradient(90deg, #C4521E 0%, #E8835A 100%)',
+    '--rt-marker-fill':   '#C4521E',
+  },
+  Aegean: {
+    label: 'Aegean',
+    '--rt-primary':       '#4A8C6F',
+    '--rt-primary-hover': '#2E7D62',
+    '--rt-primary-tint':  'rgba(74, 140, 111, 0.10)',
+    '--rt-surface':       '#F2FAF6',
+    '--rt-accent-bar':    'linear-gradient(90deg, #4A8C6F 0%, #7EC8A4 100%)',
+    '--rt-marker-fill':   '#4A8C6F',
+  },
+  Mediterranean: {
+    label: 'Mediterranean',
+    '--rt-primary':       '#C49A1E',
+    '--rt-primary-hover': '#A37E18',
+    '--rt-primary-tint':  'rgba(196, 154, 30, 0.10)',
+    '--rt-surface':       '#FDFBF0',
+    '--rt-accent-bar':    'linear-gradient(90deg, #C49A1E 0%, #E8C96A 100%)',
+    '--rt-marker-fill':   '#C49A1E',
+  },
+  'Black Sea': {
+    label: 'Black Sea',
+    '--rt-primary':       '#2D6A4F',
+    '--rt-primary-hover': '#1B4332',
+    '--rt-primary-tint':  'rgba(45, 106, 79, 0.10)',
+    '--rt-surface':       '#F1F9F5',
+    '--rt-accent-bar':    'linear-gradient(90deg, #2D6A4F 0%, #52B788 100%)',
+    '--rt-marker-fill':   '#2D6A4F',
+  },
+  Marmara: {
+    label: 'Marmara',
+    '--rt-primary':       '#7B5EA7',
+    '--rt-primary-hover': '#5E4380',
+    '--rt-primary-tint':  'rgba(123, 94, 167, 0.10)',
+    '--rt-surface':       '#F8F5FC',
+    '--rt-accent-bar':    'linear-gradient(90deg, #7B5EA7 0%, #B39CD0 100%)',
+    '--rt-marker-fill':   '#7B5EA7',
+  },
+  'Southeast Anatolia': {
+    label: 'Southeast Anatolia',
+    '--rt-primary':       '#9B2335',
+    '--rt-primary-hover': '#7A1B28',
+    '--rt-primary-tint':  'rgba(155, 35, 53, 0.10)',
+    '--rt-surface':       '#FDF5F6',
+    '--rt-accent-bar':    'linear-gradient(90deg, #9B2335 0%, #D4637A 100%)',
+    '--rt-marker-fill':   '#9B2335',
+  },
+};
+
+export function getRegionTheme(regionName) {
+  return REGION_THEMES[regionName] ?? REGION_THEMES['Anatolia'];
+}

--- a/app/frontend/src/pages/MapPage.css
+++ b/app/frontend/src/pages/MapPage.css
@@ -1,7 +1,17 @@
 .map-page {
-  background: var(--color-surface);
+  background: var(--rt-surface, var(--color-surface));
   border-radius: var(--radius-xl);
   padding: 2.5rem 3rem;
+  transition: background 0.4s ease;
+}
+
+/* ── Accent bar (region colour strip) ─ */
+.map-page-accent-bar {
+  height: 4px;
+  border-radius: var(--radius-pill);
+  background: var(--rt-accent-bar, linear-gradient(90deg, #C4521E 0%, #E8835A 100%));
+  margin-bottom: 1.25rem;
+  transition: background 0.4s ease;
 }
 
 .map-page-header {
@@ -57,7 +67,7 @@
 
 /* ── Side panel ──────────────────── */
 .map-panel {
-  background: var(--color-surface);
+  background: var(--rt-surface, var(--color-surface));
   border: 1.5px solid var(--color-border);
   border-radius: var(--radius-lg);
   padding: 1.5rem;
@@ -65,6 +75,7 @@
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  transition: background 0.4s ease;
 }
 
 .map-panel-title {
@@ -83,8 +94,9 @@
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.07em;
-  color: var(--color-primary);
+  color: var(--rt-primary, var(--color-primary));
   margin-bottom: 0.5rem;
+  transition: color 0.4s ease;
 }
 
 .map-content-list {
@@ -100,13 +112,14 @@
   gap: 0.1rem;
   padding: 0.5rem 0.75rem;
   border-radius: var(--radius-md);
-  background: var(--color-primary-subtle);
+  background: var(--rt-primary-tint, var(--color-primary-subtle));
   text-decoration: none;
   transition: background 0.15s;
 }
 
 .map-content-item:hover {
-  background: var(--color-primary-tint);
+  background: var(--rt-primary-tint, var(--color-primary-tint));
+  filter: brightness(0.95);
   text-decoration: none;
 }
 
@@ -125,6 +138,12 @@
   margin-top: auto;
   text-align: center;
   text-decoration: none;
+  background: var(--rt-primary, var(--color-primary));
+  transition: background 0.4s ease;
+}
+
+.map-panel-cta:hover {
+  background: var(--rt-primary-hover, var(--color-primary-hover));
 }
 
 .map-panel-empty {
@@ -151,16 +170,16 @@
   font-weight: 600;
   color: var(--color-text-muted);
   cursor: pointer;
-  transition: border-color 0.15s, color 0.15s, background 0.15s;
+  transition: border-color 0.15s, color 0.15s, background 0.4s;
 }
 
 .map-region-chip:hover {
-  border-color: var(--color-primary);
-  color: var(--color-primary);
+  border-color: var(--rt-primary, var(--color-primary));
+  color: var(--rt-primary, var(--color-primary));
 }
 
 .map-region-chip.active {
-  background: var(--color-primary);
-  border-color: var(--color-primary);
+  background: var(--rt-primary, var(--color-primary));
+  border-color: var(--rt-primary, var(--color-primary));
   color: #fff;
 }

--- a/app/frontend/src/pages/MapPage.jsx
+++ b/app/frontend/src/pages/MapPage.jsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { MapContainer, TileLayer, CircleMarker, Tooltip } from 'react-leaflet';
 import 'leaflet/dist/leaflet.css';
 import { fetchMapRegions } from '../services/mapService';
+import { getRegionTheme } from '../data/regionThemes';
 import './MapPage.css';
 
 export default function MapPage() {
@@ -19,9 +20,16 @@ export default function MapPage() {
       .finally(() => setLoading(false));
   }, []);
 
+  const theme = selected ? getRegionTheme(selected.name) : {};
+  // Extract only CSS variable entries (keys starting with --) for inline style
+  const themeVars = Object.fromEntries(
+    Object.entries(theme).filter(([k]) => k.startsWith('--'))
+  );
+
   return (
-    <div className="map-page">
+    <div className="map-page" style={themeVars}>
       <div className="map-page-header">
+        <div className="map-page-accent-bar" aria-hidden="true" />
         <h1>Discover by Region</h1>
         <p className="map-page-subtitle">
           Explore recipes and stories from culinary regions around Turkey and beyond.
@@ -41,15 +49,18 @@ export default function MapPage() {
                 url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
                 attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
               />
-              {regions.map((region) => (
+              {regions.map((region) => {
+                const isActive = selected?.id === region.id;
+                const markerTheme = getRegionTheme(region.name);
+                return (
                 <CircleMarker
                   key={region.id}
                   center={[region.lat, region.lng]}
-                  radius={selected?.id === region.id ? 16 : 11}
+                  radius={isActive ? 16 : 11}
                   pathOptions={{
-                    color: selected?.id === region.id ? '#A3401A' : '#C4521E',
-                    fillColor: selected?.id === region.id ? '#C4521E' : '#FAF7EF',
-                    fillOpacity: selected?.id === region.id ? 0.9 : 0.7,
+                    color: markerTheme['--rt-primary-hover'] ?? '#A3401A',
+                    fillColor: isActive ? (markerTheme['--rt-marker-fill'] ?? '#C4521E') : '#FAF7EF',
+                    fillOpacity: isActive ? 0.9 : 0.7,
                     weight: 2,
                   }}
                   eventHandlers={{ click: () => setSelected(region) }}
@@ -58,7 +69,8 @@ export default function MapPage() {
                     {region.name}
                   </Tooltip>
                 </CircleMarker>
-              ))}
+                );
+              })}
             </MapContainer>
           )}
           {loading && <div className="map-loading">Loading map…</div>}


### PR DESCRIPTION
## Summary
- `src/data/regionThemes.js` defines per-region CSS token profiles (primary, hover, tint, accent gradient, marker fill)
- Selected region's theme injected as `--rt-*` CSS variables on the map page root — global tokens untouched
- Map panel, chips, CTA button, and accent bar all respond to `--rt-*` variables
- Each marker uses its own region colour regardless of selection
- 0.4s CSS transition for smooth theme switch

> **Depends on #432** (`feat/frontend/map-discovery-ui`) — merge that first.

## Test plan
- [ ] Visit `/map`, click each region
- [ ] Page accent bar, panel section headings, and active chip colour change per region
- [ ] Anatolia → rust, Aegean → green, Mediterranean → gold, Black Sea → dark green, Marmara → purple, Southeast → burgundy