### PR TITLE
feat(mobile): ingredient substitution sheet on recipe detail (#371)

### DIFF
--- a/app/mobile/src/components/recipe/IngredientSubstitutesSheet.tsx
+++ b/app/mobile/src/components/recipe/IngredientSubstitutesSheet.tsx
@@ -1,0 +1,228 @@
+import { useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  Modal,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { fetchSubstitutes, type SubstituteGroups, type Substitute } from '../../services/substitutionService';
+import { shadows, tokens } from '../../theme';
+
+type Props = {
+  ingredientId: number | string | null;
+  ingredientName: string;
+  onClose: () => void;
+};
+
+const CATEGORY_LABEL: Record<'flavor' | 'texture' | 'chemical', string> = {
+  flavor: 'Flavor matches',
+  texture: 'Texture matches',
+  chemical: 'Chemical matches',
+};
+
+function formatCloseness(closeness: number): string {
+  if (closeness <= 0) return '';
+  return `${Math.round(closeness * 100)}%`;
+}
+
+export function IngredientSubstitutesSheet({ ingredientId, ingredientName, onClose }: Props) {
+  const visible = ingredientId != null;
+  const [data, setData] = useState<SubstituteGroups | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (ingredientId == null) {
+      setData(null);
+      setError(null);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetchSubstitutes(ingredientId)
+      .then((res) => {
+        if (!cancelled) setData(res);
+      })
+      .catch((e) => {
+        if (!cancelled) {
+          setData(null);
+          setError(e instanceof Error ? e.message : 'Could not load substitutes.');
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [ingredientId]);
+
+  const isEmpty =
+    !loading &&
+    !error &&
+    data != null &&
+    data.flavor.length === 0 &&
+    data.texture.length === 0 &&
+    data.chemical.length === 0;
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      transparent
+      onRequestClose={onClose}
+      accessibilityLabel={`Substitutes for ${ingredientName}`}
+    >
+      <Pressable style={styles.backdrop} onPress={onClose} accessibilityLabel="Close substitutes">
+        <Pressable style={styles.sheet} onPress={() => undefined}>
+          <View style={styles.handle} />
+          <View style={styles.header}>
+            <Text style={styles.title} numberOfLines={1} accessibilityRole="header">
+              Substitutes for {ingredientName}
+            </Text>
+            <Pressable onPress={onClose} style={styles.closeBtn} accessibilityRole="button" accessibilityLabel="Close">
+              <Text style={styles.closeText}>Close</Text>
+            </Pressable>
+          </View>
+
+          {loading ? (
+            <View style={styles.centered}>
+              <ActivityIndicator color={tokens.colors.primary} />
+              <Text style={styles.muted}>Loading…</Text>
+            </View>
+          ) : error ? (
+            <View style={styles.centered}>
+              <Text style={styles.errorText}>{error}</Text>
+            </View>
+          ) : isEmpty ? (
+            <View style={styles.centered}>
+              <Text style={styles.muted}>No substitutes found for this ingredient.</Text>
+            </View>
+          ) : (
+            <ScrollView contentContainerStyle={styles.scroll}>
+              {(['flavor', 'texture', 'chemical'] as const).map((cat) => {
+                const items = data?.[cat] ?? [];
+                if (items.length === 0) return null;
+                return (
+                  <View key={cat} style={styles.group}>
+                    <Text style={styles.groupTitle}>{CATEGORY_LABEL[cat]}</Text>
+                    {items.map((s) => (
+                      <SubstituteRow key={`${cat}-${s.id}`} item={s} />
+                    ))}
+                  </View>
+                );
+              })}
+            </ScrollView>
+          )}
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}
+
+function SubstituteRow({ item }: { item: Substitute }) {
+  const closeness = formatCloseness(item.closeness);
+  return (
+    <View style={styles.row}>
+      <View style={styles.rowHead}>
+        <Text style={styles.rowName} numberOfLines={1}>
+          {item.name}
+        </Text>
+        {closeness ? (
+          <View style={styles.closenessPill}>
+            <Text style={styles.closenessText}>{closeness}</Text>
+          </View>
+        ) : null}
+      </View>
+      {item.notes ? <Text style={styles.rowNotes}>{item.notes}</Text> : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: tokens.colors.backdrop,
+    justifyContent: 'flex-end',
+  },
+  sheet: {
+    backgroundColor: tokens.colors.bg,
+    borderTopLeftRadius: tokens.radius.xl,
+    borderTopRightRadius: tokens.radius.xl,
+    paddingTop: 8,
+    paddingHorizontal: 16,
+    paddingBottom: 28,
+    maxHeight: '80%',
+    ...shadows.lg,
+  },
+  handle: {
+    alignSelf: 'center',
+    width: 44,
+    height: 5,
+    borderRadius: 999,
+    backgroundColor: tokens.colors.border,
+    marginBottom: 10,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 12,
+    marginBottom: 12,
+  },
+  title: {
+    flex: 1,
+    fontSize: 18,
+    fontWeight: '800',
+    color: tokens.colors.text,
+    fontFamily: tokens.typography.display.fontFamily,
+  },
+  closeBtn: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: tokens.radius.pill,
+    backgroundColor: tokens.colors.surface,
+    borderWidth: 1,
+    borderColor: tokens.colors.border,
+  },
+  closeText: { fontSize: 13, fontWeight: '800', color: tokens.colors.text },
+  centered: { paddingVertical: 40, alignItems: 'center', gap: 8 },
+  muted: { fontSize: 14, color: tokens.colors.textMuted },
+  errorText: { fontSize: 14, color: tokens.colors.error, fontWeight: '700' },
+  scroll: { paddingBottom: 16 },
+  group: { marginBottom: 18 },
+  groupTitle: {
+    fontSize: 14,
+    fontWeight: '800',
+    color: tokens.colors.textMuted,
+    textTransform: 'uppercase',
+    letterSpacing: 0.6,
+    marginBottom: 8,
+  },
+  row: {
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    borderRadius: tokens.radius.lg,
+    backgroundColor: tokens.colors.surface,
+    borderWidth: 1,
+    borderColor: tokens.colors.border,
+    marginBottom: 8,
+    ...shadows.sm,
+  },
+  rowHead: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', gap: 12 },
+  rowName: { flex: 1, fontSize: 15, fontWeight: '800', color: tokens.colors.text },
+  rowNotes: { marginTop: 4, fontSize: 13, color: tokens.colors.textMuted, lineHeight: 18 },
+  closenessPill: {
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: tokens.radius.pill,
+    backgroundColor: tokens.colors.accentGreen,
+    borderWidth: 1,
+    borderColor: tokens.colors.surfaceDark,
+  },
+  closenessText: { fontSize: 11, fontWeight: '800', color: tokens.colors.textOnDark },
+});

--- a/app/mobile/src/screens/RecipeDetailScreen.tsx
+++ b/app/mobile/src/screens/RecipeDetailScreen.tsx
@@ -6,6 +6,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { useAuth } from '../context/AuthContext';
 import { ErrorView } from '../components/ui/ErrorView';
 import { LoadingView } from '../components/ui/LoadingView';
+import { IngredientSubstitutesSheet } from '../components/recipe/IngredientSubstitutesSheet';
 import { LinkedStoryPreviewCard } from '../components/recipe/LinkedStoryPreviewCard';
 import { RecipeCommentsSection } from '../components/recipe/RecipeCommentsSection';
 import type { RootStackParamList } from '../navigation/types';
@@ -27,6 +28,7 @@ export default function RecipeDetailScreen({ route, navigation }: Props) {
   const [reloadToken, setReloadToken] = useState(0);
   const [showConverted, setShowConverted] = useState(false);
   const [linkedStories, setLinkedStories] = useState<StoryListItem[]>([]);
+  const [substituteTarget, setSubstituteTarget] = useState<{ id: number; name: string } | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -215,11 +217,24 @@ export default function RecipeDetailScreen({ route, navigation }: Props) {
                     }
                     style={styles.ingredientRow}
                   >
-                    <Text style={styles.ingredientName}>{ri.ingredient.name}</Text>
-                    <Text style={styles.ingredientAmount}>
-                      {' — '}
-                      {displayAmount} {displayUnit}
-                    </Text>
+                    <View style={styles.ingredientText}>
+                      <Text style={styles.ingredientName}>{ri.ingredient.name}</Text>
+                      <Text style={styles.ingredientAmount}>
+                        {' — '}
+                        {displayAmount} {displayUnit}
+                      </Text>
+                    </View>
+                    <Pressable
+                      onPress={() =>
+                        setSubstituteTarget({ id: ri.ingredient.id, name: ri.ingredient.name })
+                      }
+                      style={({ pressed }) => [styles.subBtn, pressed && styles.pressed]}
+                      accessibilityRole="button"
+                      accessibilityLabel={`Find substitutes for ${ri.ingredient.name}`}
+                      hitSlop={8}
+                    >
+                      <Text style={styles.subBtnText}>Substitutes</Text>
+                    </Pressable>
                   </View>
                 );
               })}
@@ -249,6 +264,12 @@ export default function RecipeDetailScreen({ route, navigation }: Props) {
           </View>
         </View>
       </ScrollView>
+
+      <IngredientSubstitutesSheet
+        ingredientId={substituteTarget?.id ?? null}
+        ingredientName={substituteTarget?.name ?? ''}
+        onClose={() => setSubstituteTarget(null)}
+      />
     </SafeAreaView>
   );
 }
