### PR TITLE
feat(frontend): keyboard navigation — skip link, focus rings, and search shortcut (#353)

### DIFF
--- a/app/frontend/src/App.js
+++ b/app/frontend/src/App.js
@@ -1,5 +1,6 @@
 import { Routes, Route } from 'react-router-dom';
 import Navbar from './components/Navbar';
+import SkipLink from './components/SkipLink';
 import ProtectedRoute from './components/ProtectedRoute';
 import HomePage from './pages/HomePage';
 import LoginPage from './pages/LoginPage';
@@ -25,8 +26,9 @@ import NotFoundPage from './pages/NotFoundPage';
 export default function App() {
   return (
     <>
+      <SkipLink />
       <Navbar />
-      <div className="page-wrapper">
+      <div className="page-wrapper" id="main-content">
         <Routes>
           <Route path="/" element={<HomePage />} />
           <Route path="/login" element={<LoginPage />} />

--- a/app/frontend/src/components/Navbar.css
+++ b/app/frontend/src/components/Navbar.css
@@ -48,6 +48,12 @@
   text-decoration: none;
 }
 
+.navbar-link.active,
+.navbar-link[aria-current="page"] {
+  color: var(--color-primary);
+  font-weight: 600;
+}
+
 .navbar-username {
   font-size: 0.875rem;
   font-weight: 500;
@@ -61,7 +67,7 @@
 
 .navbar-brand:focus-visible,
 .navbar-link:focus-visible {
-  outline: 2px solid var(--color-primary);
+  outline: 3px solid var(--color-primary);
   outline-offset: 3px;
   border-radius: 3px;
 }

--- a/app/frontend/src/components/SkipLink.css
+++ b/app/frontend/src/components/SkipLink.css
@@ -1,0 +1,20 @@
+.skip-link {
+  position: absolute;
+  top: -100%;
+  left: 1rem;
+  z-index: 9999;
+  background: var(--color-surface-dark);
+  color: var(--color-text-on-dark);
+  padding: 0.75rem 1.25rem;
+  border-radius: 0 0 var(--radius-md) var(--radius-md);
+  font-weight: 700;
+  font-size: 0.9375rem;
+  text-decoration: none;
+  transition: top 0.15s;
+}
+
+.skip-link:focus {
+  top: 0;
+  outline: 3px solid var(--color-primary);
+  outline-offset: 2px;
+}

--- a/app/frontend/src/components/SkipLink.jsx
+++ b/app/frontend/src/components/SkipLink.jsx
@@ -1,0 +1,9 @@
+import './SkipLink.css';
+
+export default function SkipLink() {
+  return (
+    <a href="#main-content" className="skip-link">
+      Skip to main content
+    </a>
+  );
+}

--- a/app/frontend/src/hooks/useKeyboardShortcuts.js
+++ b/app/frontend/src/hooks/useKeyboardShortcuts.js
@@ -1,0 +1,15 @@
+import { useEffect } from 'react';
+
+export default function useKeyboardShortcuts(shortcuts) {
+  useEffect(() => {
+    function handler(e) {
+      // Ignore when typing in an input/textarea/select
+      const tag = document.activeElement?.tagName;
+      if (['INPUT', 'TEXTAREA', 'SELECT'].includes(tag)) return;
+      const fn = shortcuts[e.key];
+      if (fn) { e.preventDefault(); fn(e); }
+    }
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [shortcuts]);
+}

--- a/app/frontend/src/pages/HomePage.jsx
+++ b/app/frontend/src/pages/HomePage.jsx
@@ -1,9 +1,10 @@
-import { useState, useEffect, useContext, useMemo } from 'react';
+import { useState, useEffect, useContext, useMemo, useRef } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { AuthContext } from '../context/AuthContext';
 import { fetchRegions } from '../services/searchService';
 import { fetchDailyCulturalContent } from '../services/culturalContentService';
 import DailyCulturalSection from '../components/DailyCulturalSection';
+import useKeyboardShortcuts from '../hooks/useKeyboardShortcuts';
 import './HomePage.css';
 
 export default function HomePage() {
@@ -16,6 +17,10 @@ export default function HomePage() {
   const [mealType, setMealType] = useState('');
   const [regions, setRegions] = useState([]);
   const [dailyCards, setDailyCards] = useState([]);
+  const searchInputRef = useRef(null);
+
+  // Press "/" to focus the search box
+  useKeyboardShortcuts({ '/': () => searchInputRef.current?.focus() });
   const [dismissedNudge, setDismissedNudge] = useState(() => localStorage.getItem('onboarding_nudge_dismissed') === 'true');
 
   useEffect(() => {
@@ -89,12 +94,14 @@ export default function HomePage() {
           <label htmlFor="search-input" className="sr-only">Search</label>
           <input
             id="search-input"
+            ref={searchInputRef}
             role="searchbox"
             type="search"
             value={q}
             onChange={(e) => setQ(e.target.value)}
-            placeholder="Search recipes and stories…"
+            placeholder="Search recipes and stories… (press / to focus)"
             className="home-search-input"
+            aria-label="Search recipes and stories"
           />
           <button type="submit" className="btn btn-primary home-search-btn">Search</button>
         </div>

--- a/app/frontend/src/styles/global.css
+++ b/app/frontend/src/styles/global.css
@@ -204,6 +204,19 @@ a:hover {
   padding: 0.4rem 1rem;
 }
 
+/* ── Focus rings (#353) ─────────────────── */
+/* Single consistent ring used by all interactive elements */
+:focus-visible {
+  outline: 3px solid var(--color-primary);
+  outline-offset: 3px;
+  border-radius: 3px;
+}
+
+/* Suppress default :focus when :focus-visible is supported */
+:focus:not(:focus-visible) {
+  outline: none;
+}
+
 .btn:focus-visible {
   outline: 3px solid var(--color-primary-text);
   outline-offset: 3px;
@@ -214,6 +227,29 @@ a:focus-visible {
   outline: 3px solid var(--color-primary-text);
   outline-offset: 2px;
   border-radius: 2px;
+}
+
+/* Form inputs: keep border glow on :focus (visible even without keyboard) */
+.form-group input:focus-visible,
+.form-group textarea:focus-visible,
+.form-group select:focus-visible {
+  outline: 3px solid var(--color-primary);
+  outline-offset: 0;
+  border-color: var(--color-primary);
+  box-shadow: var(--shadow-focus);
+}
+
+/* Minimum touch / click target size (WCAG 2.5.5) */
+.btn,
+input[type="checkbox"],
+input[type="radio"] {
+  min-height: 2.75rem;
+}
+
+input[type="checkbox"],
+input[type="radio"] {
+  min-width: 1.25rem;
+  min-height: 1.25rem;
 }
 
 /* ── Responsive ──────────────────────────── */


### PR DESCRIPTION
## Summary
- **Skip link**: "Skip to main content" appears on Tab press, jumps to `#main-content`
- **Global focus rings**: consistent `3px solid --color-primary` `:focus-visible` on all interactive elements; suppresses `:focus` when not keyboard-triggered
- **Minimum touch targets**: `.btn` min-height 2.75rem (WCAG 2.5.5)
- **Search shortcut**: press `/` anywhere (outside inputs) to focus the homepage search box
- **Navbar active state**: `.navbar-link.active` highlighted with `--color-primary` and bold weight
- `useKeyboardShortcuts` hook for adding shortcuts to any page

## Test plan
- [ ] Tab through the homepage — skip link appears as first focus stop
- [ ] Tab through navbar — all links get visible focus ring
- [ ] Press `/` on homepage — search input is focused
- [ ] Tab into form inputs — visible focus ring with border glow