### PR TITLE
style(frontend): fix WCAG AA contrast violations across typography and color tokens (#352)

### DIFF
--- a/app/frontend/src/components/DailyCulturalSection.css
+++ b/app/frontend/src/components/DailyCulturalSection.css
@@ -46,7 +46,7 @@
 
 .daily-cultural-tags span {
   border: 1px solid var(--color-primary-border);
-  color: var(--color-primary);
+  color: var(--color-primary-text);
   background: var(--color-primary-tint);
   border-radius: 999px;
   padding: 0.15rem 0.55rem;

--- a/app/frontend/src/components/IngredientRow.css
+++ b/app/frontend/src/components/IngredientRow.css
@@ -76,7 +76,7 @@
 }
 
 .combobox-list li.add-new {
-  color: var(--color-primary);
+  color: var(--color-primary-text);
   font-style: italic;
   font-weight: 500;
 }

--- a/app/frontend/src/components/Navbar.css
+++ b/app/frontend/src/components/Navbar.css
@@ -19,7 +19,7 @@
   font-family: var(--font-display);
   font-size: 1.5rem;
   font-weight: 900;
-  color: var(--color-primary);
+  color: var(--color-primary-text);
   text-decoration: none;
   letter-spacing: -0.02em;
 }
@@ -44,7 +44,7 @@
 }
 
 .navbar-link:hover {
-  color: var(--color-primary);
+  color: var(--color-primary-text);
   text-decoration: none;
 }
 

--- a/app/frontend/src/components/RecipeCommentsSection.css
+++ b/app/frontend/src/components/RecipeCommentsSection.css
@@ -66,7 +66,7 @@
 .qa-text-button {
   border: 0;
   background: transparent;
-  color: var(--color-primary);
+  color: var(--color-primary-text);
   font-weight: 700;
   cursor: pointer;
 }
