### PR TITLE
feat(mobile): consume personalization ranking on feed and search (#345)

### DIFF
--- a/app/mobile/src/components/home/RecommendationsRail.tsx
+++ b/app/mobile/src/components/home/RecommendationsRail.tsx
@@ -1,0 +1,104 @@
+import { FlatList, Image, Pressable, StyleSheet, Text, View } from 'react-native';
+import { shadows, tokens } from '../../theme';
+import { RankReasonBadge } from '../personalization/RankReasonBadge';
+import type { RecommendationItem } from '../../services/recommendationsService';
+
+type Props = {
+  items: RecommendationItem[];
+  onItemPress: (item: RecommendationItem) => void;
+};
+
+export function RecommendationsRail({ items, onItemPress }: Props) {
+  if (items.length === 0) return null;
+
+  return (
+    <View style={styles.section}>
+      <View style={styles.header}>
+        <Text style={styles.title}>Recommended for you</Text>
+        <Text style={styles.hint}>Picked from your interests</Text>
+      </View>
+      <FlatList
+        data={items}
+        horizontal
+        keyExtractor={(item) => item.key}
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={styles.list}
+        renderItem={({ item }) => (
+          <Pressable
+            onPress={() => onItemPress(item)}
+            style={({ pressed }) => [styles.card, pressed && styles.cardPressed]}
+            accessibilityRole="button"
+            accessibilityLabel={`Open ${item.kind} ${item.title}`}
+          >
+            <View style={styles.thumbWrap}>
+              {item.image ? (
+                <Image source={{ uri: item.image }} style={styles.thumbImage} resizeMode="cover" />
+              ) : (
+                <View
+                  style={[
+                    styles.thumbPlaceholder,
+                    {
+                      backgroundColor:
+                        item.kind === 'recipe' ? tokens.colors.surfaceDark : tokens.colors.accentGreen,
+                    },
+                  ]}
+                >
+                  <Text style={styles.thumbInitial}>{item.kind === 'recipe' ? 'R' : 'S'}</Text>
+                </View>
+              )}
+            </View>
+            <View style={styles.body}>
+              <Text style={styles.cardTitle} numberOfLines={1}>
+                {item.title}
+              </Text>
+              {item.snippet ? (
+                <Text style={styles.cardSnippet} numberOfLines={2}>
+                  {item.snippet}
+                </Text>
+              ) : null}
+              <View style={styles.metaRow}>
+                <Text style={styles.kind}>{item.kind === 'recipe' ? 'Recipe' : 'Story'}</Text>
+                {item.region ? <Text style={styles.region}>· {item.region}</Text> : null}
+              </View>
+              <RankReasonBadge reason={item.rankReason} style={styles.badge} />
+            </View>
+          </Pressable>
+        )}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  section: { marginTop: 8, marginBottom: 18 },
+  header: { flexDirection: 'row', alignItems: 'baseline', gap: 10, marginBottom: 10 },
+  title: {
+    fontSize: 22,
+    fontWeight: '800',
+    color: tokens.colors.text,
+    fontFamily: tokens.typography.display.fontFamily,
+  },
+  hint: { fontSize: 13, color: tokens.colors.primaryTint, fontWeight: '800' },
+  list: { gap: 12, paddingRight: 16 },
+  card: {
+    width: 240,
+    borderWidth: 1,
+    borderColor: tokens.colors.border,
+    borderRadius: tokens.radius.xl,
+    backgroundColor: tokens.colors.surface,
+    overflow: 'hidden',
+    ...shadows.lg,
+  },
+  cardPressed: { opacity: 0.9 },
+  thumbWrap: { width: '100%', height: 110 },
+  thumbImage: { width: '100%', height: '100%' },
+  thumbPlaceholder: { width: '100%', height: '100%', alignItems: 'center', justifyContent: 'center' },
+  thumbInitial: { color: tokens.colors.text, fontSize: 28, fontWeight: '900' },
+  body: { padding: 12, gap: 6 },
+  cardTitle: { fontSize: 15, fontWeight: '800', color: tokens.colors.text },
+  cardSnippet: { fontSize: 12, color: tokens.colors.textMuted, lineHeight: 16 },
+  metaRow: { flexDirection: 'row', alignItems: 'center', gap: 6 },
+  kind: { fontSize: 11, color: tokens.colors.textMuted, fontWeight: '800', textTransform: 'uppercase' },
+  region: { fontSize: 11, color: tokens.colors.textMuted, fontWeight: '700' },
+  badge: { marginTop: 4 },
+});

--- a/app/mobile/src/components/personalization/RankReasonBadge.tsx
+++ b/app/mobile/src/components/personalization/RankReasonBadge.tsx
@@ -1,0 +1,38 @@
+import { StyleSheet, Text, View, type StyleProp, type ViewStyle } from 'react-native';
+import { tokens } from '../../theme';
+import { rankReasonLabel } from '../../utils/rankReason';
+
+type Props = {
+  reason: string | null | undefined;
+  style?: StyleProp<ViewStyle>;
+};
+
+export function RankReasonBadge({ reason, style }: Props) {
+  const label = rankReasonLabel(reason);
+  if (!label) return null;
+  return (
+    <View style={[styles.pill, style]} accessibilityLabel={`Personalization: ${label}`}>
+      <Text style={styles.label} numberOfLines={1}>
+        {label}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  pill: {
+    alignSelf: 'flex-start',
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: tokens.radius.pill,
+    backgroundColor: tokens.colors.accentGreen,
+    borderWidth: 1,
+    borderColor: tokens.colors.surfaceDark,
+  },
+  label: {
+    fontSize: 11,
+    fontWeight: '700',
+    color: tokens.colors.textOnDark,
+    letterSpacing: 0.2,
+  },
+});

--- a/app/mobile/src/components/search/SearchResultCard.tsx
+++ b/app/mobile/src/components/search/SearchResultCard.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Image, Pressable, StyleSheet, Text, View } from 'react-native';
 import type { SearchResultItem } from '../../services/searchService';
 import { shadows, tokens } from '../../theme';
