### PR TITLE
feat(frontend): cultural tag moderation queue admin page (#391)

### DIFF
--- a/app/frontend/src/App.js
+++ b/app/frontend/src/App.js
@@ -19,6 +19,7 @@ import OnboardingPage from './pages/OnboardingPage';
 import MapPage from './pages/MapPage';
 import ExplorePage from './pages/ExplorePage';
 import EventDetailPage from './pages/EventDetailPage';
+import ModerationPage from './pages/ModerationPage';
 import NotFoundPage from './pages/NotFoundPage';
 
 export default function App() {
@@ -68,6 +69,10 @@ export default function App() {
           <Route
             path="/onboarding"
             element={<ProtectedRoute><OnboardingPage /></ProtectedRoute>}
+          />
+          <Route
+            path="/admin/moderation"
+            element={<ProtectedRoute><ModerationPage /></ProtectedRoute>}
           />
 
           <Route path="*" element={<NotFoundPage />} />

--- a/app/frontend/src/mocks/moderationQueue.js
+++ b/app/frontend/src/mocks/moderationQueue.js
@@ -1,0 +1,9 @@
+export const MOCK_MODERATION_QUEUE = [
+  { id: 1, tag: 'Aegean coast', tag_type: 'region', submitted_by: 'user_123', submitted_at: '2026-05-01T10:22:00Z', status: 'pending' },
+  { id: 2, tag: 'Nowruz', tag_type: 'tradition', submitted_by: 'user_456', submitted_at: '2026-05-01T11:05:00Z', status: 'pending' },
+  { id: 3, tag: 'Hıdırellez', tag_type: 'event', submitted_by: 'user_789', submitted_at: '2026-05-01T12:30:00Z', status: 'pending' },
+  { id: 4, tag: 'Balkan cuisine', tag_type: 'region', submitted_by: 'user_321', submitted_at: '2026-05-02T08:14:00Z', status: 'pending' },
+  { id: 5, tag: 'Alevite fast', tag_type: 'tradition', submitted_by: 'user_654', submitted_at: '2026-05-02T09:00:00Z', status: 'pending' },
+  { id: 6, tag: 'Kurban Bayramı feast', tag_type: 'event', submitted_by: 'user_111', submitted_at: '2026-04-30T15:42:00Z', status: 'approved' },
+  { id: 7, tag: 'spam tag!!', tag_type: 'region', submitted_by: 'user_999', submitted_at: '2026-04-29T20:11:00Z', status: 'rejected' },
+];

--- a/app/frontend/src/pages/ModerationPage.css
+++ b/app/frontend/src/pages/ModerationPage.css
@@ -1,0 +1,158 @@
+.moderation-header {
+  margin-bottom: 1.75rem;
+}
+
+.moderation-header h1 {
+  font-size: clamp(1.75rem, 3vw, 2.5rem);
+}
+
+.moderation-subtitle {
+  margin-top: 0.4rem;
+  color: var(--color-text-muted);
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+/* ── Status tabs ─────────────────── */
+.moderation-tabs {
+  display: flex;
+  gap: 0.375rem;
+  border-bottom: 1.5px solid var(--color-border);
+  margin-bottom: 1.5rem;
+}
+
+.mod-tab-btn {
+  background: none;
+  border: none;
+  padding: 0.5rem 1rem;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  border-bottom: 2.5px solid transparent;
+  margin-bottom: -1.5px;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  transition: color 0.15s;
+}
+
+.mod-tab-btn:hover { color: var(--color-text); }
+
+.mod-tab-btn.active.mod-tab-pending  { color: var(--color-primary); border-bottom-color: var(--color-primary); }
+.mod-tab-btn.active.mod-tab-approved { color: var(--color-success); border-bottom-color: var(--color-success); }
+.mod-tab-btn.active.mod-tab-rejected { color: var(--color-error);   border-bottom-color: var(--color-error); }
+
+.mod-tab-count {
+  font-size: 0.75rem;
+  font-weight: 700;
+  background: var(--color-border);
+  color: var(--color-text-muted);
+  border-radius: var(--radius-pill);
+  padding: 0.05rem 0.45rem;
+  min-width: 1.25rem;
+  text-align: center;
+}
+
+.moderation-empty {
+  color: var(--color-text-muted);
+  text-align: center;
+  padding: 3rem 0;
+}
+
+/* ── Queue list ──────────────────── */
+.moderation-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.mod-item {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
+  border-radius: var(--radius-lg);
+  border: 1.5px solid var(--color-border);
+  background: var(--color-surface-input);
+  flex-wrap: wrap;
+}
+
+.mod-item--approved { border-color: rgba(22, 163, 74, 0.3); background: rgba(22, 163, 74, 0.04); }
+.mod-item--rejected { border-color: rgba(220, 38, 38, 0.25); background: rgba(220, 38, 38, 0.03); opacity: 0.75; }
+
+.mod-item-main {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex: 1;
+}
+
+.mod-tag-type {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  border-radius: var(--radius-pill);
+  padding: 0.2rem 0.6rem;
+  flex-shrink: 0;
+}
+
+.tag-region    { background: var(--color-primary-tint); color: var(--color-primary); }
+.tag-event     { background: var(--color-accent-green-tint); color: var(--color-accent-green); }
+.tag-tradition { background: rgba(212, 168, 48, 0.15); color: #8B6914; }
+.tag-default   { background: var(--color-border); color: var(--color-text-muted); }
+
+.mod-tag-value {
+  font-weight: 600;
+  font-size: 1rem;
+  color: var(--color-text);
+}
+
+.mod-item-meta {
+  display: flex;
+  gap: 1rem;
+  font-size: 0.8125rem;
+  color: var(--color-text-muted);
+  flex-shrink: 0;
+}
+
+.mod-item-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
+.mod-btn-approve {
+  border-color: var(--color-success);
+  color: var(--color-success);
+}
+
+.mod-btn-approve:hover:not(:disabled) {
+  background: var(--color-success);
+  color: #fff;
+}
+
+.mod-btn-reject {
+  border-color: var(--color-error);
+  color: var(--color-error);
+}
+
+.mod-btn-reject:hover:not(:disabled) {
+  background: var(--color-error);
+  color: #fff;
+}
+
+.mod-status-badge {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  border-radius: var(--radius-pill);
+  padding: 0.2rem 0.65rem;
+  flex-shrink: 0;
+}
+
+.mod-status-approved { background: rgba(22, 163, 74, 0.12); color: var(--color-success); }
+.mod-status-rejected { background: rgba(220, 38, 38, 0.10); color: var(--color-error); }

--- a/app/frontend/src/pages/ModerationPage.jsx
+++ b/app/frontend/src/pages/ModerationPage.jsx
@@ -1,0 +1,126 @@
+import { useState, useEffect, useContext } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { AuthContext } from '../context/AuthContext';
+import { fetchModerationQueue, approveTag, rejectTag } from '../services/moderationService';
+import './ModerationPage.css';
+
+const STATUS_FILTERS = ['pending', 'approved', 'rejected'];
+
+const TAG_TYPE_LABELS = {
+  region: { label: 'Region', cls: 'tag-region' },
+  event: { label: 'Event', cls: 'tag-event' },
+  tradition: { label: 'Tradition', cls: 'tag-tradition' },
+};
+
+function formatDate(iso) {
+  const d = new Date(iso);
+  return d.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' });
+}
+
+export default function ModerationPage() {
+  const { user } = useContext(AuthContext);
+  const navigate = useNavigate();
+  const [queue, setQueue] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [statusFilter, setStatusFilter] = useState('pending');
+  const [processing, setProcessing] = useState(null);
+
+  useEffect(() => {
+    if (!user) { navigate('/login'); return; }
+    fetchModerationQueue()
+      .then(setQueue)
+      .finally(() => setLoading(false));
+  }, [user, navigate]);
+
+  const handle = async (id, action) => {
+    setProcessing(id);
+    try {
+      if (action === 'approve') await approveTag(id);
+      else await rejectTag(id);
+      const updated = await fetchModerationQueue();
+      setQueue(updated);
+    } finally {
+      setProcessing(null);
+    }
+  };
+
+  const filtered = queue.filter((t) => t.status === statusFilter);
+  const counts = STATUS_FILTERS.reduce((acc, s) => {
+    acc[s] = queue.filter((t) => t.status === s).length;
+    return acc;
+  }, {});
+
+  if (loading) return <p className="page-status">Loading…</p>;
+
+  return (
+    <main className="page-card moderation-page">
+      <div className="moderation-header">
+        <h1>Cultural Tag Moderation</h1>
+        <p className="moderation-subtitle">
+          Review user-submitted region, event, and tradition tags before they appear in discovery surfaces.
+        </p>
+      </div>
+
+      <div className="moderation-tabs" role="tablist">
+        {STATUS_FILTERS.map((s) => (
+          <button
+            key={s}
+            role="tab"
+            aria-selected={statusFilter === s}
+            className={`mod-tab-btn${statusFilter === s ? ' active' : ''} mod-tab-${s}`}
+            onClick={() => setStatusFilter(s)}
+          >
+            {s.charAt(0).toUpperCase() + s.slice(1)}
+            <span className="mod-tab-count">{counts[s]}</span>
+          </button>
+        ))}
+      </div>
+
+      {filtered.length === 0 ? (
+        <p className="moderation-empty">No {statusFilter} tags.</p>
+      ) : (
+        <ul className="moderation-list">
+          {filtered.map((item) => {
+            const typeInfo = TAG_TYPE_LABELS[item.tag_type] ?? { label: item.tag_type, cls: 'tag-default' };
+            const isPending = item.status === 'pending';
+            return (
+              <li key={item.id} className={`mod-item mod-item--${item.status}`}>
+                <div className="mod-item-main">
+                  <span className={`mod-tag-type ${typeInfo.cls}`}>{typeInfo.label}</span>
+                  <span className="mod-tag-value">"{item.tag}"</span>
+                </div>
+                <div className="mod-item-meta">
+                  <span>by @{item.submitted_by}</span>
+                  <span>{formatDate(item.submitted_at)}</span>
+                </div>
+                {isPending && (
+                  <div className="mod-item-actions">
+                    <button
+                      className="btn btn-sm mod-btn-approve"
+                      disabled={processing === item.id}
+                      onClick={() => handle(item.id, 'approve')}
+                    >
+                      Approve
+                    </button>
+                    <button
+                      className="btn btn-sm mod-btn-reject"
+                      disabled={processing === item.id}
+                      onClick={() => handle(item.id, 'reject')}
+                    >
+                      Reject
+                    </button>
+                  </div>
+                )}
+                {!isPending && (
+                  <span className={`mod-status-badge mod-status-${item.status}`}>
+                    {item.status}
+                  </span>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </main>
+  );
+}

--- a/app/frontend/src/services/moderationService.js
+++ b/app/frontend/src/services/moderationService.js
@@ -1,0 +1,28 @@
+import { apiClient } from './api';
+import { MOCK_MODERATION_QUEUE } from '../mocks/moderationQueue';
+
+const USE_MOCK = process.env.REACT_APP_USE_MOCK === 'true';
+
+let mockQueue = [...MOCK_MODERATION_QUEUE];
+
+export async function fetchModerationQueue() {
+  if (USE_MOCK) return [...mockQueue];
+  const response = await apiClient.get('/api/moderation/cultural-tags/');
+  return response.data;
+}
+
+export async function approveTag(id) {
+  if (USE_MOCK) {
+    mockQueue = mockQueue.map((t) => t.id === id ? { ...t, status: 'approved' } : t);
+    return;
+  }
+  await apiClient.post(`/api/moderation/cultural-tags/${id}/approve/`);
+}
+
+export async function rejectTag(id) {
+  if (USE_MOCK) {
+    mockQueue = mockQueue.map((t) => t.id === id ? { ...t, status: 'rejected' } : t);
+    return;
+  }
+  await apiClient.post(`/api/moderation/cultural-tags/${id}/reject/`);
+}


### PR DESCRIPTION
## Summary
- New `/admin/moderation` page (ProtectedRoute) for reviewing user-submitted cultural tags
- Three-tab view: **Pending / Approved / Rejected** with counts
- Each pending item shows tag value, type badge (Region / Event / Tradition), submitter, and date
- Approve / Reject actions update state optimistically and re-fetch queue
- Wires to `/api/moderation/cultural-tags/` when backend is ready

## Test plan
- [ ] Log in (mock), visit `/admin/moderation`
- [ ] 5 pending tags visible by default
- [ ] Approve a tag → moves to Approved tab
- [ ] Reject a tag → moves to Rejected tab with reduced opacity
- [ ] Approved / Rejected tabs show historical items without action buttons