@@ -236,7 +236,7 @@
 .qa-helpful-button-active {
   border-color: var(--color-primary);
   background: var(--color-primary-tint);
-  color: var(--color-primary);
+  color: var(--color-primary-text);
 }
 
 .qa-replies {

--- a/app/frontend/src/components/SearchResultCard.css
+++ b/app/frontend/src/components/SearchResultCard.css
@@ -87,7 +87,7 @@
 .result-personalized {
   font-size: 0.72rem;
   font-weight: 700;
-  color: var(--color-primary);
+  color: var(--color-primary-text);
   background: var(--color-primary-tint);
   border: 1px solid var(--color-primary-border);
   border-radius: 999px;

--- a/app/frontend/src/pages/InboxPage.css
+++ b/app/frontend/src/pages/InboxPage.css
@@ -73,7 +73,7 @@
 
 .compose-recipient {
   font-weight: 600;
-  color: var(--color-primary);
+  color: var(--color-primary-text);
 }
 
 .compose-recipe {
@@ -182,7 +182,7 @@
 
 .thread-recipe-context {
   font-size: 0.8rem;
-  color: var(--color-primary);
+  color: var(--color-primary-text);
   font-weight: 500;
   display: block;
   margin-bottom: 0.2rem;

--- a/app/frontend/src/pages/LoginPage.css
+++ b/app/frontend/src/pages/LoginPage.css
@@ -25,5 +25,5 @@
 
 .auth-footer a {
   font-weight: 600;
-  color: var(--color-primary);
+  color: var(--color-primary-text);
 }

--- a/app/frontend/src/pages/NotFoundPage.css
+++ b/app/frontend/src/pages/NotFoundPage.css
@@ -6,7 +6,7 @@
 .not-found-heading {
   font-size: clamp(4rem, 12vw, 8rem);
   font-weight: 900;
-  color: var(--color-primary);
+  color: var(--color-primary-text);
   line-height: 1;
   margin-bottom: 1rem;
 }

--- a/app/frontend/src/pages/RecipeDetailPage.css
+++ b/app/frontend/src/pages/RecipeDetailPage.css
@@ -29,7 +29,7 @@
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  color: var(--color-primary);
+  color: var(--color-primary-text);
   background: var(--color-primary-tint);
   padding: 0.25rem 0.75rem;
   border-radius: var(--radius-pill);

--- a/app/frontend/src/pages/RecipeListPage.css
+++ b/app/frontend/src/pages/RecipeListPage.css
@@ -55,7 +55,7 @@
   display: inline-block;
   font-size: 0.75rem;
   font-weight: 600;
-  color: var(--color-accent-green);
+  color: var(--color-accent-green-text);
   background: var(--color-accent-green-tint);
   border-radius: var(--radius-pill);
   padding: 0.2rem 0.65rem;

--- a/app/frontend/src/pages/SearchPage.css
+++ b/app/frontend/src/pages/SearchPage.css
@@ -147,7 +147,7 @@
 .rich-chip-include {
   border-color: var(--color-primary);
   background: var(--color-primary-tint);
-  color: var(--color-primary);
+  color: var(--color-primary-text);
 }
 
 .rich-chip-exclude {
@@ -199,7 +199,7 @@
   font-family: var(--font-body);
   font-size: 0.8125rem;
   font-weight: 600;
-  color: var(--color-primary);
+  color: var(--color-primary-text);
   background: var(--color-primary-tint);
   border: 1.5px solid var(--color-primary-border);
   border-radius: var(--radius-pill);

--- a/app/frontend/src/pages/StoryListPage.css
+++ b/app/frontend/src/pages/StoryListPage.css
@@ -76,7 +76,7 @@
   display: inline-block;
   font-size: 0.75rem;
   font-weight: 600;
-  color: var(--color-primary);
+  color: var(--color-primary-text);
   background: var(--color-primary-tint);
   border-radius: var(--radius-pill);
   padding: 0.2rem 0.65rem;

--- a/app/frontend/src/pages/ThreadPage.css
+++ b/app/frontend/src/pages/ThreadPage.css
@@ -20,7 +20,7 @@
 .thread-back {
   font-size: 0.9rem;
   font-weight: 600;
-  color: var(--color-primary);
+  color: var(--color-primary-text);
   text-decoration: none;
   transition: opacity 0.15s;
 }
@@ -125,7 +125,7 @@
 }
 
 .bubble-time {
-  font-size: 0.7rem;
+  font-size: 0.75rem;
   color: var(--color-text-muted);
   margin-top: 0.2rem;
   padding: 0 0.25rem;

--- a/app/frontend/src/styles/global.css
+++ b/app/frontend/src/styles/global.css
@@ -22,6 +22,11 @@
   --color-accent-green-tint: rgba(74, 140, 111, 0.10);
   --color-accent-green-border: rgba(74, 140, 111, 0.30);
 
+  /* WCAG AA-compliant text variants (≥ 4.5:1 on --color-surface) */
+  --color-primary-text:       #A3401A; /* 5.93:1 — use for inline text, links */
+  --color-accent-green-text:  #2D6A4F; /* 5.97:1 — use for green inline text  */
+  --color-accent-mustard-text:#5C4300; /* 8.69:1 — use for mustard inline text */
+
   --font-display: 'Fraunces', Georgia, serif;
   --font-body: 'DM Sans', system-ui, sans-serif;
 
@@ -45,6 +50,7 @@
 
 body {
   font-family: var(--font-body);
+  font-size: 1rem;
   background-color: var(--color-bg);
   color: var(--color-text);
   min-height: 100vh;
@@ -59,7 +65,7 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 a {
-  color: var(--color-primary);
+  color: var(--color-primary-text);
   text-decoration: none;
 }
 
@@ -157,22 +163,22 @@ a:hover {
 .btn:hover { text-decoration: none; }
 
 .btn-primary {
-  background: var(--color-primary);
-  color: var(--color-surface);
-  border-color: var(--color-primary);
+  background: var(--color-primary-text);
+  color: #ffffff;
+  border-color: var(--color-primary-text);
 }
 
 .btn-primary:hover {
-  background: var(--color-primary-hover);
-  border-color: var(--color-primary-hover);
+  background: var(--color-primary);
+  border-color: var(--color-primary);
   transform: translateY(-1px);
   box-shadow: var(--shadow-md);
-  color: var(--color-surface);
+  color: #ffffff;
 }
 
 .btn-outline {
   background: transparent;
-  color: var(--color-primary);
+  color: var(--color-primary-text);
   border-color: var(--color-primary);
 }
 
@@ -199,13 +205,13 @@ a:hover {
 }
 
 .btn:focus-visible {
-  outline: 2px solid var(--color-primary);
-  outline-offset: 2px;
+  outline: 3px solid var(--color-primary-text);
+  outline-offset: 3px;
   box-shadow: var(--shadow-focus);
 }
 
 a:focus-visible {
-  outline: 2px solid var(--color-primary);
+  outline: 3px solid var(--color-primary-text);
   outline-offset: 2px;
   border-radius: 2px;
 }


### PR DESCRIPTION
## Summary
- Added accessible text color tokens to `global.css`:
  - `--color-primary-text: #A3401A` (5.93:1 on cream — replaces #C4521E for text)
  - `--color-accent-green-text: #2D6A4F` (5.97:1)
  - `--color-accent-mustard-text: #5C4300` (8.69:1)
- Fixed all `color: var(--color-primary)` text uses across 14 CSS files → `--color-primary-text`
- Fixed all `color: var(--color-accent-green)` text uses → `--color-accent-green-text`
- Fixed `btn-primary` text (#FAF7EF on #C4521E was 4.29:1 — FAILS) → #ffffff on #A3401A (6.35:1 ✓)
- Fixed `btn-outline` text color → `--color-primary-text`
- Fixed global link `a { color }` → `--color-primary-text`
- Bumped minimum badge font size from 0.7rem to 0.75rem
- Explicit `font-size: 1rem` on body

## Test plan
- [ ] Run the app and visually confirm buttons, links, region tags still render correctly
- [ ] Check contrast of primary text, links, and badges with a contrast checker tool