### PR TITLE
feat(mobile): cultural onboarding wizard (#344)

### DIFF
--- a/app/mobile/src/context/AuthContext.tsx
+++ b/app/mobile/src/context/AuthContext.tsx
@@ -20,6 +20,7 @@ export type AuthContextValue = {
   isReady: boolean;
   login: (userData: AuthUser, accessToken: string) => Promise<void>;
   logout: () => Promise<void>;
+  updateUser: (userData: AuthUser) => Promise<void>;
 };
 
 const AuthContext = createContext<AuthContextValue | null>(null);
@@ -66,9 +67,14 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     await AsyncStorage.multiRemove([TOKEN_KEY, USER_KEY]);
   }, []);
 
+  const updateUser = useCallback(async (userData: AuthUser) => {
+    setUser(userData);
+    await AsyncStorage.setItem(USER_KEY, JSON.stringify(userData));
+  }, []);
+
   const value = useMemo(
-    () => ({ user, token, isAuthenticated: Boolean(token), isReady, login, logout }),
-    [user, token, isReady, login, logout]
+    () => ({ user, token, isAuthenticated: Boolean(token), isReady, login, logout, updateUser }),
+    [user, token, isReady, login, logout, updateUser]
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/app/mobile/src/navigation/PublicStackNavigator.tsx
+++ b/app/mobile/src/navigation/PublicStackNavigator.tsx
@@ -3,6 +3,7 @@ import HomeScreen from '../screens/HomeScreen';
 import InboxScreen from '../screens/InboxScreen';
 import LoginScreen from '../screens/LoginScreen';
 import MessageThreadScreen from '../screens/MessageThreadScreen';
+import OnboardingScreen from '../screens/OnboardingScreen';
 import RecipeCreateScreen from '../screens/RecipeCreateScreen';
 import RecipeDetailScreen from '../screens/RecipeDetailScreen';
 import RecipeEditScreen from '../screens/RecipeEditScreen';
@@ -86,6 +87,11 @@ export function PublicStackNavigator() {
         name="MessageThread"
         component={MessageThreadScreen}
         options={{ title: 'Conversation' }}
+      />
+      <Stack.Screen
+        name="Onboarding"
+        component={OnboardingScreen}
+        options={{ title: 'Cultural Onboarding' }}
       />
     </Stack.Navigator>
   );

--- a/app/mobile/src/navigation/types.ts
+++ b/app/mobile/src/navigation/types.ts
@@ -18,6 +18,7 @@ export type RootStackParamList = {
     otherUserId?: number | string;
     otherUsername?: string;
   };
+  Onboarding: undefined;
 };
 
 declare global {

--- a/app/mobile/src/screens/OnboardingScreen.tsx
+++ b/app/mobile/src/screens/OnboardingScreen.tsx
@@ -1,0 +1,315 @@
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useAuth } from '../context/AuthContext';
+import { updateMe } from '../services/authService';
+import { tokens } from '../theme';
+import type { RootStackParamList } from '../navigation/types';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'Onboarding'>;
+
+const SKIP_FLAG = 'onboarding_skipped';
+
+type StepKey =
+  | 'cultural_interests'
+  | 'regional_ties'
+  | 'religious_preferences'
+  | 'event_interests';
+
+type Step = {
+  key: StepKey;
+  title: string;
+  description: string;
+  options: string[];
+};
+
+const STEPS: Step[] = [
+  {
+    key: 'cultural_interests',
+    title: 'Cultural Interests',
+    description: 'Choose cuisines and traditions you want to explore.',
+    options: ['Ottoman', 'Anatolian', 'Balkan', 'Levantine', 'Mediterranean', 'Central Asian'],
+  },
+  {
+    key: 'regional_ties',
+    title: 'Regional Ties',
+    description: 'Select regions connected to your family or roots.',
+    options: ['Aegean', 'Marmara', 'Central Anatolia', 'Black Sea', 'Mediterranean', 'Southeastern Anatolia'],
+  },
+  {
+    key: 'religious_preferences',
+    title: 'Dietary / Religious Preferences',
+    description: 'Pick preferences to personalize recommendations.',
+    options: ['Halal', 'Kosher', 'Vegetarian', 'Vegan', 'Pescetarian', 'No Preference'],
+  },
+  {
+    key: 'event_interests',
+    title: 'Event Interests',
+    description: 'Choose occasions you cook for most often.',
+    options: ['Ramadan', 'Eid', 'Weddings', 'Family Gatherings', 'Religious Holidays', 'Weeknight Meals'],
+  },
+];
+
+function normalizeList(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((v) => typeof v === 'string') : [];
+}
+
+export default function OnboardingScreen({ navigation }: Props) {
+  const { user, updateUser } = useAuth();
+  const [stepIndex, setStepIndex] = useState(0);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [values, setValues] = useState<Record<StepKey, string[]>>(() => ({
+    cultural_interests: normalizeList(user?.cultural_interests),
+    regional_ties: normalizeList(user?.regional_ties),
+    religious_preferences: normalizeList(user?.religious_preferences),
+    event_interests: normalizeList(user?.event_interests),
+  }));
+
+  const current = STEPS[stepIndex];
+  const progress = Math.round(((stepIndex + 1) / STEPS.length) * 100);
+
+  const isComplete = useMemo(
+    () => STEPS.every((step) => Array.isArray(values[step.key])),
+    [values],
+  );
+
+  const toggleValue = (option: string) => {
+    setValues((prev) => {
+      const currentValues = prev[current.key];
+      const exists = currentValues.includes(option);
+      const next = exists
+        ? currentValues.filter((item) => item !== option)
+        : [...currentValues, option];
+      return { ...prev, [current.key]: next };
+    });
+  };
+
+  const handleSkip = async () => {
+    await AsyncStorage.setItem(SKIP_FLAG, 'true');
+    navigation.popToTop();
+  };
+
+  const handleFinish = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      const updated = await updateMe(values);
+      await updateUser({ ...(user ?? ({} as never)), ...updated });
+      await AsyncStorage.removeItem(SKIP_FLAG);
+      navigation.popToTop();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not save onboarding preferences.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
+      <ScrollView contentContainerStyle={styles.container} keyboardShouldPersistTaps="handled">
+        <View style={styles.header}>
+          <Text style={styles.heading} accessibilityRole="header">
+            Cultural Onboarding
+          </Text>
+          <Text style={styles.subheading}>
+            Help us personalize recipes, stories, and recommendations for you.
+          </Text>
+          <View style={styles.progressTrack} accessibilityLabel="Onboarding progress">
+            <View style={[styles.progressFill, { width: `${progress}%` }]} />
+          </View>
+          <Text style={styles.stepLabel}>
+            Step {stepIndex + 1} of {STEPS.length}
+          </Text>
+        </View>
+
+        <View style={styles.stepCard}>
+          <Text style={styles.stepTitle}>{current.title}</Text>
+          <Text style={styles.stepDesc}>{current.description}</Text>
+          <View style={styles.options}>
+            {current.options.map((option) => {
+              const checked = values[current.key].includes(option);
+              return (
+                <Pressable
+                  key={option}
+                  onPress={() => toggleValue(option)}
+                  accessibilityRole="checkbox"
+                  accessibilityState={{ checked }}
+                  accessibilityLabel={option}
+                  style={({ pressed }) => [
+                    styles.chip,
+                    checked && styles.chipActive,
+                    pressed && { opacity: 0.85 },
+                  ]}
+                >
+                  <Text style={[styles.chipText, checked && styles.chipTextActive]}>{option}</Text>
+                </Pressable>
+              );
+            })}
+          </View>
+        </View>
+
+        {error ? <Text style={styles.errorText}>{error}</Text> : null}
+
+        <View style={styles.actions}>
+          <Pressable
+            onPress={() => setStepIndex((prev) => Math.max(0, prev - 1))}
+            disabled={stepIndex === 0 || saving}
+            accessibilityRole="button"
+            accessibilityLabel="Back"
+            style={({ pressed }) => [
+              styles.btn,
+              styles.btnOutline,
+              (stepIndex === 0 || saving) && styles.btnDisabled,
+              pressed && { opacity: 0.85 },
+            ]}
+          >
+            <Text style={styles.btnOutlineText}>Back</Text>
+          </Pressable>
+
+          <View style={styles.rightActions}>
+            <Pressable
+              onPress={handleSkip}
+              disabled={saving}
+              accessibilityRole="button"
+              accessibilityLabel="Skip onboarding for now"
+              style={({ pressed }) => [
+                styles.btn,
+                styles.btnOutline,
+                saving && styles.btnDisabled,
+                pressed && { opacity: 0.85 },
+              ]}
+            >
+              <Text style={styles.btnOutlineText}>Skip for now</Text>
+            </Pressable>
+
+            {stepIndex < STEPS.length - 1 ? (
+              <Pressable
+                onPress={() => setStepIndex((prev) => Math.min(STEPS.length - 1, prev + 1))}
+                disabled={saving}
+                accessibilityRole="button"
+                accessibilityLabel="Next step"
+                style={({ pressed }) => [
+                  styles.btn,
+                  styles.btnPrimary,
+                  saving && styles.btnDisabled,
+                  pressed && { opacity: 0.85 },
+                ]}
+              >
+                <Text style={styles.btnPrimaryText}>Next</Text>
+              </Pressable>
+            ) : (
+              <Pressable
+                onPress={handleFinish}
+                disabled={!isComplete || saving}
+                accessibilityRole="button"
+                accessibilityLabel="Finish onboarding"
+                style={({ pressed }) => [
+                  styles.btn,
+                  styles.btnPrimary,
+                  (!isComplete || saving) && styles.btnDisabled,
+                  pressed && { opacity: 0.85 },
+                ]}
+              >
+                {saving ? (
+                  <ActivityIndicator color="#FAF7EF" />
+                ) : (
+                  <Text style={styles.btnPrimaryText}>Finish</Text>
+                )}
+              </Pressable>
+            )}
+          </View>
+        </View>
+
+        <Text style={styles.helpText}>
+          You can update these preferences later from your profile.
+        </Text>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: tokens.colors.surface },
+  container: { padding: 16, gap: 18, paddingBottom: 40 },
+  header: { gap: 8 },
+  heading: { fontSize: 24, fontWeight: '900', color: tokens.colors.text },
+  subheading: { fontSize: 14, color: tokens.colors.textMuted, lineHeight: 20 },
+  progressTrack: {
+    height: 8,
+    borderRadius: tokens.radius.pill,
+    backgroundColor: 'rgba(0,0,0,0.12)',
+    overflow: 'hidden',
+    marginTop: 8,
+  },
+  progressFill: {
+    height: '100%',
+    backgroundColor: tokens.colors.accentGreen,
+  },
+  stepLabel: {
+    fontSize: 12,
+    fontWeight: '800',
+    color: tokens.colors.surfaceDark,
+    letterSpacing: 0.4,
+  },
+  stepCard: {
+    padding: 16,
+    borderRadius: tokens.radius.lg,
+    backgroundColor: tokens.colors.surfaceInput,
+    borderWidth: 1,
+    borderColor: tokens.colors.border,
+    gap: 12,
+  },
+  stepTitle: { fontSize: 18, fontWeight: '900', color: tokens.colors.text },
+  stepDesc: { fontSize: 14, color: tokens.colors.textMuted, lineHeight: 20 },
+  options: { flexDirection: 'row', flexWrap: 'wrap', gap: 8 },
+  chip: {
+    paddingVertical: 8,
+    paddingHorizontal: 14,
+    borderRadius: tokens.radius.pill,
+    borderWidth: 1.5,
+    borderColor: '#000000',
+    backgroundColor: tokens.colors.accentMustard,
+  },
+  chipActive: {
+    backgroundColor: tokens.colors.accentGreen,
+    borderColor: '#000000',
+  },
+  chipText: { fontSize: 13, fontWeight: '800', color: '#000000' },
+  chipTextActive: { color: '#FAF7EF' },
+  errorText: { color: '#991b1b', fontSize: 13, fontWeight: '700' },
+  actions: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', gap: 8 },
+  rightActions: { flexDirection: 'row', gap: 8 },
+  btn: {
+    paddingVertical: 10,
+    paddingHorizontal: 16,
+    borderRadius: tokens.radius.pill,
+    minWidth: 88,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  btnOutline: {
+    backgroundColor: 'transparent',
+    borderWidth: 1.5,
+    borderColor: tokens.colors.surfaceDark,
+  },
+  btnOutlineText: { color: tokens.colors.surfaceDark, fontWeight: '800', fontSize: 14 },
+  btnPrimary: {
+    backgroundColor: tokens.colors.accentGreen,
+    borderWidth: 1.5,
+    borderColor: '#000000',
+  },
+  btnPrimaryText: { color: '#FAF7EF', fontWeight: '800', fontSize: 14 },
+  btnDisabled: { opacity: 0.5 },
+  helpText: { fontSize: 12, color: tokens.colors.textMuted, textAlign: 'center', marginTop: 4 },
+});