@@ -373,13 +394,26 @@ const styles = StyleSheet.create({
   ingredientRow: {
     flexDirection: 'row',
     flexWrap: 'wrap',
-    alignItems: 'baseline',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 8,
     paddingVertical: 10,
     borderBottomWidth: StyleSheet.hairlineWidth,
     borderBottomColor: tokens.colors.primaryTint,
   },
+  ingredientText: { flex: 1, flexDirection: 'row', flexWrap: 'wrap', alignItems: 'baseline' },
   ingredientName: { fontSize: 16, color: tokens.colors.text, fontWeight: '700' },
   ingredientAmount: { fontSize: 16, color: tokens.colors.text },
+  subBtn: {
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+    borderRadius: tokens.radius.pill,
+    backgroundColor: tokens.colors.accentGreen,
+    borderWidth: 1,
+    borderColor: tokens.colors.surfaceDark,
+  },
+  subBtnText: { fontSize: 12, fontWeight: '800', color: tokens.colors.textOnDark },
+  pressed: { opacity: 0.85 },
   storiesSection: { marginTop: 28, paddingTop: 16, borderTopWidth: 1, borderTopColor: tokens.colors.primaryTint, gap: 12 },
   storyList: { gap: 10 },
 });

--- a/app/mobile/src/services/substitutionService.ts
+++ b/app/mobile/src/services/substitutionService.ts
@@ -1,0 +1,68 @@
+import { apiGetJson } from './httpClient';
+
+export type Substitute = {
+  id: number;
+  name: string;
+  /** Backend returns a stringified decimal like "0.70". */
+  closeness: number;
+  notes: string;
+};
+
+export type SubstituteCategory = 'flavor' | 'texture' | 'chemical';
+
+export type SubstituteGroups = {
+  ingredient: { id: number; name: string };
+  flavor: Substitute[];
+  texture: Substitute[];
+  chemical: Substitute[];
+};
+
+type RawSubstitute = {
+  id: number | string;
+  name?: string;
+  closeness?: string | number;
+  notes?: string;
+};
+
+type RawResponse = {
+  ingredient?: { id?: number | string; name?: string };
+  flavor?: RawSubstitute[];
+  texture?: RawSubstitute[];
+  chemical?: RawSubstitute[];
+};
+
+function pick(list: RawSubstitute[] | undefined): Substitute[] {
+  if (!Array.isArray(list)) return [];
+  return list
+    .map((s) => {
+      const id = Number(s.id);
+      if (!Number.isFinite(id)) return null;
+      const closenessRaw = s.closeness;
+      const closeness =
+        typeof closenessRaw === 'number'
+          ? closenessRaw
+          : typeof closenessRaw === 'string'
+            ? Number(closenessRaw)
+            : 0;
+      return {
+        id,
+        name: typeof s.name === 'string' ? s.name : '',
+        closeness: Number.isFinite(closeness) ? closeness : 0,
+        notes: typeof s.notes === 'string' ? s.notes : '',
+      };
+    })
+    .filter((s): s is Substitute => s !== null);
+}
+
+export async function fetchSubstitutes(ingredientId: number | string): Promise<SubstituteGroups> {
+  const data = await apiGetJson<RawResponse>(`/api/ingredients/${ingredientId}/substitutes/`);
+  return {
+    ingredient: {
+      id: Number(data.ingredient?.id ?? ingredientId),
+      name: typeof data.ingredient?.name === 'string' ? data.ingredient.name : '',
+    },
+    flavor: pick(data.flavor),
+    texture: pick(data.texture),
+    chemical: pick(data.chemical),
+  };
+}


### PR DESCRIPTION
## Summary
Mobile substitution UI for #371. Backend in #444.

A "Substitutes" button on each ingredient in `RecipeDetailScreen`. Tap it, a sheet opens with substitutes grouped into flavor, texture, and chemical matches. Each one shows a closeness percent and notes if any.

## Files
- `services/substitutionService.ts` — wraps `GET /api/ingredients/<id>/substitutes/`
- `components/recipe/IngredientSubstitutesSheet.tsx` — the sheet (uses RN `Modal`, no new dep)
- `screens/RecipeDetailScreen.tsx` — adds the button per ingredient row

## Test
- `npx tsc --noEmit` clean
- Local emulator: opened Mücver and Mıhlama. Egg has no substitutes (seed data), the rest show flavor/texture matches as expected. Backdrop dismiss works.

## Notes
- Plain `Modal`, not `@gorhom/bottom-sheet` — that one is reserved for #385 (region sheet on the map screen).
- Pairs with web #437 (still open).

Closes #371