+import { RankReasonBadge } from '../personalization/RankReasonBadge';
 
 type Props = {
   item: SearchResultItem;
@@ -50,6 +51,7 @@ export function SearchResultCard({ item, onPress }: Props) {
             </Text>
           </View>
         </View>
+        <RankReasonBadge reason={item.rankReason} />
       </View>
     </Pressable>
   );

--- a/app/mobile/src/screens/HomeScreen.tsx
+++ b/app/mobile/src/screens/HomeScreen.tsx
@@ -6,8 +6,11 @@ import { shadows, tokens } from '../theme';
 import { fetchRecipesList } from '../services/recipeService';
 import { apiGetJson } from '../services/httpClient';
 import { fetchDailyCultural } from '../services/dailyCulturalService';
+import { fetchRecommendations, type RecommendationItem } from '../services/recommendationsService';
 import { DailyCulturalSection } from '../components/home/DailyCulturalSection';
+import { RecommendationsRail } from '../components/home/RecommendationsRail';
 import { StoryFeatureCard } from '../components/home/StoryFeatureCard';
+import { RankReasonBadge } from '../components/personalization/RankReasonBadge';
 import type { DailyCulturalCard } from '../mocks/dailyCultural';
 import type { RootStackParamList } from '../navigation/types';
 
@@ -19,27 +22,36 @@ export default function HomeScreen({ navigation }: Props) {
   const [stories, setStories] = useState<any[]>([]);
   const [recipes, setRecipes] = useState<any[]>([]);
   const [daily, setDaily] = useState<DailyCulturalCard[]>([]);
+  const [recommendations, setRecommendations] = useState<RecommendationItem[]>([]);
   const [loadError, setLoadError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
     void (async () => {
       try {
-        const [storyData, recipeData, dailyData] = await Promise.all([
-          apiGetJson<any[]>('/api/stories/'),
+        const [storyData, recipeData, dailyData, recsData] = await Promise.all([
+          apiGetJson<any>('/api/stories/'),
           fetchRecipesList(),
           fetchDailyCultural(),
+          fetchRecommendations('feed', 10).catch(() => [] as RecommendationItem[]),
         ]);
         if (cancelled) return;
-        setStories(Array.isArray(storyData) ? storyData : []);
+        const storyList = Array.isArray(storyData)
+          ? storyData
+          : storyData && Array.isArray(storyData.results)
+            ? storyData.results
+            : [];
+        setStories(storyList);
         setRecipes(Array.isArray(recipeData) ? recipeData : []);
         setDaily(Array.isArray(dailyData) ? dailyData : []);
+        setRecommendations(Array.isArray(recsData) ? recsData : []);
         setLoadError(null);
       } catch (e) {
         if (!cancelled) {
           setStories([]);
           setRecipes([]);
           setDaily([]);
+          setRecommendations([]);
           setLoadError(e instanceof Error ? e.message : 'Could not load feed.');
         }
       }
@@ -48,6 +60,14 @@ export default function HomeScreen({ navigation }: Props) {
       cancelled = true;
     };
   }, []);
+
+  const onRecommendationPress = (item: RecommendationItem) => {
+    if (item.kind === 'recipe') {
+      navigation.navigate('RecipeDetail', { id: item.id });
+    } else {
+      navigation.navigate('StoryDetail', { id: item.id });
+    }
+  };
 
   return (
     <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
@@ -79,6 +99,8 @@ export default function HomeScreen({ navigation }: Props) {
         </View>
 
         <DailyCulturalSection items={daily} />
+
+        <RecommendationsRail items={recommendations} onItemPress={onRecommendationPress} />
 
         <View style={styles.section}>
           <View style={styles.sectionHeader}>
@@ -112,29 +134,31 @@ export default function HomeScreen({ navigation }: Props) {
                       ? String(linkedRecipeRaw.title)
                       : null;
                 return (
-                  <StoryFeatureCard
-                    key={String(item.id)}
-                    title={item.title}
-                    body={item.body}
-                    image={item.image}
-                    authorUsername={authorUsername ?? null}
-                    recipeTitle={linkedRecipeId ? linkedRecipeTitle : null}
-                    onPress={() => navigation.navigate('StoryDetail', { id: String(item.id) })}
-                    onPressAuthor={
-                      authorId != null && authorUsername
-                        ? () =>
-                            navigation.navigate('UserProfile', {
-                              userId: authorId,
-                              username: authorUsername,
-                            })
-                        : undefined
-                    }
-                    onPressRecipe={
-                      linkedRecipeId
-                        ? () => navigation.navigate('RecipeDetail', { id: linkedRecipeId })
-                        : undefined
-                    }
-                  />
+                  <View key={String(item.id)} style={styles.storyWrap}>
+                    <StoryFeatureCard
+                      title={item.title}
+                      body={item.body}
+                      image={item.image}
+                      authorUsername={authorUsername ?? null}
+                      recipeTitle={linkedRecipeId ? linkedRecipeTitle : null}
+                      onPress={() => navigation.navigate('StoryDetail', { id: String(item.id) })}
+                      onPressAuthor={
+                        authorId != null && authorUsername
+                          ? () =>
+                              navigation.navigate('UserProfile', {
+                                userId: authorId,
+                                username: authorUsername,
+                              })
+                          : undefined
+                      }
+                      onPressRecipe={
+                        linkedRecipeId
+                          ? () => navigation.navigate('RecipeDetail', { id: linkedRecipeId })
+                          : undefined
+                      }
+                    />
+                    <RankReasonBadge reason={item.rank_reason} style={styles.storyBadge} />
+                  </View>
                 );
               })}
             </View>
@@ -210,6 +234,7 @@ export default function HomeScreen({ navigation }: Props) {
                       {regionName ?? 'Recipe'}
                     </Text>
                   </View>
+                  <RankReasonBadge reason={item.rank_reason} style={styles.recipeBadge} />
                 </Pressable>
               );
             }}
@@ -331,4 +356,7 @@ const styles = StyleSheet.create({
   },
   tagText: { fontSize: 12, fontWeight: '800', color: tokens.colors.text },
   link: { fontSize: 15, color: tokens.colors.text, fontWeight: '800' },
+  storyWrap: { gap: 6 },
+  storyBadge: { marginLeft: 4 },
+  recipeBadge: { marginLeft: 12, marginBottom: 12 },
 });

--- a/app/mobile/src/services/recipeService.ts
+++ b/app/mobile/src/services/recipeService.ts
@@ -108,6 +108,8 @@ export async function fetchRecipesList(): Promise<
     author?: any;
     author_username?: string;
     image?: string | null;
+    rank_score?: number;
+    rank_reason?: string | null;
   }[]
 > {
   const data = await apiGetJson<any>(`/api/recipes/`);
@@ -137,6 +139,8 @@ export async function fetchRecipesList(): Promise<
       author: r.author ?? undefined,
       author_username: typeof r.author_username === 'string' ? r.author_username : undefined,
       image: typeof r.image === 'string' ? r.image : null,
+      rank_score: typeof r.rank_score === 'number' ? r.rank_score : undefined,
+      rank_reason: typeof r.rank_reason === 'string' ? r.rank_reason : null,
     };
   });
 }