--- a/app/mobile/src/screens/RegisterScreen.tsx
+++ b/app/mobile/src/screens/RegisterScreen.tsx
@@ -44,8 +44,8 @@ export default function RegisterScreen({ navigation }: Props) {
       await login(data.user, data.access);
       navigation.dispatch(
         CommonActions.reset({
-          index: 0,
-          routes: [{ name: 'Home' }],
+          index: 1,
+          routes: [{ name: 'Home' }, { name: 'Onboarding' }],
         })
       );
     } catch (err) {
@@ -190,17 +190,17 @@ const styles = StyleSheet.create({
   fieldError: { color: tokens.colors.error, marginTop: 6, fontSize: 14 },
   apiError: { color: tokens.colors.error, marginBottom: 12, fontSize: 15 },
   primaryButton: {
-    backgroundColor: tokens.colors.accentGreen,
+    backgroundColor: '#EFBF04',
     paddingVertical: 14,
     borderRadius: tokens.radius.pill,
     alignItems: 'center',
     marginTop: 8,
     borderWidth: 2,
-    borderColor: tokens.colors.primary,
+    borderColor: '#000000',
     ...shadows.md,
   },
   primaryButtonPressed: { opacity: 0.88 },
-  primaryButtonText: { color: tokens.colors.text, fontSize: 16, fontWeight: '700' },
+  primaryButtonText: { color: '#000000', fontSize: 16, fontWeight: '800' },
   footer: {
     flexDirection: 'row',
     flexWrap: 'wrap',

--- a/app/mobile/src/screens/tabs/ProfileTabScreen.tsx
+++ b/app/mobile/src/screens/tabs/ProfileTabScreen.tsx
@@ -32,6 +32,15 @@ export default function ProfileTabScreen() {
               </Pressable>
               <View style={{ height: 12 }} />
               <Pressable
+                onPress={() => navigation.navigate('Feed', { screen: 'Onboarding' })}
+                style={({ pressed }) => [styles.secondary, pressed && styles.pressed]}
+                accessibilityRole="button"
+                accessibilityLabel="Update cultural preferences"
+              >
+                <Text style={styles.secondaryText}>Cultural preferences</Text>
+              </Pressable>
+              <View style={{ height: 12 }} />
+              <Pressable
                 onPress={() => void logout()}
                 style={({ pressed }) => [styles.secondary, pressed && styles.pressed]}
                 accessibilityRole="button"
@@ -56,11 +65,11 @@ export default function ProfileTabScreen() {
                 </Pressable>
                 <Pressable
                   onPress={() => navigation.navigate('Feed', { screen: 'Register' })}
-                  style={({ pressed }) => [styles.secondary, pressed && styles.pressed]}
+                  style={({ pressed }) => [styles.registerBtn, pressed && styles.pressed]}
                   accessibilityRole="button"
                   accessibilityLabel="Go to Register"
                 >
-                  <Text style={styles.secondaryText}>Register</Text>
+                  <Text style={styles.registerBtnText}>Register</Text>
                 </Pressable>
               </View>
             </>
@@ -99,7 +108,7 @@ const styles = StyleSheet.create({
     borderRadius: tokens.radius.pill,
     alignItems: 'center',
     borderWidth: 2,
-    borderColor: tokens.colors.primary,
+    borderColor: '#000000',
     ...shadows.md,
     maxWidth: 340,
     alignSelf: 'center',
@@ -116,6 +125,20 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   secondaryText: { color: tokens.colors.text, fontSize: 16, fontWeight: '800' },
+  registerBtn: {
+    flex: 1,
+    backgroundColor: '#EFBF04',
+    paddingVertical: 12,
+    paddingHorizontal: 14,
+    borderRadius: tokens.radius.pill,
+    alignItems: 'center',
+    borderWidth: 2,
+    borderColor: '#000000',
+    ...shadows.md,
+    maxWidth: 340,
+    alignSelf: 'center',
+  },
+  registerBtnText: { color: '#000000', fontSize: 16, fontWeight: '800' },
   pressed: { opacity: 0.9 },
 });
 

--- a/app/mobile/src/services/authService.ts
+++ b/app/mobile/src/services/authService.ts
@@ -1,5 +1,5 @@
-import type { AuthSuccess } from './mockAuthService';
-import { apiPostJson } from './httpClient';
+import type { AuthSuccess, AuthUser } from './mockAuthService';
+import { apiPatchJson, apiPostJson } from './httpClient';
 
 /**
  * Real backend auth service.
@@ -20,5 +20,10 @@ export async function registerRequest(
   password: string
 ): Promise<AuthSuccess> {
   return apiPostJson<AuthSuccess>('/api/auth/register/', { username, email, password });
+}
+
+/** PATCH /api/users/me/ — same shape as web `updateMe` in `authService.js`. */
+export async function updateMe(payload: Partial<AuthUser>): Promise<AuthUser> {
+  return apiPatchJson<AuthUser>('/api/users/me/', payload);
 }
 

--- a/app/mobile/src/services/mockAuthService.ts
+++ b/app/mobile/src/services/mockAuthService.ts
@@ -7,6 +7,11 @@ export type AuthUser = {
   id: string;
   username: string;
   email: string;
+  cultural_interests?: string[];
+  regional_ties?: string[];
+  religious_preferences?: string[];
+  event_interests?: string[];
+  is_contactable?: boolean;
 };
 
 export type AuthSuccess = {


### PR DESCRIPTION
Closes #344. Mobile side of the cultural onboarding flow (web shipped in #429).

Four-step wizard — interests, regional ties, dietary, events — same options
and field keys as `OnboardingPage.jsx`. Multi-select chips, progress bar,
Back / Skip / Next / Finish.

Finish hits `PATCH /api/users/me/` (from #420) and updates AuthContext.
Skip just sets the `onboarding_skipped` flag and goes home, like web does.

You get into it two ways:
- right after registering, the stack resets to `[Home, Onboarding]`
- from the Profile tab, via a new "Cultural preferences" button — that's the
  "soft nudge to complete later" the issue asked for

Re-opening from Profile shows your previous picks already selected.

Also bundled in: yellow pill Register button (#EFBF04, black outline) on the
Register screen and Profile tab, since the auth flow is the natural entry.

## Files
- `services/authService.ts` — `updateMe`
- `services/mockAuthService.ts` — extend `AuthUser` with the cultural fields
  and `is_contactable`
- `context/AuthContext.tsx` — `updateUser`
- `screens/OnboardingScreen.tsx` — new
- `screens/RegisterScreen.tsx` — push Onboarding post-register, yellow button
- `screens/tabs/ProfileTabScreen.tsx` — "Cultural preferences" entry
- `navigation/types.ts` + `navigation/PublicStackNavigator.tsx` — register the route

## Test
- [ ] Register → land on Onboarding
- [ ] Pick chips, Next through all steps, Finish → home
- [ ] Skip → home, no API call
- [ ] Profile → Cultural preferences → earlier picks are checked
- [ ] Network down on Finish → error shows, picks kept

Reviewers: @Daglar1500 @mustafaocakxyz @ErenCanOzkaya