### PR TITLE
feat(mobile): contactability toggle (#342)

### DIFF
--- a/app/mobile/src/components/ContactabilityToggle.tsx
+++ b/app/mobile/src/components/ContactabilityToggle.tsx
@@ -1,0 +1,84 @@
+import { useState } from 'react';
+import { Pressable, StyleSheet, Switch, Text, View } from 'react-native';
+import { useAuth } from '../context/AuthContext';
+import { updateMe } from '../services/authService';
+import { tokens } from '../theme';
+
+function readContactable(user: { is_contactable?: boolean } | null): boolean {
+  if (!user) return true;
+  if (typeof user.is_contactable === 'boolean') return user.is_contactable;
+  return true;
+}
+
+export function ContactabilityToggle() {
+  const { user, updateUser } = useAuth();
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!user) return null;
+  const enabled = readContactable(user);
+
+  const handleChange = async (next: boolean) => {
+    if (saving) return;
+    setError(null);
+    setSaving(true);
+    const previous = enabled;
+    await updateUser({ ...user, is_contactable: next });
+    try {
+      const updated = await updateMe({ is_contactable: next });
+      await updateUser({ ...user, ...updated });
+    } catch (e) {
+      await updateUser({ ...user, is_contactable: previous });
+      setError(e instanceof Error ? e.message : 'Could not update messaging preference.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <View style={styles.card} accessibilityLabel="Messaging preferences">
+      <View style={styles.headerRow}>
+        <View style={styles.textCol}>
+          <Text style={styles.title}>Messaging preferences</Text>
+          <Text style={styles.desc}>
+            Allow others to start new message threads with you.
+          </Text>
+        </View>
+        <Switch
+          value={enabled}
+          onValueChange={handleChange}
+          disabled={saving}
+          accessibilityLabel={enabled ? 'Allow new threads' : 'Block new threads'}
+          trackColor={{ false: '#aaa', true: tokens.colors.accentGreen }}
+          thumbColor={'#FAF7EF'}
+        />
+      </View>
+      <Text style={styles.status}>
+        {saving ? 'Updating…' : enabled ? 'Allow new threads' : 'Block new threads'}
+      </Text>
+      {error ? (
+        <Pressable onPress={() => setError(null)} hitSlop={6} accessibilityRole="button">
+          <Text style={styles.error}>{error} (tap to dismiss)</Text>
+        </Pressable>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    margin: 12,
+    padding: 14,
+    borderRadius: tokens.radius.lg,
+    backgroundColor: tokens.colors.surfaceInput,
+    borderWidth: 1,
+    borderColor: tokens.colors.border,
+    gap: 6,
+  },
+  headerRow: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', gap: 12 },
+  textCol: { flex: 1, gap: 2 },
+  title: { fontSize: 15, fontWeight: '900', color: tokens.colors.text },
+  desc: { fontSize: 12, color: tokens.colors.textMuted, lineHeight: 16 },
+  status: { fontSize: 12, fontWeight: '800', color: tokens.colors.surfaceDark },
+  error: { fontSize: 12, fontWeight: '700', color: '#991b1b' },
+});

--- a/app/mobile/src/screens/InboxScreen.tsx
+++ b/app/mobile/src/screens/InboxScreen.tsx
@@ -10,6 +10,7 @@ import {
   View,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { ContactabilityToggle } from '../components/ContactabilityToggle';
 import { ErrorView } from '../components/ui/ErrorView';
 import { LoadingView } from '../components/ui/LoadingView';
 import { useAuth } from '../context/AuthContext';
@@ -102,6 +103,7 @@ export default function InboxScreen({ navigation }: Props) {
     <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
       <FlatList
         data={threads}
+        ListHeaderComponent={<ContactabilityToggle />}
         keyExtractor={(t) => String(t.id)}
         contentContainerStyle={
           threads.length === 0 ? styles.emptyContainer : styles.listContent


### PR DESCRIPTION
Closes #342. Mobile counterpart of the web toggle (web in #429, backend
in #430 — still open).

Adds a "Messaging preferences" Switch at the top of Inbox. Tap to flip,
optimistic update, rollback on error. Hits `PATCH /api/users/me/` with
`{ is_contactable }`. Server enforcement comes from #430 — once that
merges, MessageThread already surfaces the 403 error if the other user
turned new threads off.

## Files
- `components/ContactabilityToggle.tsx` — new, Switch + label + rollback
- `screens/InboxScreen.tsx` — toggle as the FlatList header

## Test
- [ ] Inbox shows the "Messaging preferences" card
- [ ] Default is on (`is_contactable: true`)
- [ ] Tap → optimistic flip + "Updating…"
- [ ] On failure the Switch rolls back, error shown inline

## Known
- Switch visually reverts after save until #430 lands the `is_contactable`
  field on the user response. Tracked in #450.

Reviewers: @Daglar1500 @mustafaocakxyz @ErenCanOzkaya