--- a/app/mobile/src/services/recommendationsService.ts
+++ b/app/mobile/src/services/recommendationsService.ts
@@ -1,0 +1,52 @@
+import { apiGetJson } from './httpClient';
+
+export type RecommendationItem = {
+  key: string;
+  kind: 'recipe' | 'story';
+  id: string;
+  title: string;
+  snippet: string;
+  image: string | null;
+  region: string | null;
+  authorUsername: string | null;
+  rankScore: number;
+  rankReason: string | null;
+};
+
+type BackendRecommendationsResponse = {
+  surface: string;
+  results: Array<{
+    result_type: 'recipe' | 'story';
+    id: number | string;
+    title?: string;
+    description?: string;
+    body?: string;
+    image?: string | null;
+    region_tag?: string | null;
+    author_username?: string | null;
+    rank_score?: number;
+    rank_reason?: string | null;
+  }>;
+  total_count?: number;
+};
+
+export async function fetchRecommendations(
+  surface: 'feed' | 'explore' | 'map' | 'recs' = 'feed',
+  limit = 10,
+): Promise<RecommendationItem[]> {
+  const params = new URLSearchParams({ surface, limit: String(limit) });
+  const data = await apiGetJson<BackendRecommendationsResponse>(`/api/recommendations/?${params.toString()}`);
+  const results = Array.isArray(data?.results) ? data.results : [];
+  return results.map((r) => ({
+    key: `${r.result_type}-${r.id}`,
+    kind: r.result_type,
+    id: String(r.id),
+    title: String(r.title ?? ''),
+    snippet: String(r.description ?? r.body ?? ''),
+    image: typeof r.image === 'string' ? r.image : null,
+    region: typeof r.region_tag === 'string' ? r.region_tag : null,
+    authorUsername: typeof r.author_username === 'string' ? r.author_username : null,
+    rankScore: typeof r.rank_score === 'number' ? r.rank_score : 0,
+    rankReason: typeof r.rank_reason === 'string' ? r.rank_reason : null,
+  }));
+}

