### PR TITLE
feat(frontend): event-based explore page with category rails and detail view (#387)

### DIFF
--- a/app/frontend/src/App.js
+++ b/app/frontend/src/App.js
@@ -17,6 +17,8 @@ import InboxPage from './pages/InboxPage';
 import ThreadPage from './pages/ThreadPage';
 import OnboardingPage from './pages/OnboardingPage';
 import MapPage from './pages/MapPage';
+import ExplorePage from './pages/ExplorePage';
+import EventDetailPage from './pages/EventDetailPage';
 import NotFoundPage from './pages/NotFoundPage';
 
 export default function App() {
@@ -32,6 +34,8 @@ export default function App() {
           <Route path="/recipes" element={<RecipeListPage />} />
           <Route path="/stories" element={<StoryListPage />} />
           <Route path="/map" element={<MapPage />} />
+          <Route path="/explore" element={<ExplorePage />} />
+          <Route path="/explore/:eventId" element={<EventDetailPage />} />
 
           <Route
             path="/recipes/new"

--- a/app/frontend/src/components/Navbar.jsx
+++ b/app/frontend/src/components/Navbar.jsx
@@ -15,6 +15,7 @@ export default function Navbar() {
           <NavLink to="/recipes" className="navbar-link">Recipes</NavLink>
           <NavLink to="/stories" className="navbar-link">Stories</NavLink>
           <NavLink to="/map" className="navbar-link">Map</NavLink>
+          <NavLink to="/explore" className="navbar-link">Explore</NavLink>
         </div>
         <div className="navbar-links">
           {user ? (

--- a/app/frontend/src/mocks/exploreEvents.js
+++ b/app/frontend/src/mocks/exploreEvents.js
@@ -1,0 +1,74 @@
+export const MOCK_EXPLORE_EVENTS = [
+  {
+    id: 'wedding',
+    name: 'Wedding',
+    emoji: '💍',
+    description: 'Traditional and modern dishes served at weddings across Turkey and the wider region.',
+    featured: [
+      { type: 'recipe', id: 1, title: 'Düğün Çorbası', author_username: 'chef_ayse', region: 'Anatolia' },
+      { type: 'recipe', id: 2, title: 'Etli Pilav', author_username: 'demo_chef', region: 'Marmara' },
+      { type: 'story', id: 1, title: 'My grandmother\'s wedding feast', author_username: 'demo_chef', region: 'Anatolia' },
+      { type: 'recipe', id: 3, title: 'Baklava', author_username: 'chef_ayse', region: 'Southeast Anatolia' },
+    ],
+  },
+  {
+    id: 'ramadan',
+    name: 'Ramadan',
+    emoji: '🌙',
+    description: 'Iftar and suhoor recipes to share and celebrate the holy month.',
+    featured: [
+      { type: 'recipe', id: 4, title: 'Iftar Çorbası', author_username: 'chef_musa', region: 'Marmara' },
+      { type: 'story', id: 2, title: 'Breaking fast at the Bosphorus', author_username: 'demo_chef', region: 'Marmara' },
+      { type: 'recipe', id: 5, title: 'Güllaç', author_username: 'demo_chef', region: 'Marmara' },
+      { type: 'recipe', id: 6, title: 'Pide', author_username: 'chef_musa', region: 'Anatolia' },
+    ],
+  },
+  {
+    id: 'new-year',
+    name: 'New Year',
+    emoji: '🎉',
+    description: 'Festive recipes to ring in the new year with family and friends.',
+    featured: [
+      { type: 'recipe', id: 7, title: 'New Year\'s Roast', author_username: 'demo_chef', region: 'Marmara' },
+      { type: 'story', id: 3, title: 'How we celebrate the new year in our village', author_username: 'chef_ayse', region: 'Aegean' },
+      { type: 'recipe', id: 8, title: 'Champagne Cake', author_username: 'demo_chef', region: 'Marmara' },
+    ],
+  },
+  {
+    id: 'eid',
+    name: 'Eid',
+    emoji: '☪️',
+    description: 'Classic sweets, cookies, and festive dishes for Eid al-Fitr and Eid al-Adha.',
+    featured: [
+      { type: 'recipe', id: 9, title: 'Kurabiye', author_username: 'chef_ayse', region: 'Anatolia' },
+      { type: 'recipe', id: 10, title: 'Kurban Kavurma', author_username: 'chef_musa', region: 'Southeast Anatolia' },
+      { type: 'story', id: 4, title: 'Eid morning in our neighborhood', author_username: 'chef_musa', region: 'Marmara' },
+      { type: 'recipe', id: 11, title: 'Lokma', author_username: 'demo_chef', region: 'Aegean' },
+    ],
+  },
+  {
+    id: 'graduation',
+    name: 'Graduation',
+    emoji: '🎓',
+    description: 'Celebration foods and party recipes for graduations and academic milestones.',
+    featured: [
+      { type: 'recipe', id: 12, title: 'Celebration Pilaf', author_username: 'demo_chef', region: 'Marmara' },
+      { type: 'story', id: 5, title: 'The dinner my family made for my graduation', author_username: 'chef_ayse', region: 'Aegean' },
+    ],
+  },
+  {
+    id: 'baby-shower',
+    name: 'Baby Shower',
+    emoji: '👶',
+    description: 'Sweet treats and sharing dishes for welcoming a new life.',
+    featured: [
+      { type: 'recipe', id: 13, title: 'Lohusa Şerbeti', author_username: 'chef_ayse', region: 'Anatolia' },
+      { type: 'recipe', id: 14, title: 'Hediye Helvası', author_username: 'demo_chef', region: 'Anatolia' },
+      { type: 'story', id: 6, title: 'Sweet traditions for a new baby', author_username: 'demo_chef', region: 'Anatolia' },
+    ],
+  },
+];
+
+export function getMockEventById(id) {
+  return MOCK_EXPLORE_EVENTS.find((e) => e.id === id) ?? null;
+}

--- a/app/frontend/src/pages/EventDetailPage.css
+++ b/app/frontend/src/pages/EventDetailPage.css
@@ -1,0 +1,153 @@
+.event-detail-back {
+  display: inline-block;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  margin-bottom: 1.5rem;
+  text-decoration: none;
+  transition: color 0.15s;
+}
+
+.event-detail-back:hover {
+  color: var(--color-primary);
+  text-decoration: none;
+}
+
+.event-detail-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  margin-bottom: 1.75rem;
+}
+
+.event-detail-emoji {
+  font-size: 3rem;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.event-detail-title {
+  font-size: clamp(1.75rem, 3vw, 2.5rem);
+  color: var(--color-text);
+  margin-bottom: 0.35rem;
+}
+
+.event-detail-desc {
+  color: var(--color-text-muted);
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+/* ── Tabs ────────────────────────── */
+.event-detail-tabs {
+  display: flex;
+  gap: 0.375rem;
+  border-bottom: 1.5px solid var(--color-border);
+  padding-bottom: 0;
+  margin-bottom: 1.5rem;
+}
+
+.event-tab-btn {
+  background: none;
+  border: none;
+  padding: 0.5rem 1rem;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  border-bottom: 2.5px solid transparent;
+  margin-bottom: -1.5px;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  transition: color 0.15s;
+}
+
+.event-tab-btn:hover {
+  color: var(--color-text);
+}
+
+.event-tab-btn.active {
+  color: var(--color-primary);
+  border-bottom-color: var(--color-primary);
+}
+
+.event-tab-count {
+  font-size: 0.75rem;
+  font-weight: 700;
+  background: var(--color-border);
+  color: var(--color-text-muted);
+  border-radius: var(--radius-pill);
+  padding: 0.05rem 0.45rem;
+  min-width: 1.25rem;
+  text-align: center;
+}
+
+.event-tab-btn.active .event-tab-count {
+  background: var(--color-primary-tint);
+  color: var(--color-primary);
+}
+
+/* ── Grid ────────────────────────── */
+.event-detail-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 1.25rem;
+}
+
+.event-detail-card {
+  border-radius: var(--radius-lg);
+  border: 1.5px solid var(--color-border);
+  background: var(--color-surface-input);
+  overflow: hidden;
+  text-decoration: none;
+  transition: box-shadow 0.18s, transform 0.18s;
+  display: flex;
+  flex-direction: column;
+}
+
+.event-detail-card:hover {
+  box-shadow: var(--shadow-md);
+  transform: translateY(-2px);
+  text-decoration: none;
+}
+
+.event-detail-card-placeholder {
+  height: 130px;
+  background: linear-gradient(135deg, var(--color-accent-green-tint), var(--color-primary-subtle));
+}
+
+.event-detail-card-body {
+  padding: 0.875rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.event-detail-card-title {
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--color-text);
+  line-height: 1.35;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.event-detail-card-region {
+  display: inline-block;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--color-primary);
+  background: var(--color-primary-tint);
+  border-radius: var(--radius-pill);
+  padding: 0.1rem 0.5rem;
+  width: fit-content;
+}
+
+.event-detail-card-author {
+  font-size: 0.8125rem;
+  color: var(--color-text-muted);
+  margin-top: 0.1rem;
+}

--- a/app/frontend/src/pages/EventDetailPage.jsx
+++ b/app/frontend/src/pages/EventDetailPage.jsx
@@ -1,0 +1,88 @@
+import { useState, useEffect } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { fetchEventDetail } from '../services/exploreService';
+import './EventDetailPage.css';
+
+const TABS = ['all', 'recipe', 'story'];
+
+export default function EventDetailPage() {
+  const { eventId } = useParams();
+  const [event, setEvent] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [tab, setTab] = useState('all');
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    fetchEventDetail(eventId)
+      .then((data) => { if (!cancelled) setEvent(data); })
+      .catch(() => { if (!cancelled) setError('Could not load event content.'); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [eventId]);
+
+  if (loading) return <p className="page-status">Loading…</p>;
+  if (error) return <p className="page-status page-error">{error}</p>;
+  if (!event) return null;
+
+  const items = tab === 'all'
+    ? event.featured
+    : event.featured.filter((item) => item.type === tab);
+
+  return (
+    <main className="page-card event-detail-page">
+      <Link to="/explore" className="event-detail-back">← Explore</Link>
+
+      <div className="event-detail-header">
+        <span className="event-detail-emoji" aria-hidden="true">{event.emoji}</span>
+        <div>
+          <h1 className="event-detail-title">{event.name}</h1>
+          <p className="event-detail-desc">{event.description}</p>
+        </div>
+      </div>
+
+      <div className="event-detail-tabs" role="tablist">
+        {TABS.map((t) => (
+          <button
+            key={t}
+            role="tab"
+            aria-selected={tab === t}
+            className={`event-tab-btn${tab === t ? ' active' : ''}`}
+            onClick={() => setTab(t)}
+          >
+            {t === 'all' ? 'All' : t === 'recipe' ? 'Recipes' : 'Stories'}
+            <span className="event-tab-count">
+              {t === 'all'
+                ? event.featured.length
+                : event.featured.filter((i) => i.type === t).length}
+            </span>
+          </button>
+        ))}
+      </div>
+
+      {items.length === 0 ? (
+        <p className="page-status">No {tab}s for this event yet.</p>
+      ) : (
+        <div className="event-detail-grid">
+          {items.map((item) => {
+            const href = item.type === 'recipe' ? `/recipes/${item.id}` : `/stories/${item.id}`;
+            return (
+              <Link to={href} key={`${item.type}-${item.id}`} className="event-detail-card">
+                <div className="event-detail-card-placeholder" />
+                <div className="event-detail-card-body">
+                  <span className={`explore-card-type ${item.type}`}>{item.type}</span>
+                  <p className="event-detail-card-title">{item.title}</p>
+                  {item.region && (
+                    <span className="event-detail-card-region">{item.region}</span>
+                  )}
+                  <p className="event-detail-card-author">@{item.author_username}</p>
+                </div>
+              </Link>
+            );
+          })}
+        </div>
+      )}
+    </main>
+  );
+}

--- a/app/frontend/src/pages/ExplorePage.css
+++ b/app/frontend/src/pages/ExplorePage.css
@@ -1,0 +1,148 @@
+.explore-page-header {
+  margin-bottom: 2rem;
+}
+
+.explore-page-header h1 {
+  font-size: clamp(1.75rem, 3vw, 2.5rem);
+  color: var(--color-text);
+}
+
+.explore-page-subtitle {
+  margin-top: 0.4rem;
+  color: var(--color-text-muted);
+  font-size: 1rem;
+}
+
+/* ── Rails ───────────────────────── */
+.explore-rails {
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+.event-rail {
+  display: flex;
+  flex-direction: column;
+  gap: 0.875rem;
+}
+
+.event-rail-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.event-rail-emoji {
+  font-size: 1.375rem;
+  line-height: 1;
+}
+
+.event-rail-name {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--color-text);
+  flex: 1;
+}
+
+.event-rail-see-all {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--color-primary);
+  text-decoration: none;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.event-rail-see-all:hover {
+  text-decoration: underline;
+}
+
+/* ── Horizontal scroll ───────────── */
+.event-rail-scroll {
+  display: flex;
+  gap: 1rem;
+  overflow-x: auto;
+  padding-bottom: 0.5rem;
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-border) transparent;
+}
+
+.event-rail-scroll::-webkit-scrollbar {
+  height: 4px;
+}
+
+.event-rail-scroll::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.event-rail-scroll::-webkit-scrollbar-thumb {
+  background: var(--color-border);
+  border-radius: var(--radius-pill);
+}
+
+/* ── Content card ────────────────── */
+.explore-card {
+  flex: 0 0 200px;
+  border-radius: var(--radius-lg);
+  border: 1.5px solid var(--color-border);
+  background: var(--color-surface-input);
+  overflow: hidden;
+  text-decoration: none;
+  transition: box-shadow 0.18s, transform 0.18s;
+  display: flex;
+  flex-direction: column;
+}
+
+.explore-card:hover {
+  box-shadow: var(--shadow-md);
+  transform: translateY(-2px);
+  text-decoration: none;
+}
+
+.explore-card-placeholder {
+  height: 110px;
+  background: linear-gradient(135deg, var(--color-accent-green-tint), var(--color-primary-subtle));
+}
+
+.explore-card-body {
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.explore-card-type {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  border-radius: var(--radius-pill);
+  padding: 0.15rem 0.5rem;
+  width: fit-content;
+}
+
+.explore-card-type.recipe {
+  background: var(--color-primary-tint);
+  color: var(--color-primary);
+}
+
+.explore-card-type.story {
+  background: var(--color-accent-green-tint);
+  color: var(--color-accent-green);
+}
+
+.explore-card-title {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--color-text);
+  line-height: 1.35;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.explore-card-author {
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+}

--- a/app/frontend/src/pages/ExplorePage.jsx
+++ b/app/frontend/src/pages/ExplorePage.jsx
@@ -1,0 +1,71 @@
+import { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import { fetchExploreEvents } from '../services/exploreService';
+import './ExplorePage.css';
+
+function ContentCard({ item }) {
+  const href = item.type === 'recipe' ? `/recipes/${item.id}` : `/stories/${item.id}`;
+  return (
+    <Link to={href} className="explore-card">
+      <div className="explore-card-placeholder" />
+      <div className="explore-card-body">
+        <span className={`explore-card-type ${item.type}`}>{item.type}</span>
+        <p className="explore-card-title">{item.title}</p>
+        <p className="explore-card-author">@{item.author_username}</p>
+      </div>
+    </Link>
+  );
+}
+
+function EventRail({ event }) {
+  return (
+    <section className="event-rail">
+      <div className="event-rail-header">
+        <span className="event-rail-emoji" aria-hidden="true">{event.emoji}</span>
+        <h2 className="event-rail-name">{event.name}</h2>
+        <Link to={`/explore/${event.id}`} className="event-rail-see-all">
+          See all →
+        </Link>
+      </div>
+      <div className="event-rail-scroll">
+        {event.featured.map((item) => (
+          <ContentCard key={`${item.type}-${item.id}`} item={item} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export default function ExplorePage() {
+  const [events, setEvents] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchExploreEvents()
+      .then((data) => { if (!cancelled) setEvents(data); })
+      .catch(() => { if (!cancelled) setError('Could not load explore content.'); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, []);
+
+  if (loading) return <p className="page-status">Loading…</p>;
+  if (error) return <p className="page-status page-error">{error}</p>;
+
+  return (
+    <main className="page-card explore-page">
+      <div className="explore-page-header">
+        <h1>Explore</h1>
+        <p className="explore-page-subtitle">
+          Discover recipes and stories curated around life's most meaningful moments.
+        </p>
+      </div>
+      <div className="explore-rails">
+        {events.map((event) => (
+          <EventRail key={event.id} event={event} />
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/app/frontend/src/services/exploreService.js
+++ b/app/frontend/src/services/exploreService.js
@@ -1,0 +1,20 @@
+import { apiClient } from './api';
+import { MOCK_EXPLORE_EVENTS, getMockEventById } from '../mocks/exploreEvents';
+
+const USE_MOCK = process.env.REACT_APP_USE_MOCK === 'true';
+
+export async function fetchExploreEvents() {
+  if (USE_MOCK) return MOCK_EXPLORE_EVENTS;
+  const response = await apiClient.get('/api/explore/events/');
+  return response.data;
+}
+
+export async function fetchEventDetail(id) {
+  if (USE_MOCK) {
+    const event = getMockEventById(id);
+    if (!event) return Promise.reject(new Error('Not found'));
+    return event;
+  }
+  const response = await apiClient.get(`/api/explore/events/${id}/`);
+  return response.data;
+}


### PR DESCRIPTION
## Summary
- New `/explore` page with horizontal scrollable rails for 6 life-event categories (Wedding, Ramadan, Eid, New Year, Graduation, Baby Shower)
- New `/explore/:eventId` detail page with All / Recipes / Stories tabs and full content grid
- `exploreService.js` wires to `/api/explore/events/` when backend #M5-20 is ready
- "Explore" link added to navbar

## Test plan
- [ ] Visit `/explore` — 6 event rails visible, each horizontally scrollable
- [ ] "See all →" navigates to `/explore/:eventId`
- [ ] Detail page tabs filter by type; counts update accordingly