### PR TITLE
feat(frontend): event + religion/region cultural filter combination (#388)

### DIFF
--- a/app/frontend/src/mocks/exploreEvents.js
+++ b/app/frontend/src/mocks/exploreEvents.js
@@ -5,10 +5,12 @@ export const MOCK_EXPLORE_EVENTS = [
     emoji: '💍',
     description: 'Traditional and modern dishes served at weddings across Turkey and the wider region.',
     featured: [
-      { type: 'recipe', id: 1, title: 'Düğün Çorbası', author_username: 'chef_ayse', region: 'Anatolia' },
-      { type: 'recipe', id: 2, title: 'Etli Pilav', author_username: 'demo_chef', region: 'Marmara' },
-      { type: 'story', id: 1, title: 'My grandmother\'s wedding feast', author_username: 'demo_chef', region: 'Anatolia' },
-      { type: 'recipe', id: 3, title: 'Baklava', author_username: 'chef_ayse', region: 'Southeast Anatolia' },
+      { type: 'recipe', id: 1, title: 'Düğün Çorbası', author_username: 'chef_ayse', region: 'Anatolia', religion: 'Muslim' },
+      { type: 'recipe', id: 2, title: 'Etli Pilav', author_username: 'demo_chef', region: 'Marmara', religion: 'Muslim' },
+      { type: 'story', id: 1, title: 'My grandmother\'s wedding feast', author_username: 'demo_chef', region: 'Anatolia', religion: 'Universal' },
+      { type: 'recipe', id: 3, title: 'Baklava', author_username: 'chef_ayse', region: 'Southeast Anatolia', religion: 'Muslim' },
+      { type: 'recipe', id: 20, title: 'Wedding Kourabiedes', author_username: 'chef_nikos', region: 'Aegean', religion: 'Christian' },
+      { type: 'story', id: 10, title: 'A Jewish wedding in Istanbul', author_username: 'chef_rachel', region: 'Marmara', religion: 'Jewish' },
     ],
   },
   {
@@ -17,10 +19,10 @@ export const MOCK_EXPLORE_EVENTS = [
     emoji: '🌙',
     description: 'Iftar and suhoor recipes to share and celebrate the holy month.',
     featured: [
-      { type: 'recipe', id: 4, title: 'Iftar Çorbası', author_username: 'chef_musa', region: 'Marmara' },
-      { type: 'story', id: 2, title: 'Breaking fast at the Bosphorus', author_username: 'demo_chef', region: 'Marmara' },
-      { type: 'recipe', id: 5, title: 'Güllaç', author_username: 'demo_chef', region: 'Marmara' },
-      { type: 'recipe', id: 6, title: 'Pide', author_username: 'chef_musa', region: 'Anatolia' },
+      { type: 'recipe', id: 4, title: 'Iftar Çorbası', author_username: 'chef_musa', region: 'Marmara', religion: 'Muslim' },
+      { type: 'story', id: 2, title: 'Breaking fast at the Bosphorus', author_username: 'demo_chef', region: 'Marmara', religion: 'Muslim' },
+      { type: 'recipe', id: 5, title: 'Güllaç', author_username: 'demo_chef', region: 'Marmara', religion: 'Muslim' },
+      { type: 'recipe', id: 6, title: 'Pide', author_username: 'chef_musa', region: 'Anatolia', religion: 'Muslim' },
     ],
   },
   {
@@ -29,9 +31,10 @@ export const MOCK_EXPLORE_EVENTS = [
     emoji: '🎉',
     description: 'Festive recipes to ring in the new year with family and friends.',
     featured: [
-      { type: 'recipe', id: 7, title: 'New Year\'s Roast', author_username: 'demo_chef', region: 'Marmara' },
-      { type: 'story', id: 3, title: 'How we celebrate the new year in our village', author_username: 'chef_ayse', region: 'Aegean' },
-      { type: 'recipe', id: 8, title: 'Champagne Cake', author_username: 'demo_chef', region: 'Marmara' },
+      { type: 'recipe', id: 7, title: 'New Year\'s Roast', author_username: 'demo_chef', region: 'Marmara', religion: 'Secular' },
+      { type: 'story', id: 3, title: 'How we celebrate the new year in our village', author_username: 'chef_ayse', region: 'Aegean', religion: 'Universal' },
+      { type: 'recipe', id: 8, title: 'Champagne Cake', author_username: 'demo_chef', region: 'Marmara', religion: 'Secular' },
+      { type: 'recipe', id: 21, title: 'Vasilopita Bread', author_username: 'chef_nikos', region: 'Aegean', religion: 'Christian' },
     ],
   },
   {
@@ -40,10 +43,10 @@ export const MOCK_EXPLORE_EVENTS = [
     emoji: '☪️',
     description: 'Classic sweets, cookies, and festive dishes for Eid al-Fitr and Eid al-Adha.',
     featured: [
-      { type: 'recipe', id: 9, title: 'Kurabiye', author_username: 'chef_ayse', region: 'Anatolia' },
-      { type: 'recipe', id: 10, title: 'Kurban Kavurma', author_username: 'chef_musa', region: 'Southeast Anatolia' },
-      { type: 'story', id: 4, title: 'Eid morning in our neighborhood', author_username: 'chef_musa', region: 'Marmara' },
-      { type: 'recipe', id: 11, title: 'Lokma', author_username: 'demo_chef', region: 'Aegean' },
+      { type: 'recipe', id: 9, title: 'Kurabiye', author_username: 'chef_ayse', region: 'Anatolia', religion: 'Muslim' },
+      { type: 'recipe', id: 10, title: 'Kurban Kavurma', author_username: 'chef_musa', region: 'Southeast Anatolia', religion: 'Muslim' },
+      { type: 'story', id: 4, title: 'Eid morning in our neighborhood', author_username: 'chef_musa', region: 'Marmara', religion: 'Muslim' },
+      { type: 'recipe', id: 11, title: 'Lokma', author_username: 'demo_chef', region: 'Aegean', religion: 'Muslim' },
     ],
   },
   {
@@ -52,8 +55,9 @@ export const MOCK_EXPLORE_EVENTS = [
     emoji: '🎓',
     description: 'Celebration foods and party recipes for graduations and academic milestones.',
     featured: [
-      { type: 'recipe', id: 12, title: 'Celebration Pilaf', author_username: 'demo_chef', region: 'Marmara' },
-      { type: 'story', id: 5, title: 'The dinner my family made for my graduation', author_username: 'chef_ayse', region: 'Aegean' },
+      { type: 'recipe', id: 12, title: 'Celebration Pilaf', author_username: 'demo_chef', region: 'Marmara', religion: 'Universal' },
+      { type: 'story', id: 5, title: 'The dinner my family made for my graduation', author_username: 'chef_ayse', region: 'Aegean', religion: 'Universal' },
+      { type: 'recipe', id: 22, title: 'Graduation Börek', author_username: 'chef_musa', region: 'Black Sea', religion: 'Muslim' },
     ],
   },
   {
@@ -62,9 +66,9 @@ export const MOCK_EXPLORE_EVENTS = [
     emoji: '👶',
     description: 'Sweet treats and sharing dishes for welcoming a new life.',
     featured: [
-      { type: 'recipe', id: 13, title: 'Lohusa Şerbeti', author_username: 'chef_ayse', region: 'Anatolia' },
-      { type: 'recipe', id: 14, title: 'Hediye Helvası', author_username: 'demo_chef', region: 'Anatolia' },
-      { type: 'story', id: 6, title: 'Sweet traditions for a new baby', author_username: 'demo_chef', region: 'Anatolia' },
+      { type: 'recipe', id: 13, title: 'Lohusa Şerbeti', author_username: 'chef_ayse', region: 'Anatolia', religion: 'Muslim' },
+      { type: 'recipe', id: 14, title: 'Hediye Helvası', author_username: 'demo_chef', region: 'Anatolia', religion: 'Muslim' },
+      { type: 'story', id: 6, title: 'Sweet traditions for a new baby', author_username: 'demo_chef', region: 'Anatolia', religion: 'Universal' },
     ],
   },
 ];

--- a/app/frontend/src/pages/EventDetailPage.css
+++ b/app/frontend/src/pages/EventDetailPage.css
@@ -151,3 +151,96 @@
   color: var(--color-text-muted);
   margin-top: 0.1rem;
 }
+
+/* ── Cultural filters (#388) ─────── */
+.cultural-filters {
+  background: var(--color-primary-subtle);
+  border: 1.5px solid var(--color-primary-border);
+  border-radius: var(--radius-lg);
+  padding: 1rem 1.25rem;
+  margin-bottom: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.cultural-filters-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.filter-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.filter-group-label {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--color-primary);
+}
+
+.filter-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+}
+
+.filter-chip {
+  background: none;
+  border: 1.5px solid var(--color-border);
+  border-radius: var(--radius-pill);
+  padding: 0.25rem 0.75rem;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s, background 0.15s;
+}
+
+.filter-chip:hover {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+}
+
+.filter-chip.active {
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+  color: #fff;
+}
+
+.filter-clear {
+  background: none;
+  border: none;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  text-decoration: underline;
+  padding: 0;
+  align-self: flex-start;
+  transition: color 0.15s;
+}
+
+.filter-clear:hover { color: var(--color-error); }
+
+.event-detail-card-badges {
+  display: flex;
+  gap: 0.3rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.1rem;
+}
+
+.event-detail-card-religion {
+  font-size: 0.7rem;
+  font-weight: 700;
+  background: var(--color-accent-mustard);
+  color: #3D1500;
+  border-radius: var(--radius-pill);
+  padding: 0.15rem 0.5rem;
+  opacity: 0.85;
+}

--- a/app/frontend/src/pages/EventDetailPage.jsx
+++ b/app/frontend/src/pages/EventDetailPage.jsx
@@ -1,9 +1,22 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { fetchEventDetail } from '../services/exploreService';
 import './EventDetailPage.css';
 
 const TABS = ['all', 'recipe', 'story'];
+const RELIGIONS = ['Muslim', 'Christian', 'Jewish', 'Secular', 'Universal'];
+
+function FilterChip({ label, active, onClick }) {
+  return (
+    <button
+      className={`filter-chip${active ? ' active' : ''}`}
+      onClick={onClick}
+      aria-pressed={active}
+    >
+      {label}
+    </button>
+  );
+}
 
 export default function EventDetailPage() {
   const { eventId } = useParams();
@@ -11,10 +24,14 @@ export default function EventDetailPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
   const [tab, setTab] = useState('all');
+  const [selectedReligion, setSelectedReligion] = useState(null);
+  const [selectedRegion, setSelectedRegion] = useState(null);
 
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
+    setSelectedReligion(null);
+    setSelectedRegion(null);
     fetchEventDetail(eventId)
       .then((data) => { if (!cancelled) setEvent(data); })
       .catch(() => { if (!cancelled) setError('Could not load event content.'); })
@@ -22,13 +39,32 @@ export default function EventDetailPage() {
     return () => { cancelled = true; };
   }, [eventId]);
 
+  const availableRegions = useMemo(() => {
+    if (!event) return [];
+    return [...new Set(event.featured.map((i) => i.region).filter(Boolean))].sort();
+  }, [event]);
+
+  const availableReligions = useMemo(() => {
+    if (!event) return [];
+    const present = new Set(event.featured.map((i) => i.religion).filter(Boolean));
+    return RELIGIONS.filter((r) => present.has(r));
+  }, [event]);
+
+  const items = useMemo(() => {
+    if (!event) return [];
+    return event.featured.filter((item) => {
+      if (tab !== 'all' && item.type !== tab) return false;
+      if (selectedReligion && item.religion !== selectedReligion) return false;
+      if (selectedRegion && item.region !== selectedRegion) return false;
+      return true;
+    });
+  }, [event, tab, selectedReligion, selectedRegion]);
+
+  const hasActiveFilter = selectedReligion || selectedRegion;
+
   if (loading) return <p className="page-status">Loading…</p>;
   if (error) return <p className="page-status page-error">{error}</p>;
   if (!event) return null;
-
-  const items = tab === 'all'
-    ? event.featured
-    : event.featured.filter((item) => item.type === tab);
 
   return (
     <main className="page-card event-detail-page">
@@ -42,6 +78,7 @@ export default function EventDetailPage() {
         </div>
       </div>
 
+      {/* Type tabs */}
       <div className="event-detail-tabs" role="tablist">
         {TABS.map((t) => (
           <button
@@ -53,16 +90,62 @@ export default function EventDetailPage() {
           >
             {t === 'all' ? 'All' : t === 'recipe' ? 'Recipes' : 'Stories'}
             <span className="event-tab-count">
-              {t === 'all'
-                ? event.featured.length
-                : event.featured.filter((i) => i.type === t).length}
+              {event.featured.filter((i) => t === 'all' || i.type === t).length}
             </span>
           </button>
         ))}
       </div>
 
+      {/* Cultural filters (#388) */}
+      {(availableReligions.length > 0 || availableRegions.length > 0) && (
+        <div className="cultural-filters">
+          <div className="cultural-filters-row">
+            {availableReligions.length > 0 && (
+              <div className="filter-group">
+                <span className="filter-group-label">Religion</span>
+                <div className="filter-chips">
+                  {availableReligions.map((r) => (
+                    <FilterChip
+                      key={r}
+                      label={r}
+                      active={selectedReligion === r}
+                      onClick={() => setSelectedReligion(selectedReligion === r ? null : r)}
+                    />
+                  ))}
+                </div>
+              </div>
+            )}
+            {availableRegions.length > 0 && (
+              <div className="filter-group">
+                <span className="filter-group-label">Region</span>
+                <div className="filter-chips">
+                  {availableRegions.map((r) => (
+                    <FilterChip
+                      key={r}
+                      label={r}
+                      active={selectedRegion === r}
+                      onClick={() => setSelectedRegion(selectedRegion === r ? null : r)}
+                    />
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+          {hasActiveFilter && (
+            <button
+              className="filter-clear"
+              onClick={() => { setSelectedReligion(null); setSelectedRegion(null); }}
+            >
+              Clear filters
+            </button>
+          )}
+        </div>
+      )}
+
       {items.length === 0 ? (
-        <p className="page-status">No {tab}s for this event yet.</p>
+        <p className="page-status">
+          {hasActiveFilter ? 'No results for this combination.' : `No ${tab}s for this event yet.`}
+        </p>
       ) : (
         <div className="event-detail-grid">
           {items.map((item) => {
@@ -71,7 +154,12 @@ export default function EventDetailPage() {
               <Link to={href} key={`${item.type}-${item.id}`} className="event-detail-card">
                 <div className="event-detail-card-placeholder" />
                 <div className="event-detail-card-body">
-                  <span className={`explore-card-type ${item.type}`}>{item.type}</span>
+                  <div className="event-detail-card-badges">
+                    <span className={`explore-card-type ${item.type}`}>{item.type}</span>
+                    {item.religion && item.religion !== 'Universal' && (
+                      <span className="event-detail-card-religion">{item.religion}</span>
+                    )}
+                  </div>
                   <p className="event-detail-card-title">{item.title}</p>
                   {item.region && (
                     <span className="event-detail-card-region">{item.region}</span>


### PR DESCRIPTION
## Summary
- Event detail page now surfaces **Religion** and **Region** filter chip rows derived from the event's content
- Filters combine: e.g. selecting "Muslim" + "Anatolia" shows only matching items
- Active filter chips are togglable; "Clear filters" resets both
- Religion badge shown on each content card (except Universal)
- Mock data enriched with `religion` and `region` per featured item

> **Depends on #435** (`feat/frontend/event-explore-ui`) — merge that first.

## Test plan
- [ ] Visit `/explore/wedding` — Religion and Region filter rows visible
- [ ] Select "Christian" → only Christian wedding items shown
- [ ] Combine "Muslim" + "Southeast Anatolia" → intersection result
- [ ] Clear filters restores full list