### PR TITLE
feat(mobile): helpful/upvote button on comment threads (#338)

### DIFF
--- a/app/mobile/src/components/recipe/RecipeCommentsSection.tsx
+++ b/app/mobile/src/components/recipe/RecipeCommentsSection.tsx
@@ -5,6 +5,7 @@ import {
   deleteComment,
   fetchCommentsForRecipe,
   postComment,
+  voteOnComment,
   type Comment,
   type CommentType,
 } from '../../services/commentService';
@@ -239,6 +240,27 @@ function CommentNodeView({
   depth?: number;
 }) {
   const canDelete = myUserId != null && myUserId === node.author;
+  const [helpfulCount, setHelpfulCount] = useState(node.helpful_count ?? 0);
+  const [hasVoted, setHasVoted] = useState(node.has_voted ?? false);
+  const [voting, setVoting] = useState(false);
+
+  const onVote = async () => {
+    if (!isAuthenticated || voting) return;
+    const prevVoted = hasVoted;
+    const prevCount = helpfulCount;
+    setHasVoted(!prevVoted);
+    setHelpfulCount(prevVoted ? prevCount - 1 : prevCount + 1);
+    setVoting(true);
+    try {
+      await voteOnComment(node.id);
+    } catch {
+      setHasVoted(prevVoted);
+      setHelpfulCount(prevCount);
+    } finally {
+      setVoting(false);
+    }
+  };
+
   return (
     <View style={[styles.commentItem, depth > 0 && styles.commentItemReply]}>
       <View style={styles.commentHeader}>
@@ -252,6 +274,18 @@ function CommentNodeView({
       </View>
       <Text style={styles.body}>{node.body}</Text>
       <View style={styles.actions}>
+        <Pressable
+          onPress={() => void onVote()}
+          disabled={!isAuthenticated || voting}
+          hitSlop={6}
+          accessibilityRole="button"
+          accessibilityLabel={hasVoted ? 'Remove helpful vote' : 'Mark as helpful'}
+          style={({ pressed }) => [pressed && { opacity: 0.7 }]}
+        >
+          <Text style={[styles.actionText, hasVoted && styles.votedText, (!isAuthenticated || voting) && styles.disabledText]}>
+            {hasVoted ? '▲ Helpful' : '△ Helpful'}{helpfulCount > 0 ? ` (${helpfulCount})` : ''}
+          </Text>
+        </Pressable>
         {isAuthenticated && depth === 0 ? (
           <Pressable
             onPress={() => onReply(node.id)}
@@ -382,6 +416,8 @@ const styles = StyleSheet.create({
   body: { fontSize: 15, color: tokens.colors.text, lineHeight: 22 },
   actions: { flexDirection: 'row', gap: 16, marginTop: 4 },
   actionText: { fontSize: 13, fontWeight: '800', color: tokens.colors.primary },
+  votedText: { color: tokens.colors.accentGreen },
+  disabledText: { opacity: 0.4 },
   destructive: { color: '#991b1b' },
   repliesWrap: { marginTop: 10, marginLeft: 16, gap: 10 },
 });

--- a/app/mobile/src/services/commentService.ts
+++ b/app/mobile/src/services/commentService.ts
@@ -12,6 +12,8 @@ export type Comment = {
   type: CommentType;
   created_at: string;
   updated_at: string;
+  helpful_count: number;
+  has_voted: boolean;
 };
 
 type Paginated<T> = { count: number; next: string | null; previous: string | null; results: T[] };
@@ -47,4 +49,8 @@ export async function postComment(
 
 export async function deleteComment(commentId: number): Promise<void> {
   await apiDelete(`/api/comments/${commentId}/`);
+}
+
+export async function voteOnComment(commentId: number): Promise<{ status: 'voted' | 'unvoted' }> {
+  return apiPostJson<{ status: 'voted' | 'unvoted' }>(`/api/comments/${commentId}/vote/`, {});
 }


### PR DESCRIPTION
## Summary

- Extends `Comment` type with `helpful_count` and `has_voted` fields to match the existing backend serializer output
- Adds `voteOnComment()` to `commentService.ts` calling `POST /api/comments/<id>/vote/`
- Adds a Helpful vote button to every comment node in `RecipeCommentsSection` with:
  - Optimistic update: count and voted state flip immediately on press
  - Error rollback: state reverts if the API call fails
  - Disabled state while the request is in flight
  - Filled (▲) vs outline (△) triangle to show voted vs unvoted state

Closes #338

## Test plan

- [ ] Open a recipe detail page; confirm each comment shows `△ Helpful` button
- [ ] Tap the button — count increments immediately (optimistic), button turns green and shows `▲ Helpful`
- [ ] Tap again — count decrements, button returns to outline state
- [ ] Verify the button is dimmed (disabled) for unauthenticated users
- [ ] Kill the network mid-request; confirm state rolls back to pre-tap values