### PR TITLE
feat(frontend): ingredient check-off, substitution UI, and shopping list (#372, #370, #373)

### DIFF
--- a/app/frontend/src/mocks/substitutions.js
+++ b/app/frontend/src/mocks/substitutions.js
@@ -1,0 +1,28 @@
+// Keyed by ingredient_name (lowercased) for mock lookup
+export const MOCK_SUBSTITUTES = {
+  tomato: [
+    { id: 101, name: 'Canned tomatoes', match_type: 'Flavor Match' },
+    { id: 102, name: 'Red bell pepper', match_type: 'Texture Match' },
+    { id: 103, name: 'Sun-dried tomatoes', match_type: 'Flavor Match' },
+  ],
+  onion: [
+    { id: 104, name: 'Shallot', match_type: 'Flavor Match' },
+    { id: 105, name: 'Leek', match_type: 'Flavor Match' },
+    { id: 106, name: 'Green onion', match_type: 'Flavor Match' },
+  ],
+  olives: [
+    { id: 107, name: 'Capers', match_type: 'Flavor Match' },
+    { id: 108, name: 'Sun-dried tomatoes', match_type: 'Texture Match' },
+  ],
+  'olive oil': [
+    { id: 109, name: 'Sunflower oil', match_type: 'Texture Match' },
+    { id: 110, name: 'Avocado oil', match_type: 'Flavor Match' },
+  ],
+};
+
+export function getMockSubstitutes(ingredientName) {
+  const key = (ingredientName ?? '').toLowerCase();
+  return MOCK_SUBSTITUTES[key] ?? [
+    { id: 999, name: 'Similar ingredient', match_type: 'Flavor Match' },
+  ];
+}

--- a/app/frontend/src/pages/RecipeDetailPage.css
+++ b/app/frontend/src/pages/RecipeDetailPage.css
@@ -63,6 +63,7 @@
   margin-bottom: 2rem;
 }
 
+/* ── Ingredients section ─────────── */
 .recipe-ingredients {
   border-top: 1.5px solid var(--color-border);
   padding-top: 1.5rem;
@@ -72,6 +73,8 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.75rem;
   margin-bottom: 1rem;
 }
 
@@ -80,6 +83,14 @@
   margin: 0;
 }
 
+.ingredients-header-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  flex-wrap: wrap;
+}
+
+/* ── Unit toggle (#377) ──────────── */
 .unit-toggle {
   display: flex;
   border: 1.5px solid var(--color-border);
@@ -98,35 +109,251 @@
   transition: background 0.15s, color 0.15s;
 }
 
-.unit-toggle-btn:hover {
-  color: var(--color-text);
-}
+.unit-toggle-btn:hover { color: var(--color-text); }
 
 .unit-toggle-btn.active {
   background: var(--color-primary);
   color: #fff;
 }
 
+/* ── Ingredient list ─────────────── */
 .ingredients-list {
   list-style: none;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
 }
 
 .ingredient-item {
   display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 0.6rem 0;
+  flex-direction: column;
   border-bottom: 1px solid var(--color-border);
+  transition: opacity 0.2s;
+}
+
+.ingredient-item.checked {
+  opacity: 0.45;
+}
+
+.ingredient-row {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.6rem 0;
+}
+
+/* ── Check-off (#372) ────────────── */
+.ingredient-checkbox {
+  width: 1.1rem;
+  height: 1.1rem;
+  accent-color: var(--color-primary);
+  flex-shrink: 0;
+  cursor: pointer;
 }
 
 .ingredient-name {
+  flex: 1;
   font-weight: 500;
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  flex-wrap: wrap;
 }
