### PR TITLE
feat(mobile): event-based explore screen with category rails (#387)

### DIFF
--- a/app/mobile/src/navigation/PublicStackNavigator.tsx
+++ b/app/mobile/src/navigation/PublicStackNavigator.tsx
@@ -1,4 +1,6 @@
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import EventDetailScreen from '../screens/EventDetailScreen';
+import ExploreScreen from '../screens/ExploreScreen';
 import HomeScreen from '../screens/HomeScreen';
 import InboxScreen from '../screens/InboxScreen';
 import LoginScreen from '../screens/LoginScreen';
@@ -92,6 +94,16 @@ export function PublicStackNavigator() {
         name="Onboarding"
         component={OnboardingScreen}
         options={{ title: 'Cultural Onboarding' }}
+      />
+      <Stack.Screen
+        name="Explore"
+        component={ExploreScreen}
+        options={{ title: 'Explore' }}
+      />
+      <Stack.Screen
+        name="EventDetail"
+        component={EventDetailScreen}
+        options={{ title: 'Event' }}
       />
     </Stack.Navigator>
   );

--- a/app/mobile/src/navigation/types.ts
+++ b/app/mobile/src/navigation/types.ts
@@ -19,6 +19,8 @@ export type RootStackParamList = {
     otherUsername?: string;
   };
   Onboarding: undefined;
+  Explore: undefined;
+  EventDetail: { eventId: number; eventName: string };
 };
 
 declare global {

--- a/app/mobile/src/screens/EventDetailScreen.tsx
+++ b/app/mobile/src/screens/EventDetailScreen.tsx
@@ -1,0 +1,153 @@
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { useEffect, useState } from 'react';
+import { FlatList, Image, Pressable, StyleSheet, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { ErrorView } from '../components/ui/ErrorView';
+import { LoadingView } from '../components/ui/LoadingView';
+import type { RootStackParamList } from '../navigation/types';
+import { fetchRecipesForEvent, type ExploreItem } from '../services/exploreService';
+import { shadows, tokens } from '../theme';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'EventDetail'>;
+
+export default function EventDetailScreen({ route, navigation }: Props) {
+  const { eventName } = route.params;
+  const [items, setItems] = useState<ExploreItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadToken, setReloadToken] = useState(0);
+
+  useEffect(() => {
+    navigation.setOptions({ title: eventName });
+  }, [navigation, eventName]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetchRecipesForEvent(eventName, 100)
+      .then((res) => {
+        if (!cancelled) setItems(res);
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : 'Could not load recipes.');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [eventName, reloadToken]);
+
+  if (loading) {
+    return (
+      <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
+        <View style={styles.centered}>
+          <LoadingView message={`Loading ${eventName} recipes…`} />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (error) {
+    return (
+      <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
+        <View style={styles.padded}>
+          <ErrorView message={error} onRetry={() => setReloadToken((t) => t + 1)} />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
+      <FlatList
+        data={items}
+        keyExtractor={(it) => it.id}
+        contentContainerStyle={items.length === 0 ? styles.emptyContainer : styles.list}
+        ListHeaderComponent={
+          <View style={styles.header}>
+            <Text style={styles.title}>{eventName}</Text>
+            <Text style={styles.subtitle}>
+              {items.length} {items.length === 1 ? 'recipe' : 'recipes'}
+            </Text>
+          </View>
+        }
+        ListEmptyComponent={
+          <View>
+            <Text style={styles.emptyTitle}>No recipes for {eventName} yet</Text>
+            <Text style={styles.emptyHint}>Check back soon — community recipes are tagged often.</Text>
+          </View>
+        }
+        renderItem={({ item }) => (
+          <Pressable
+            onPress={() => navigation.navigate('RecipeDetail', { id: item.id })}
+            style={({ pressed }) => [styles.row, pressed && styles.pressed]}
+            accessibilityRole="button"
+            accessibilityLabel={`Open recipe ${item.title}`}
+          >
+            {item.image ? (
+              <Image source={{ uri: item.image }} style={styles.rowThumb} resizeMode="cover" />
+            ) : (
+              <View style={[styles.rowThumb, styles.rowThumbPlaceholder]}>
+                <Text style={styles.rowThumbInitial}>R</Text>
+              </View>
+            )}
+            <View style={styles.rowBody}>
+              <Text style={styles.rowTitle} numberOfLines={2}>
+                {item.title}
+              </Text>
+              {item.region ? <Text style={styles.rowMeta}>{item.region}</Text> : null}
+            </View>
+          </Pressable>
+        )}
+      />
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: tokens.colors.bg },
+  centered: { flex: 1, justifyContent: 'center', alignItems: 'center', padding: 20 },
+  padded: { flex: 1, padding: 20, justifyContent: 'center' },
+  list: { padding: 16, gap: 10 },
+  emptyContainer: { flexGrow: 1, justifyContent: 'center', padding: 24 },
+  header: { marginBottom: 8 },
+  title: {
+    fontSize: 26,
+    fontWeight: '800',
+    color: tokens.colors.text,
+    fontFamily: tokens.typography.display.fontFamily,
+  },
+  subtitle: { fontSize: 13, color: tokens.colors.text, marginTop: 2 },
+  emptyTitle: {
+    fontSize: 20,
+    fontWeight: '800',
+    color: tokens.colors.text,
+    textAlign: 'center',
+    marginBottom: 6,
+  },
+  emptyHint: { fontSize: 14, color: tokens.colors.text, textAlign: 'center' },
+  row: {
+    flexDirection: 'row',
+    gap: 12,
+    padding: 10,
+    borderWidth: 2,
+    borderColor: tokens.colors.surfaceDark,
+    borderRadius: tokens.radius.lg,
+    backgroundColor: tokens.colors.bg,
+    ...shadows.sm,
+  },
+  pressed: { opacity: 0.9 },
+  rowThumb: { width: 84, height: 84, borderRadius: tokens.radius.md, overflow: 'hidden' },
+  rowThumbPlaceholder: {
+    backgroundColor: tokens.colors.surfaceDark,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  rowThumbInitial: { color: tokens.colors.textOnDark, fontSize: 22, fontWeight: '900' },
+  rowBody: { flex: 1, justifyContent: 'center', gap: 4 },
+  rowTitle: { fontSize: 16, fontWeight: '800', color: tokens.colors.text },
+  rowMeta: { fontSize: 13, color: tokens.colors.text },
+});

--- a/app/mobile/src/screens/ExploreScreen.tsx
+++ b/app/mobile/src/screens/ExploreScreen.tsx
@@ -1,0 +1,199 @@
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { useEffect, useState } from 'react';
+import { FlatList, Image, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { ErrorView } from '../components/ui/ErrorView';
+import { LoadingView } from '../components/ui/LoadingView';
+import type { RootStackParamList } from '../navigation/types';
+import { fetchExploreCategories, type EventCategory, type ExploreItem } from '../services/exploreService';
+import { shadows, tokens } from '../theme';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'Explore'>;
+
+export default function ExploreScreen({ navigation }: Props) {
+  const [categories, setCategories] = useState<EventCategory[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadToken, setReloadToken] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetchExploreCategories()
+      .then((cats) => {
+        if (!cancelled) setCategories(cats);
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : 'Could not load Explore.');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [reloadToken]);
+
+  if (loading) {
+    return (
+      <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
+        <View style={styles.centered}>
+          <LoadingView message="Loading Explore…" />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (error) {
+    return (
+      <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
+        <View style={styles.padded}>
+          <ErrorView message={error} onRetry={() => setReloadToken((t) => t + 1)} />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (categories.length === 0) {
+    return (
+      <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
+        <View style={styles.padded}>
+          <Text style={styles.emptyTitle}>Nothing to explore yet</Text>
+          <Text style={styles.emptyHint}>
+            Recipes will start appearing here once they get tagged with life-event categories.
+          </Text>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
+      <ScrollView contentContainerStyle={styles.scroll}>
+        <Text style={styles.heading} accessibilityRole="header">
+          Explore by event
+        </Text>
+        <Text style={styles.lead}>Recipes for the moments that matter.</Text>
+
+        {categories.map((cat) => (
+          <View key={cat.id} style={styles.section}>
+            <View style={styles.sectionHeader}>
+              <Text style={styles.sectionTitle}>{cat.name}</Text>
+              <Pressable
+                onPress={() =>
+                  navigation.navigate('EventDetail', { eventId: cat.id, eventName: cat.name })
+                }
+                accessibilityRole="link"
+                accessibilityLabel={`See all ${cat.name} recipes`}
+                hitSlop={8}
+              >
+                <Text style={styles.seeAll}>See all</Text>
+              </Pressable>
+            </View>
+            <FlatList
+              data={cat.recipes}
+              horizontal
+              keyExtractor={(item) => item.id}
+              showsHorizontalScrollIndicator={false}
+              contentContainerStyle={styles.rail}
+              renderItem={({ item }) => (
+                <RailCard
+                  item={item}
+                  onPress={() => navigation.navigate('RecipeDetail', { id: item.id })}
+                />
+              )}
+            />
+          </View>
+        ))}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+function RailCard({ item, onPress }: { item: ExploreItem; onPress: () => void }) {
+  return (
+    <Pressable
+      onPress={onPress}
+      style={({ pressed }) => [styles.card, pressed && styles.pressed]}
+      accessibilityRole="button"
+      accessibilityLabel={`Open recipe ${item.title}`}
+    >
+      <View style={styles.thumbWrap}>
+        {item.image ? (
+          <Image source={{ uri: item.image }} style={styles.thumb} resizeMode="cover" />
+        ) : (
+          <View style={styles.thumbPlaceholder}>
+            <Text style={styles.thumbInitial}>R</Text>
+          </View>
+        )}
+      </View>
+      <View style={styles.cardBody}>
+        <Text style={styles.cardTitle} numberOfLines={2}>
+          {item.title}
+        </Text>
+        {item.region ? <Text style={styles.cardMeta}>{item.region}</Text> : null}
+      </View>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: tokens.colors.bg },
+  scroll: { padding: 16, paddingBottom: 28 },
+  centered: { flex: 1, justifyContent: 'center', alignItems: 'center', padding: 20 },
+  padded: { flex: 1, padding: 20, justifyContent: 'center' },
+  heading: {
+    fontSize: 28,
+    fontWeight: '800',
+    color: tokens.colors.text,
+    fontFamily: tokens.typography.display.fontFamily,
+  },
+  lead: { fontSize: 14, color: tokens.colors.text, marginTop: 4, marginBottom: 12 },
+  emptyTitle: {
+    fontSize: 20,
+    fontWeight: '800',
+    color: tokens.colors.text,
+    textAlign: 'center',
+    marginBottom: 8,
+  },
+  emptyHint: { fontSize: 14, color: tokens.colors.text, textAlign: 'center', lineHeight: 20 },
+  section: { marginTop: 16, marginBottom: 4 },
+  sectionHeader: {
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    justifyContent: 'space-between',
+    marginBottom: 10,
+  },
+  sectionTitle: {
+    fontSize: 20,
+    fontWeight: '800',
+    color: tokens.colors.text,
+    fontFamily: tokens.typography.display.fontFamily,
+  },
+  seeAll: { fontSize: 13, fontWeight: '800', color: tokens.colors.text, textDecorationLine: 'underline' },
+  rail: { gap: 12, paddingRight: 16 },
+  card: {
+    width: 200,
+    borderWidth: 1,
+    borderColor: tokens.colors.border,
+    borderRadius: tokens.radius.xl,
+    backgroundColor: tokens.colors.bg,
+    overflow: 'hidden',
+    ...shadows.md,
+  },
+  pressed: { opacity: 0.9 },
+  thumbWrap: { width: '100%', height: 110 },
+  thumb: { width: '100%', height: '100%' },
+  thumbPlaceholder: {
+    width: '100%',
+    height: '100%',
+    backgroundColor: tokens.colors.surfaceDark,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  thumbInitial: { color: tokens.colors.textOnDark, fontSize: 28, fontWeight: '900' },
+  cardBody: { padding: 12, gap: 4 },
+  cardTitle: { fontSize: 15, fontWeight: '800', color: tokens.colors.text },
+  cardMeta: { fontSize: 12, color: tokens.colors.text },
+});

--- a/app/mobile/src/screens/HomeScreen.tsx
+++ b/app/mobile/src/screens/HomeScreen.tsx
@@ -78,6 +78,19 @@ export default function HomeScreen({ navigation }: Props) {
           />
         </View>
 
+        <Pressable
+          onPress={() => navigation.navigate('Explore')}
+          style={({ pressed }) => [styles.exploreEntry, pressed && styles.exploreEntryPressed]}
+          accessibilityRole="button"
+          accessibilityLabel="Open Explore by event"
+        >
+          <View style={{ flex: 1 }}>
+            <Text style={styles.exploreTitle}>Explore by event</Text>
+            <Text style={styles.exploreSubtitle}>Wedding, Ramadan, Birthday, and more</Text>
+          </View>
+          <Text style={styles.exploreArrow}>→</Text>
+        </Pressable>
+
         <DailyCulturalSection items={daily} />
 
         <View style={styles.section}>
@@ -247,6 +260,23 @@ const styles = StyleSheet.create({
     fontFamily: tokens.typography.display.fontFamily,
   },
   searchWrap: { marginBottom: 14 },
+  exploreEntry: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    paddingVertical: 14,
+    paddingHorizontal: 16,
+    borderRadius: tokens.radius.xl,
+    backgroundColor: tokens.colors.accentGreen,
+    borderWidth: 2,
+    borderColor: tokens.colors.surfaceDark,
+    marginBottom: 14,
+    ...shadows.md,
+  },
+  exploreEntryPressed: { opacity: 0.9 },
+  exploreTitle: { fontSize: 16, fontWeight: '800', color: tokens.colors.textOnDark },
+  exploreSubtitle: { fontSize: 12, color: tokens.colors.textOnDark, marginTop: 2, opacity: 0.85 },
+  exploreArrow: { fontSize: 22, fontWeight: '900', color: tokens.colors.textOnDark },
   searchInput: {
     borderWidth: 2,
     borderColor: tokens.colors.primaryBorder,

--- a/app/mobile/src/services/exploreService.ts
+++ b/app/mobile/src/services/exploreService.ts
@@ -1,0 +1,81 @@
+import { apiGetJson } from './httpClient';
+import { fetchEventTags, type Tag } from './tagsService';
+
+export type ExploreItem = {
+  id: string;
+  title: string;
+  region: string | null;
+  image: string | null;
+  authorUsername: string | null;
+};
+
+export type EventCategory = {
+  id: number;
+  name: string;
+  recipes: ExploreItem[];
+};
+
+type RawRecipe = {
+  id: number | string;
+  title?: string;
+  image?: string | null;
+  region?: { name?: string } | string | null;
+  region_name?: string;
+  author_username?: string | null;
+};
+
+function toItem(r: RawRecipe): ExploreItem {
+  const reg = r.region;
+  const region =
+    typeof reg === 'string'
+      ? reg
+      : reg && typeof reg === 'object' && typeof reg.name === 'string'
+        ? reg.name
+        : typeof r.region_name === 'string'
+          ? r.region_name
+          : null;
+  return {
+    id: String(r.id),
+    title: typeof r.title === 'string' ? r.title : '',
+    region,
+    image: typeof r.image === 'string' ? r.image : null,
+    authorUsername: typeof r.author_username === 'string' ? r.author_username : null,
+  };
+}
+
+function unwrap(data: unknown): RawRecipe[] {
+  if (Array.isArray(data)) return data as RawRecipe[];
+  if (data && typeof data === 'object' && Array.isArray((data as { results?: unknown }).results)) {
+    return (data as { results: RawRecipe[] }).results;
+  }
+  return [];
+}
+
+export async function fetchRecipesForEvent(
+  eventName: string,
+  limit = 20,
+): Promise<ExploreItem[]> {
+  const params = new URLSearchParams({ event: eventName });
+  const data = await apiGetJson<unknown>(`/api/recipes/?${params.toString()}`);
+  return unwrap(data).slice(0, limit).map(toItem);
+}
+
+/**
+ * Aggregate event categories with their first few recipes for the Explore rail.
+ * Categories with zero recipes are dropped so the UI doesn't show empty rails.
+ */
+export async function fetchExploreCategories(perRail = 8): Promise<EventCategory[]> {
+  const tags: Tag[] = await fetchEventTags();
+  if (tags.length === 0) return [];
+  const grouped = await Promise.all(
+    tags.map(async (tag) => {
+      try {
+        const recipes = await fetchRecipesForEvent(tag.name, perRail);
+        return { id: tag.id, name: tag.name, recipes };
+      } catch {
+        return { id: tag.id, name: tag.name, recipes: [] };
+      }
+    }),
+  );
+  return grouped.filter((g) => g.recipes.length > 0);
+}

--- a/app/mobile/src/services/tagsService.ts
+++ b/app/mobile/src/services/tagsService.ts
@@ -1,6 +1,6 @@
 import { apiGetJson } from './httpClient';
 
-export type Tag = { id: number; name: string; is_approved: boolean };
+export type Tag = { id: number; name: string; is_approved?: boolean };
 
 type Paginated<T> = { count: number; next: string | null; previous: string | null; results: T[] };
 
@@ -18,7 +18,9 @@ async function fetchAll(path: string): Promise<Tag[]> {
     const u: URL = new URL(data.next);
     cursor = `${u.pathname}${u.search}`;
   }
-  return collected.filter((t) => t.is_approved);
+  // Server already filters list/retrieve by is_approved=True; the lookup
+  // serializer doesn't expose the flag at all. No client-side filtering needed.
+  return collected;
 }
 
 export async function fetchDietaryTags(): Promise<Tag[]> {


### PR DESCRIPTION
## Summary
Explore for #387, using the filter API from #421.

New Explore screen with one rail per event tag (Wedding, Ramadan, Eid, etc.). Tap "See all" on a rail to see every recipe for that event. Green entry button on Home opens it.

## Files
- `services/exploreService.ts` — pulls event tags, then recipes per tag via `/api/recipes/?event=<name>`
- `screens/ExploreScreen.tsx` — rail screen
- `screens/EventDetailScreen.tsx` — full list for one event
- `services/tagsService.ts` — dropped a broken `is_approved` filter that was making `fetchEventTags` always return []
- nav types + stack — registered `Explore` and `EventDetail`
- `screens/HomeScreen.tsx` — green entry card above the daily section

## Test
- `npx tsc --noEmit` clean
- Local emulator: seeded 6 event tags, tagged the 18 recipes. Home → Explore shows the rails. Wedding "See all" lists 5 recipes. Tapping a card opens RecipeDetail. Empty state works when no tags exist.

## Notes
- Stories aren't here yet. The story endpoint doesn't take `?event=` (no rich filter on `StoryViewSet`). Add later when backend grows it.
- Pairs with web #435 (still open).

Closes #387