### PR TITLE
feat(mobile): rich filter UI for search (#347)

### DIFF
--- a/app/mobile/src/components/search/FilterChipRail.tsx
+++ b/app/mobile/src/components/search/FilterChipRail.tsx
@@ -1,0 +1,106 @@
+import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { tokens } from '../../theme';
+
+export type ChipState = 'off' | 'include' | 'exclude';
+
+type Props = {
+  label: string;
+  options: string[];
+  include: string[];
+  exclude: string[];
+  onChange: (next: { include: string[]; exclude: string[] }) => void;
+  loading?: boolean;
+};
+
+function nextState(current: ChipState): ChipState {
+  return current === 'off' ? 'include' : current === 'include' ? 'exclude' : 'off';
+}
+
+function stateOf(name: string, include: string[], exclude: string[]): ChipState {
+  if (include.includes(name)) return 'include';
+  if (exclude.includes(name)) return 'exclude';
+  return 'off';
+}
+
+export function FilterChipRail({ label, options, include, exclude, onChange, loading }: Props) {
+  const handleToggle = (name: string) => {
+    const cur = stateOf(name, include, exclude);
+    const next = nextState(cur);
+    const inc = include.filter((v) => v !== name);
+    const exc = exclude.filter((v) => v !== name);
+    if (next === 'include') inc.push(name);
+    if (next === 'exclude') exc.push(name);
+    onChange({ include: inc, exclude: exc });
+  };
+
+  return (
+    <View style={styles.section}>
+      <Text style={styles.label}>{label}</Text>
+      {loading ? (
+        <Text style={styles.hint}>Loading…</Text>
+      ) : options.length === 0 ? (
+        <Text style={styles.hint}>No tags available.</Text>
+      ) : (
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={styles.rail}
+          accessibilityRole="tablist"
+        >
+          {options.map((name) => {
+            const state = stateOf(name, include, exclude);
+            return (
+              <Pressable
+                key={name}
+                onPress={() => handleToggle(name)}
+                accessibilityRole="button"
+                accessibilityLabel={`${name} filter, ${state}`}
+                accessibilityState={{ selected: state !== 'off' }}
+                style={({ pressed }) => [
+                  styles.chip,
+                  state === 'include' && styles.chipInclude,
+                  state === 'exclude' && styles.chipExclude,
+                  pressed && { opacity: 0.85 },
+                ]}
+              >
+                <Text
+                  style={[
+                    styles.chipText,
+                    state === 'include' && styles.chipTextInclude,
+                    state === 'exclude' && styles.chipTextExclude,
+                  ]}
+                >
+                  {state === 'exclude' ? `− ${name}` : state === 'include' ? `+ ${name}` : name}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </ScrollView>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  section: { gap: 6 },
+  label: { fontSize: 13, fontWeight: '900', color: tokens.colors.surfaceDark, letterSpacing: 0.4 },
+  hint: { fontSize: 12, color: tokens.colors.textMuted, fontStyle: 'italic' },
+  rail: { gap: 8, paddingVertical: 4 },
+  chip: {
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    borderRadius: tokens.radius.pill,
+    borderWidth: 1.5,
+    borderColor: '#000000',
+    backgroundColor: tokens.colors.accentMustard,
+  },
+  chipInclude: {
+    backgroundColor: tokens.colors.accentGreen,
+  },
+  chipExclude: {
+    backgroundColor: '#B33A3A',
+  },
+  chipText: { fontSize: 13, fontWeight: '800', color: '#000000' },
+  chipTextInclude: { color: '#FAF7EF' },
+  chipTextExclude: { color: '#FAF7EF', textDecorationLine: 'line-through' },
+});

--- a/app/mobile/src/screens/SearchScreen.tsx
+++ b/app/mobile/src/screens/SearchScreen.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   FlatList,
   Pressable,
+  ScrollView,
   StyleSheet,
   Text,
   TextInput,
@@ -10,10 +11,12 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { EmptyState } from '../components/search/EmptyState';
+import { FilterChipRail } from '../components/search/FilterChipRail';
 import { SearchResultCard } from '../components/search/SearchResultCard';
 import type { RootStackParamList } from '../navigation/types';
-import { search, type SearchResultItem } from '../services/searchService';
+import { search, type SearchFilters, type SearchResultItem } from '../services/searchService';
 import { fetchStoryById } from '../services/storyService';
+import { fetchDietaryTags, fetchEventTags } from '../services/tagsService';
 import { shadows, tokens } from '../theme';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Search'>;
@@ -37,6 +40,43 @@ export default function SearchScreen({ navigation, route }: Props) {
   const [error, setError] = useState<string | null>(null);
   const storyThumbCacheRef = useRef<Map<string, string | null>>(new Map());
 
+  const [dietOptions, setDietOptions] = useState<string[]>([]);
+  const [eventOptions, setEventOptions] = useState<string[]>([]);
+  const [tagsLoading, setTagsLoading] = useState(true);
+  const [dietInclude, setDietInclude] = useState<string[]>([]);
+  const [dietExclude, setDietExclude] = useState<string[]>([]);
+  const [eventInclude, setEventInclude] = useState<string[]>([]);
+  const [eventExclude, setEventExclude] = useState<string[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const [diets, events] = await Promise.all([fetchDietaryTags(), fetchEventTags()]);
+        if (cancelled) return;
+        setDietOptions(diets.map((t) => t.name));
+        setEventOptions(events.map((t) => t.name));
+      } catch {
+        if (cancelled) return;
+        setDietOptions([]);
+        setEventOptions([]);
+      } finally {
+        if (!cancelled) setTagsLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const filtersKey = useMemo(
+    () => [...dietInclude, '|', ...dietExclude, '|', ...eventInclude, '|', ...eventExclude].join(','),
+    [dietInclude, dietExclude, eventInclude, eventExclude],
+  );
+
+  const hasActiveFilters =
+    dietInclude.length + dietExclude.length + eventInclude.length + eventExclude.length > 0;
+
   useEffect(() => {
     if (route.params?.query != null) setQuery(route.params.query);
     if (route.params?.region != null) setRegion(route.params.region);
@@ -46,7 +86,7 @@ export default function SearchScreen({ navigation, route }: Props) {
   useEffect(() => {
     const q = query.trim();
     // Keep pristine state empty without calling backend.
-    if (!q && !region.trim()) {
+    if (!q && !region.trim() && !hasActiveFilters) {
       setResults([]);
       setError(null);
       setLoading(false);
@@ -55,9 +95,15 @@ export default function SearchScreen({ navigation, route }: Props) {
     let cancelled = false;
     setLoading(true);
     setError(null);
+    const filters: SearchFilters = {
+      diet: dietInclude,
+      diet_exclude: dietExclude,
+      event: eventInclude,
+      event_exclude: eventExclude,
+    };
     void (async () => {
       try {
-        const data = await search(q, region.trim() || undefined);
+        const data = await search(q, region.trim() || undefined, filters);
         if (cancelled) return;
         setResults(data);
 
@@ -91,12 +137,12 @@ export default function SearchScreen({ navigation, route }: Props) {
     return () => {
       cancelled = true;
     };
-  }, [query, region]);
+  }, [query, region, filtersKey, hasActiveFilters]);
 
   const selectedRegionLabel =
     REGIONS.find((r) => r.value === region)?.label ?? 'All regions';
 
-  const isPristine = query.trim() === '' && region.trim() === '';
+  const isPristine = query.trim() === '' && region.trim() === '' && !hasActiveFilters;
 
   function onPressItem(item: SearchResultItem) {
     if (item.kind === 'recipe') {
@@ -125,7 +171,11 @@ export default function SearchScreen({ navigation, route }: Props) {
 
         <View style={styles.filtersRow}>
           <Text style={styles.filterLabel}>Region</Text>
-          <View style={styles.pills}>
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            contentContainerStyle={styles.regionRail}
+          >
             {REGIONS.map((opt) => {
               const active = opt.value === region;
               return (
@@ -146,7 +196,52 @@ export default function SearchScreen({ navigation, route }: Props) {
                 </Pressable>
               );
             })}
+          </ScrollView>
+        </View>
+
+        <View style={styles.tagFilters}>
+          <View style={styles.tagHeaderRow}>
+            <Text style={styles.filterLabel}>Tags (tap to include, again to exclude)</Text>
+            {hasActiveFilters ? (
+              <Pressable
+                onPress={() => {
+                  setDietInclude([]);
+                  setDietExclude([]);
+                  setEventInclude([]);
+                  setEventExclude([]);
+                  setRegion('');
+                }}
+                hitSlop={10}
+                accessibilityRole="button"
+                accessibilityLabel="Clear all filters"
+                style={({ pressed }) => [styles.clearBtn, pressed && { opacity: 0.85 }]}
+              >
+                <Text style={styles.clearBtnText}>Clear filters</Text>
+              </Pressable>
+            ) : null}
           </View>
+          <FilterChipRail
+            label="Dietary"
+            options={dietOptions}
+            include={dietInclude}
+            exclude={dietExclude}
+            onChange={({ include, exclude }) => {
+              setDietInclude(include);
+              setDietExclude(exclude);
+            }}
+            loading={tagsLoading}
+          />
+          <FilterChipRail
+            label="Event"
+            options={eventOptions}
+            include={eventInclude}
+            exclude={eventExclude}
+            onChange={({ include, exclude }) => {
+              setEventInclude(include);
+              setEventExclude(exclude);
+            }}
+            loading={tagsLoading}
+          />
         </View>
 
         <FlatList
@@ -232,18 +327,29 @@ const styles = StyleSheet.create({
     marginBottom: 8,
     fontFamily: tokens.typography.display.fontFamily,
   },
-  pills: { flexDirection: 'row', flexWrap: 'wrap', gap: 8 },
+  regionRail: { gap: 8, paddingVertical: 4 },
   pill: {
     paddingVertical: 8,
-    paddingHorizontal: 10,
+    paddingHorizontal: 12,
     borderRadius: tokens.radius.pill,
     borderWidth: 2,
-    borderColor: tokens.colors.primary,
+    borderColor: '#000000',
     backgroundColor: 'transparent',
   },
-  pillActive: { backgroundColor: tokens.colors.accentGreen, borderColor: tokens.colors.primary },
-  pillText: { fontSize: 14, fontWeight: '700', color: tokens.colors.text },
-  pillTextActive: { color: tokens.colors.text },
+  pillActive: { backgroundColor: tokens.colors.accentGreen, borderColor: '#000000' },
+  pillText: { fontSize: 13, fontWeight: '800', color: '#000000' },
+  pillTextActive: { color: '#FAF7EF' },
+  tagFilters: { gap: 10, marginBottom: 10 },
+  tagHeaderRow: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', gap: 8 },
+  clearBtn: {
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    borderRadius: tokens.radius.pill,
+    borderWidth: 1.5,
+    borderColor: '#000000',
+    backgroundColor: '#EFBF04',
+  },
+  clearBtnText: { fontSize: 12, fontWeight: '800', color: '#000000' },
   grid: { paddingBottom: 24, gap: 12 },
   gridRow: { gap: 12 },
   gridItem: { flex: 1 },

--- a/app/mobile/src/services/searchService.ts
+++ b/app/mobile/src/services/searchService.ts
@@ -28,10 +28,26 @@ type BackendSearchResponse = {
   total_count?: number;
 };
 
-export async function search(q: string, region?: string): Promise<SearchResultItem[]> {
+export type SearchFilters = {
+  diet?: string[];
+  diet_exclude?: string[];
+  event?: string[];
+  event_exclude?: string[];
+};
+
+export async function search(
+  q: string,
+  region?: string,
+  filters?: SearchFilters,
+): Promise<SearchResultItem[]> {
   const params = new URLSearchParams();
   params.set('q', q);
   if (region) params.set('region', region);
+  if (filters) {
+    for (const [key, values] of Object.entries(filters) as [keyof SearchFilters, string[] | undefined][]) {
+      if (values && values.length > 0) params.set(key, values.join(','));
+    }
+  }
   const data = await apiGetJson<BackendSearchResponse>(`/api/search/?${params.toString()}`);
 
   const recipes = (data.recipes ?? []).map((r) => ({

--- a/app/mobile/src/services/tagsService.ts
+++ b/app/mobile/src/services/tagsService.ts
@@ -1,0 +1,30 @@
+import { apiGetJson } from './httpClient';
+
+export type Tag = { id: number; name: string; is_approved: boolean };
+
+type Paginated<T> = { count: number; next: string | null; previous: string | null; results: T[] };
+
+async function fetchAll(path: string): Promise<Tag[]> {
+  const collected: Tag[] = [];
+  let cursor: string | null = path;
+  while (cursor) {
+    const data: Paginated<Tag> | Tag[] = await apiGetJson<Paginated<Tag> | Tag[]>(cursor);
+    if (Array.isArray(data)) {
+      collected.push(...data);
+      break;
+    }
+    collected.push(...data.results);
+    if (!data.next) break;
+    const u: URL = new URL(data.next);
+    cursor = `${u.pathname}${u.search}`;
+  }
+  return collected.filter((t) => t.is_approved);
+}
+
+export async function fetchDietaryTags(): Promise<Tag[]> {
+  return fetchAll('/api/dietary-tags/');
+}
+
+export async function fetchEventTags(): Promise<Tag[]> {
+  return fetchAll('/api/event-tags/');
+}


### PR DESCRIPTION
Closes #347. Mobile counterpart of the web rich filters (#429, backend #421).

Search now has horizontal rails for Region, Dietary and Event tags. Each tag
chip is tri-state — tap once to include (green `+`), again to exclude
(red `−`), again to clear. Multi-axis filters AND together, same as web.

Tags come from `/api/dietary-tags/` and `/api/event-tags/`. Active filters
get joined to CSV and passed to `/api/search/` as `diet` / `diet_exclude` /
`event` / `event_exclude`.

A "Clear filters" pill in the header wipes everything — region included.
Region pills are now a horizontal rail too, so they stop wrapping on small
screens.

## Files
- `services/tagsService.ts` — new
- `services/searchService.ts` — accept filters
- `components/search/FilterChipRail.tsx` — new tri-state chip rail
- `screens/SearchScreen.tsx` — rails + state + clear button

## Test
- [ ] Tap a Diet/Event tag → results narrow to that tag
- [ ] Tap again → switches to exclude
- [ ] Tap a third time → off
- [ ] Mix axes (e.g. Halal include + Wedding include) → AND together
- [ ] Clear filters resets region + every chip in one tap

Reviewers: @Daglar1500 @mustafaocakxyz @ErenCanOzkaya