+
+.ingredient-name-subbed {
+  text-decoration: line-through;
+  color: var(--color-text-muted);
+  font-weight: 400;
+}
+
+.ingredient-sub-arrow {
+  color: var(--color-text-muted);
+  font-size: 0.85rem;
+}
+
+.ingredient-sub-name {
+  color: var(--color-accent-green);
+  font-weight: 600;
+}
+
+.ingredient-clear-sub {
+  background: none;
+  border: none;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+  padding: 0 0.1rem;
+  transition: color 0.15s;
+}
+
+.ingredient-clear-sub:hover { color: var(--color-error); }
 
 .ingredient-amount {
   color: var(--color-text-muted);
   font-size: 0.9375rem;
+  flex-shrink: 0;
+}
+
+/* ── Substitution button (#370) ──── */
+.ingredient-sub-btn {
+  background: none;
+  border: 1.5px solid var(--color-border);
+  border-radius: var(--radius-pill);
+  padding: 0.2rem 0.65rem;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: border-color 0.15s, color 0.15s, background 0.15s;
+}
+
+.ingredient-sub-btn:hover,
+.ingredient-sub-btn.active {
+  border-color: var(--color-accent-green);
+  color: var(--color-accent-green);
+  background: var(--color-accent-green-tint);
+}
+
+/* ── Substitution panel (#370) ───── */
+.sub-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  padding: 0.625rem 0 0.75rem 1.7rem;
+}
+
+.sub-option {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  background: var(--color-primary-subtle);
+  border: none;
+  border-radius: var(--radius-md);
+  padding: 0.45rem 0.75rem;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.15s;
+}
+
+.sub-option:hover { background: var(--color-accent-green-tint); }
+
+.sub-option-name {
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--color-text);
+}
+
+.sub-match-chip {
+  font-size: 0.7rem;
+  font-weight: 700;
+  border-radius: var(--radius-pill);
+  padding: 0.15rem 0.5rem;
+  flex-shrink: 0;
+}
+
+.chip-flavor {
+  background: var(--color-primary-tint);
+  color: var(--color-primary);
+}
+
+.chip-texture {
+  background: var(--color-accent-green-tint);
+  color: var(--color-accent-green);
+}
+
+.chip-default {
+  background: var(--color-border);
+  color: var(--color-text-muted);
+}
+
+.sub-loading {
+  font-size: 0.875rem;
+  color: var(--color-text-muted);
+  padding: 0.25rem 0;
+}
+
+/* ── Shopping list (#373) ────────── */
+.shopping-list {
+  margin-top: 1.25rem;
+  background: var(--color-primary-subtle);
+  border: 1.5px solid var(--color-primary-border);
+  border-radius: var(--radius-lg);
+  padding: 1.25rem;
+}
+
+.shopping-list-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.875rem;
+}
+
+.shopping-list-header h3 {
+  font-size: 1.0625rem;
+  font-weight: 700;
+  color: var(--color-text);
+}
+
+.shopping-list-copy {
+  background: none;
+  border: 1.5px solid var(--color-primary-border);
+  border-radius: var(--radius-pill);
+  padding: 0.25rem 0.75rem;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--color-primary);
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.shopping-list-copy:hover { background: var(--color-primary-tint); }
+
+.shopping-list-empty {
+  font-size: 0.9375rem;
+  color: var(--color-accent-green);
+  font-weight: 600;
+  text-align: center;
+  padding: 0.5rem 0;
+}
+
+.shopping-list-items {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.shopping-list-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.4rem 0.25rem;
+  border-bottom: 1px solid var(--color-primary-border);
+}
+
+.shopping-list-item:last-child { border-bottom: none; }
+
+.shopping-item-name {
+  font-weight: 500;
+  font-size: 0.9375rem;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.shopping-sub-badge {
+  font-size: 0.65rem;
+  font-weight: 700;
+  background: var(--color-accent-green-tint);
+  color: var(--color-accent-green);
+  border-radius: var(--radius-pill);
+  padding: 0.1rem 0.4rem;
+  text-transform: uppercase;
+}
+
+.shopping-item-qty {
+  font-size: 0.9rem;
+  color: var(--color-text-muted);
 }

--- a/app/frontend/src/pages/RecipeDetailPage.jsx
+++ b/app/frontend/src/pages/RecipeDetailPage.jsx
@@ -1,20 +1,43 @@
-import { useState, useEffect, useContext } from 'react';
+import { useState, useEffect, useContext, useCallback } from 'react';
 import { useParams, Link, useNavigate } from 'react-router-dom';
 import { AuthContext } from '../context/AuthContext';
 import { fetchRecipe } from '../services/recipeService';
 import { fetchRegions } from '../services/searchService';
+import { fetchSubstitutes, checkIngredient, uncheckIngredient } from '../services/ingredientService';
 import RecipeCommentsSection from '../components/RecipeCommentsSection';
 import './RecipeDetailPage.css';
+
+const MATCH_TYPE_LABELS = {
+  'Flavor Match': { label: 'Flavor', cls: 'chip-flavor' },
+  'Texture Match': { label: 'Texture', cls: 'chip-texture' },
+};
+
+function MatchChip({ type }) {
+  const info = MATCH_TYPE_LABELS[type] ?? { label: type, cls: 'chip-default' };
+  return <span className={`sub-match-chip ${info.cls}`}>{info.label}</span>;
+}
 
 export default function RecipeDetailPage() {
   const { id } = useParams();
   const { user } = useContext(AuthContext);
   const navigate = useNavigate();
+
   const [recipe, setRecipe] = useState(null);
   const [regions, setRegions] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
   const [useConverted, setUseConverted] = useState(false);
+
+  // #372 — ingredient check-off
+  const [checked, setChecked] = useState(new Set());
+
+  // #370 — substitution UI
+  const [openSubPanel, setOpenSubPanel] = useState(null); // ingredientId
+  const [substitutes, setSubstitutes] = useState({});     // ingredientId → options[]
+  const [appliedSubs, setAppliedSubs] = useState({});     // ingredientId → substitute obj
+
+  // #373 — shopping list
+  const [showShoppingList, setShowShoppingList] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -26,6 +49,41 @@ export default function RecipeDetailPage() {
     return () => { cancelled = true; };
   }, [id]);
 
+  const toggleCheck = useCallback(async (ingredientId) => {
+    const next = new Set(checked);
+    if (next.has(ingredientId)) {
+      next.delete(ingredientId);
+      await uncheckIngredient(id, ingredientId).catch(() => {});
+    } else {
+      next.add(ingredientId);
+      await checkIngredient(id, ingredientId).catch(() => {});
+    }
+    setChecked(next);
+    // Close sub panel if ingredient gets checked
+    if (openSubPanel === ingredientId) setOpenSubPanel(null);
+  }, [checked, id, openSubPanel]);
+
+  const openSub = useCallback(async (ingredientId, ingredientName) => {
+    if (openSubPanel === ingredientId) {
+      setOpenSubPanel(null);
+      return;
+    }
+    setOpenSubPanel(ingredientId);
+    if (!substitutes[ingredientId]) {
+      const subs = await fetchSubstitutes(ingredientId, ingredientName).catch(() => []);
+      setSubstitutes((prev) => ({ ...prev, [ingredientId]: subs }));
+    }
+  }, [openSubPanel, substitutes]);
+
+  const applySub = useCallback((ingredientId, sub) => {
+    setAppliedSubs((prev) => ({ ...prev, [ingredientId]: sub }));
+    setOpenSubPanel(null);
+  }, []);
+
+  const clearSub = useCallback((ingredientId) => {
+    setAppliedSubs((prev) => { const n = { ...prev }; delete n[ingredientId]; return n; });
+  }, []);
+
   if (loading) return <p className="page-status">Loading…</p>;
   if (error) return <p className="page-status page-error">{error}</p>;
   if (!recipe) return null;
@@ -33,6 +91,24 @@ export default function RecipeDetailPage() {
   const isAuthor = user && user.id === recipe.author;
   const authorContactable = recipe.author_is_contactable ?? recipe.author_contactable ?? true;
   const regionName = regions.find((r) => r.id === recipe.region)?.name;
+
+  const hasConverted = recipe.ingredients.some((ri) => ri.converted_amount);
+
+  // Shopping list: unchecked ingredients with substitutions applied
+  const shoppingItems = recipe.ingredients
+    .filter((ri) => !checked.has(ri.ingredient))
+    .map((ri) => {
+      const sub = appliedSubs[ri.ingredient];
+      const amount = useConverted && ri.converted_amount ? ri.converted_amount : ri.amount;
+      const unit = useConverted && ri.converted_unit_name ? ri.converted_unit_name : ri.unit_name;
+      return {
+        key: ri.ingredient,
+        name: sub ? sub.name : ri.ingredient_name,
+        amount,
+        unit,
+        isSub: Boolean(sub),
+      };
+    });
 
   return (
     <main className="page-card recipe-detail">
@@ -73,58 +149,158 @@ export default function RecipeDetailPage() {
       </div>
 
       {recipe.image && (
-        <img
-          src={recipe.image}
-          alt={recipe.title}
-          className="recipe-detail-image"
-        />
+        <img src={recipe.image} alt={recipe.title} className="recipe-detail-image" />
       )}
 
       {recipe.video && (
-        <video
-          data-testid="recipe-video"
-          controls
-          src={recipe.video}
-          className="recipe-video"
-        />
+        <video data-testid="recipe-video" controls src={recipe.video} className="recipe-video" />
       )}
 
       {recipe.description && (
         <p className="recipe-description">{recipe.description}</p>
       )}
 
+      {/* ── Ingredients (#372 check-off, #370 substitution, #377 unit toggle) ── */}
       <section className="recipe-ingredients">
         <div className="ingredients-header">
           <h2>Ingredients</h2>
-          {recipe.ingredients.some((ri) => ri.converted_amount) && (
-            <div className="unit-toggle" role="group" aria-label="Unit system">
+          <div className="ingredients-header-controls">
+            {hasConverted && (
+              <div className="unit-toggle" role="group" aria-label="Unit system">
+                <button
+                  className={`unit-toggle-btn${!useConverted ? ' active' : ''}`}
+                  onClick={() => setUseConverted(false)}
+                >
+                  Original
+                </button>
+                <button
+                  className={`unit-toggle-btn${useConverted ? ' active' : ''}`}
+                  onClick={() => setUseConverted(true)}
+                >
+                  Converted
+                </button>
+              </div>
+            )}
+            {user && shoppingItems.length > 0 && (
               <button
-                className={`unit-toggle-btn${!useConverted ? ' active' : ''}`}
-                onClick={() => setUseConverted(false)}
+                className="btn btn-outline btn-sm"
+                onClick={() => setShowShoppingList((v) => !v)}
               >
-                Original
+                {showShoppingList ? 'Hide list' : `Shopping list (${shoppingItems.length})`}
               </button>
-              <button
-                className={`unit-toggle-btn${useConverted ? ' active' : ''}`}
-                onClick={() => setUseConverted(true)}
-              >
-                Converted
-              </button>
-            </div>
-          )}
+            )}
+          </div>
         </div>
+
         <ul className="ingredients-list">
           {recipe.ingredients.map((ri) => {
+            const isChecked = checked.has(ri.ingredient);
+            const sub = appliedSubs[ri.ingredient];
             const amount = useConverted && ri.converted_amount ? ri.converted_amount : ri.amount;
             const unit = useConverted && ri.converted_unit_name ? ri.converted_unit_name : ri.unit_name;
+            const isSubOpen = openSubPanel === ri.ingredient;
+
             return (
-              <li key={ri.ingredient} className="ingredient-item">
-                <span className="ingredient-name">{ri.ingredient_name}</span>
-                <span className="ingredient-amount">{amount} {unit}</span>
+              <li key={ri.ingredient} className={`ingredient-item${isChecked ? ' checked' : ''}`}>
+                <div className="ingredient-row">
+                  {user && (
+                    <input
+                      type="checkbox"
+                      className="ingredient-checkbox"
+                      checked={isChecked}
+                      onChange={() => toggleCheck(ri.ingredient)}
+                      aria-label={`Mark ${ri.ingredient_name} as available`}
+                    />
+                  )}
+                  <span className="ingredient-name">
+                    {sub ? (
+                      <>
+                        <span className="ingredient-name-subbed">{ri.ingredient_name}</span>
+                        <span className="ingredient-sub-arrow">→</span>
+                        <span className="ingredient-sub-name">{sub.name}</span>
+                        <button
+                          className="ingredient-clear-sub"
+                          onClick={() => clearSub(ri.ingredient)}
+                          aria-label="Remove substitution"
+                        >
+                          ×
+                        </button>
+                      </>
+                    ) : (
+                      ri.ingredient_name
+                    )}
+                  </span>
+                  <span className="ingredient-amount">{amount} {unit}</span>
+                  {user && !isChecked && (
+                    <button
+                      className={`ingredient-sub-btn${isSubOpen ? ' active' : ''}`}
+                      onClick={() => openSub(ri.ingredient, ri.ingredient_name)}
+                      aria-expanded={isSubOpen}
+                      aria-label={`Find substitutes for ${ri.ingredient_name}`}
+                    >
+                      Sub
+                    </button>
+                  )}
+                </div>
+
+                {isSubOpen && (
+                  <div className="sub-panel" role="listbox" aria-label="Substitution options">
+                    {substitutes[ri.ingredient] ? (
+                      substitutes[ri.ingredient].map((s) => (
+                        <button
+                          key={s.id}
+                          className="sub-option"
+                          role="option"
+                          onClick={() => applySub(ri.ingredient, s)}
+                        >
+                          <span className="sub-option-name">{s.name}</span>
+                          <MatchChip type={s.match_type} />
+                        </button>
+                      ))
+                    ) : (
+                      <p className="sub-loading">Loading…</p>
+                    )}
+                  </div>
+                )}
               </li>
             );
           })}
         </ul>
+
+        {/* ── Shopping list (#373) ── */}
+        {user && showShoppingList && (
+          <div className="shopping-list">
+            <div className="shopping-list-header">
+              <h3>Shopping List</h3>
+              <button
+                className="shopping-list-copy"
+                onClick={() => {
+                  const text = shoppingItems
+                    .map((i) => `${i.name} — ${i.amount} ${i.unit}`)
+                    .join('\n');
+                  navigator.clipboard.writeText(text).catch(() => {});
+                }}
+              >
+                Copy
+              </button>
+            </div>
+            {shoppingItems.length === 0 ? (
+              <p className="shopping-list-empty">All ingredients are checked off!</p>
+            ) : (
+              <ul className="shopping-list-items">
+                {shoppingItems.map((item) => (
+                  <li key={item.key} className={`shopping-list-item${item.isSub ? ' is-sub' : ''}`}>
+                    <span className="shopping-item-name">
+                      {item.name}
+                      {item.isSub && <span className="shopping-sub-badge">sub</span>}
+                    </span>
+                    <span className="shopping-item-qty">{item.amount} {item.unit}</span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        )}
       </section>
 
       <RecipeCommentsSection

--- a/app/frontend/src/services/ingredientService.js
+++ b/app/frontend/src/services/ingredientService.js
@@ -1,0 +1,20 @@
+import { apiClient } from './api';
+import { getMockSubstitutes } from '../mocks/substitutions';
+
+const USE_MOCK = process.env.REACT_APP_USE_MOCK === 'true';
+
+export async function fetchSubstitutes(ingredientId, ingredientName) {
+  if (USE_MOCK) return getMockSubstitutes(ingredientName);
+  const response = await apiClient.get(`/api/ingredients/${ingredientId}/substitutes/`);
+  return response.data;
+}
+
+export async function checkIngredient(recipeId, ingredientId) {
+  if (USE_MOCK) return;
+  await apiClient.post(`/api/recipes/${recipeId}/check-ingredient/`, { ingredient: ingredientId });
+}
+
+export async function uncheckIngredient(recipeId, ingredientId) {
+  if (USE_MOCK) return;
+  await apiClient.delete(`/api/recipes/${recipeId}/check-ingredient/${ingredientId}/`);
+}


### PR DESCRIPTION
## Summary
- **#372 Ingredient check-off**: checkboxes on each ingredient; checked items are faded/struck through; persisted via `POST/DELETE /api/recipes/:id/check-ingredient/` (mock: local state)
- **#370 Substitution UI**: "Sub" button on unchecked ingredients opens an inline panel with substitute options tagged by match type (Flavor Match / Texture Match); applying a sub replaces the ingredient display
- **#373 Dynamic shopping list**: collapsible panel below ingredients showing only unchecked items with applied substitutions; updates live; "Copy" button copies to clipboard
- Also includes unit toggle (#377) — **this PR supersedes `feat/frontend/unit-toggle-ui`**

## Test plan
- [ ] Log in (mock), visit `/recipes/1`
- [ ] Check an ingredient — row fades, disappears from shopping list
- [ ] Click "Sub" on unchecked ingredient — panel opens with options and match chips
- [ ] Apply a substitution — ingredient name shows strikethrough + new name
- [ ] Shopping list button appears; shows remaining unchecked items with substitutions applied
- [ ] Copy button copies list to clipboard