--- a/app/mobile/src/services/searchService.ts
+++ b/app/mobile/src/services/searchService.ts
@@ -8,6 +8,8 @@ export type SearchResultItem = {
   subtitle: string;
   region?: string;
   thumbnail?: string | null;
+  rankScore: number;
+  rankReason: string | null;
 };
 
 type BackendSearchResponse = {
@@ -17,6 +19,8 @@ type BackendSearchResponse = {
     title: string;
     image?: string | null;
     region_tag?: string | null;
+    rank_score?: number;
+    rank_reason?: string | null;
   }>;
   stories?: Array<{
     result_type: 'story';
@@ -24,6 +28,8 @@ type BackendSearchResponse = {
     title: string;
     linked_recipe_id?: number | string | null;
     region_tag?: string | null;
+    rank_score?: number;
+    rank_reason?: string | null;
   }>;
   total_count?: number;
 };
@@ -50,7 +56,7 @@ export async function search(
   }
   const data = await apiGetJson<BackendSearchResponse>(`/api/search/?${params.toString()}`);
 
-  const recipes = (data.recipes ?? []).map((r) => ({
+  const recipes = (data.recipes ?? []).map<SearchResultItem>((r) => ({
     key: `recipe-${r.id}`,
     kind: 'recipe' as const,
     id: String(r.id),
@@ -58,9 +64,11 @@ export async function search(
     subtitle: r.region_tag ? `Recipe · ${r.region_tag}` : 'Recipe',
     region: r.region_tag ?? undefined,
     thumbnail: r.image ?? null,
+    rankScore: typeof r.rank_score === 'number' ? r.rank_score : 0,
+    rankReason: typeof r.rank_reason === 'string' ? r.rank_reason : null,
   }));
 
-  const stories = (data.stories ?? []).map((s) => ({
+  const stories = (data.stories ?? []).map<SearchResultItem>((s) => ({
     key: `story-${s.id}`,
     kind: 'story' as const,
     id: String(s.id),
@@ -68,6 +76,8 @@ export async function search(
     subtitle: 'Story',
     region: s.region_tag ?? undefined,
     thumbnail: null,
+    rankScore: typeof s.rank_score === 'number' ? s.rank_score : 0,
+    rankReason: typeof s.rank_reason === 'string' ? s.rank_reason : null,
   }));
 
   return [...recipes, ...stories];

--- a/app/mobile/src/services/storyService.ts
+++ b/app/mobile/src/services/storyService.ts
@@ -15,6 +15,8 @@ export type StoryListItem = {
   image: string | null;
   authorUsername: string | null;
   linkedRecipeId: string | null;
+  rank_score?: number;
+  rank_reason?: string | null;
 };
 
 function pickListItem(raw: any): StoryListItem {
@@ -38,15 +40,24 @@ function pickListItem(raw: any): StoryListItem {
     image: typeof raw?.image === 'string' ? raw.image : null,
     authorUsername,
     linkedRecipeId,
+    rank_score: typeof raw?.rank_score === 'number' ? raw.rank_score : undefined,
+    rank_reason: typeof raw?.rank_reason === 'string' ? raw.rank_reason : null,
   };
+}
+
+function unwrapStoriesPayload(data: unknown): any[] {
+  if (Array.isArray(data)) return data;
+  if (data && typeof data === 'object' && Array.isArray((data as { results?: unknown }).results)) {
+    return (data as { results: any[] }).results;
+  }
+  return [];
 }
 
 /** Stories where `linked_recipe` matches the given recipe id. Filters client-side. */
 export async function fetchStoriesForRecipe(recipeId: string | number): Promise<StoryListItem[]> {
-  const list = await apiGetJson<any[]>(`/api/stories/`);
-  if (!Array.isArray(list)) return [];
+  const data = await apiGetJson<unknown>(`/api/stories/`);
   const target = String(recipeId);
-  return list.map(pickListItem).filter((s) => s.linkedRecipeId === target);
+  return unwrapStoriesPayload(data).map(pickListItem).filter((s) => s.linkedRecipeId === target);
 }
 
 function normalizeStoryDetail(data: StoryDetail & Record<string, unknown>): StoryDetail {

--- a/app/mobile/src/types/recipe.ts
+++ b/app/mobile/src/types/recipe.ts
@@ -21,4 +21,6 @@ export type RecipeDetail = {
   ingredients?: RecipeIngredientRow[];
   /** Matches web `RecipeEditPage` (`qa_enabled`). */
   qa_enabled?: boolean;
+  rank_score?: number;
+  rank_reason?: string | null;
 };

--- a/app/mobile/src/types/story.ts
+++ b/app/mobile/src/types/story.ts
@@ -9,5 +9,7 @@ export type StoryDetail = {
   is_published?: boolean;
   /** Optional image URL/uri (mock uses remote url). */
   image?: string | null;
+  rank_score?: number;
+  rank_reason?: string | null;
 };
 

--- a/app/mobile/src/utils/rankReason.ts
+++ b/app/mobile/src/utils/rankReason.ts
@@ -1,0 +1,11 @@
+const labels: Record<string, string> = {
+  regional_match: 'From your region',
+  dietary_match: 'Matches your dietary preference',
+  event_match: 'For your events',
+  cultural_match: 'Matches your interests',
+};
+
+export function rankReasonLabel(reason: string | null | undefined): string | null {
+  if (!reason) return null;
+  return labels[reason] ?? null;
+}


### PR DESCRIPTION
## Summary
Closes the **mobile portion** of #345 (M4-14 Preference-driven personalization). Backend ranking lives in #443 (closes the backend portion); web counterpart shipped in #429.

Mobile now consumes the server-ranked output and surfaces personalization reasoning to the user.

### What ships
- **`RecommendationsRail`** on `HomeScreen` — horizontal rail consuming `GET /api/recommendations/?surface=feed&limit=10`, hides itself gracefully when the endpoint is empty/unavailable.
- **`RankReasonBadge`** on story cards, recipe cards, and search results — pill that maps `rank_reason` (`regional_match`/`dietary_match`/`event_match`/`cultural_match`) to a human-readable label and renders nothing when null.
- **`recommendationsService`** wraps the recs endpoint.
- **`rankReason.ts`** util — pure mapper, no UI deps, easy to unit-test later.
- Types extended: optional `rank_score` and `rank_reason` on `RecipeDetail`/`StoryDetail`/list items/`SearchResultItem`.
- Services pass the rank fields straight through; **no client-side resorting** — the server's order wins.

### Out of scope
- Map and Explore surfaces (M5 issues #383/#387 — separate PRs).
- `rank_score` is consumed but not displayed (web doesn't either; see #429).
- Push notifications, onboarding flow, daily cultural ranking — all upstream/sibling work already merged.

### Backend dependency
Backend ranking (#443) is currently merged into `feat/backend/contact-toggle`, **not yet on `main`**. Once that integration branch lands, this PR begins working end-to-end against prod (genipe.app). Until then, the rail is hidden and badges don't render — graceful degradation.

### Visual design
`RankReasonBadge`, `RecommendationsRail` action buttons, and the recipe/story badges use `accentGreen` + `surfaceDark` outline + `textOnDark` text — palette-safe across the current and in-flight palette work (#418/#426).

### Test plan
- [x] `npx tsc --noEmit` passes
- [x] No client-side sort introduced; serverside order preserved
- [x] Local end-to-end smoke (with backend cherry-picked from `feat/backend/contact-toggle`):
  - logged in as `cagan` (regional_ties: Aegean) → rail renders, badges show **"From your region"** on matching items
  - search results show badges; non-matching items have no badge
- [x] Anon user / no profile: rail hidden, no badges, no crash
- [x] Endpoint missing (current `main`): rail hidden, no badges, no crash

### References
- Closes **#345** (mobile portion)
- Backend: **#443** (still needs to reach `main`)
- Web counterpart: **#429**
- Related design tokens: **#418/#426** (palette swap)
Closes #345