### PR TITLE
feat(backend): preference-driven personalization ranking (#345)

### DIFF
--- a/app/backend/apps/common/pagination.py
+++ b/app/backend/apps/common/pagination.py
@@ -1,0 +1,7 @@
+from rest_framework.pagination import PageNumberPagination
+
+
+class StandardResultsSetPagination(PageNumberPagination):
+    page_size = 10
+    page_size_query_param = 'page_size'
+    max_page_size = 100

--- a/app/backend/apps/common/personalization.py
+++ b/app/backend/apps/common/personalization.py
@@ -1,0 +1,319 @@
+from datetime import datetime
+
+
+PROFILE_FIELDS = (
+    'cultural_interests',
+    'regional_ties',
+    'religious_preferences',
+    'event_interests',
+)
+
+RANK_REASONS = {
+    'regional': 'regional_match',
+    'dietary': 'dietary_match',
+    'event': 'event_match',
+    'cultural': 'cultural_match',
+}
+
+# Weight rationale: regional matches dominate as the strongest direct relevance
+# signal; dietary/religious follow because they constrain what users can eat;
+# event interests capture occasion-based fit; textual cultural matches are the
+# noisiest signal and weighted lowest.
+WEIGHTS = {
+    'regional': 40,
+    'dietary': 30,
+    'event': 25,
+    'cultural': 15,
+}
+
+
+def normalize_terms(values):
+    if not values:
+        return set()
+    return {
+        value.strip().lower()
+        for value in values
+        if isinstance(value, str) and value.strip()
+    }
+
+
+def profile_terms(user):
+    if not user or not getattr(user, 'is_authenticated', False):
+        return {field: set() for field in PROFILE_FIELDS}
+    return {
+        field: normalize_terms(getattr(user, field, []) or [])
+        for field in PROFILE_FIELDS
+    }
+
+
+def has_profile_terms(user):
+    terms = profile_terms(user)
+    return any(terms[field] for field in PROFILE_FIELDS)
+
+
+def attach_rank(obj, score, reason):
+    obj.rank_score = score
+    obj.rank_reason = reason
+    return obj
+
+
+def rank_items(items, user, scorer, *, recency_attr='created_at', personalize=True, scorer_kwargs=None):
+    """Rank items based on user profile.
+
+    If personalize=False, or user has no profile terms, returns items as-is
+    so the caller can keep DB-level pagination and lazy evaluation.
+    """
+    if not personalize or not has_profile_terms(user):
+        return items
+
+    if scorer_kwargs is None:
+        scorer_kwargs = {}
+
+    items = list(items)
+    ranked = []
+    for index, item in enumerate(items):
+        score, reason = scorer(item, user, **scorer_kwargs)
+        attach_rank(item, score, reason)
+        ranked.append((item, index))
+
+    ranked.sort(
+        key=lambda pair: (
+            -pair[0].rank_score,
+            -_timestamp(getattr(pair[0], recency_attr, None)),
+            -int(getattr(pair[0], 'id', 0) or 0),
+            pair[1],
+        )
+    )
+    return [item for item, _ in ranked]
+
+
+def rank_payloads(payloads, *, recency_key='created_at'):
+    payloads = list(payloads)
+    payloads.sort(
+        key=lambda item: (
+            -int(item.get('rank_score') or 0),
+            -_timestamp(item.get(recency_key)),
+            -int(item.get('id') or 0),
+        )
+    )
+    return payloads
+
+
+def score_recipe(recipe, user, weights=None):
+    if weights is None:
+        weights = WEIGHTS
+    terms = profile_terms(user)
+
+    region_name = getattr(getattr(recipe, 'region', None), 'name', None)
+    dietary_candidates = [
+        *_names_from_related(getattr(recipe, 'dietary_tags', None)),
+        *_names_from_related(getattr(recipe, 'religions', None)),
+    ]
+    event_candidates = _names_from_related(getattr(recipe, 'event_tags', None))
+
+    contributions = {
+        'regional': _weighted_intersection(
+            terms['regional_ties'],
+            [region_name],
+            weights['regional'],
+        ),
+        'dietary': _weighted_intersection(
+            terms['religious_preferences'],
+            dietary_candidates,
+            weights['dietary'],
+        ),
+        'event': _weighted_intersection(
+            terms['event_interests'],
+            event_candidates,
+            weights['event'],
+        ),
+        'cultural': _weighted_text_matches(
+            terms['cultural_interests'],
+            [
+                getattr(recipe, 'title', ''),
+                getattr(recipe, 'description', ''),
+                region_name or '',
+                *dietary_candidates,
+                *event_candidates,
+            ],
+            weights['cultural'],
+        ),
+    }
+    return _score_and_reason(contributions, weights)
+
+
+def score_story(story, user, weights=None):
+    if weights is None:
+        weights = WEIGHTS
+    terms = profile_terms(user)
+
+    # Story carries its own region (#381) and taxonomy (#386 / #388) since the
+    # story-centric refactor (#379). Linked recipes are now M2M via
+    # StoryRecipeLink and contribute as fallback / additional signal.
+    direct_region = getattr(story, 'region', None)
+    story_dietary = _names_from_related(getattr(story, 'dietary_tags', None))
+    story_events = _names_from_related(getattr(story, 'event_tags', None))
+    story_religions = _names_from_related(getattr(story, 'religions', None))
+
+    linked_recipes = _linked_recipes(story)
+
+    region_candidates = []
+    if direct_region is not None:
+        region_candidates.append(getattr(direct_region, 'name', None))
+    for recipe in linked_recipes:
+        rgn = getattr(recipe, 'region', None)
+        if rgn is not None:
+            region_candidates.append(getattr(rgn, 'name', None))
+
+    dietary_candidates = list(story_dietary)
+    event_candidates = list(story_events)
+    religion_candidates = list(story_religions)
+    for recipe in linked_recipes:
+        dietary_candidates += _names_from_related(getattr(recipe, 'dietary_tags', None))
+        event_candidates += _names_from_related(getattr(recipe, 'event_tags', None))
+        religion_candidates += _names_from_related(getattr(recipe, 'religions', None))
+
+    contributions = {
+        'regional': _weighted_intersection(
+            terms['regional_ties'],
+            region_candidates,
+            weights['regional'],
+        ),
+        'dietary': _weighted_intersection(
+            terms['religious_preferences'],
+            [*dietary_candidates, *religion_candidates],
+            weights['dietary'],
+        ),
+        'event': _weighted_intersection(
+            terms['event_interests'],
+            event_candidates,
+            weights['event'],
+        ),
+        'cultural': _weighted_text_matches(
+            terms['cultural_interests'],
+            [
+                getattr(story, 'title', ''),
+                getattr(story, 'body', ''),
+                *[getattr(recipe, 'title', '') for recipe in linked_recipes],
+                *[getattr(recipe, 'description', '') for recipe in linked_recipes],
+                *region_candidates,
+                *dietary_candidates,
+                *event_candidates,
+                *religion_candidates,
+            ],
+            weights['cultural'],
+        ),
+    }
+    return _score_and_reason(contributions, weights)
+
+
+def score_cultural_content(content, user, weights=None):
+    if weights is None:
+        weights = WEIGHTS
+    terms = profile_terms(user)
+    tags = getattr(content, 'cultural_tags', []) or []
+
+    # CulturalContent now carries a Region FK (#381) plus a legacy region_text
+    # string. Use whichever resolves to a name.
+    region_obj = getattr(content, 'region', None)
+    region_name = getattr(region_obj, 'name', None) if region_obj is not None else None
+    region_text = getattr(content, 'region_text', None) or region_name
+
+    contributions = {
+        'regional': _weighted_intersection(
+            terms['regional_ties'],
+            [region_name, region_text, *tags],
+            weights['regional'],
+        ),
+        'dietary': _weighted_intersection(
+            terms['religious_preferences'],
+            tags,
+            weights['dietary'],
+        ),
+        'event': _weighted_intersection(
+            terms['event_interests'],
+            tags,
+            weights['event'],
+        ),
+        'cultural': _weighted_text_matches(
+            terms['cultural_interests'],
+            [
+                getattr(content, 'title', ''),
+                getattr(content, 'body', ''),
+                region_name or '',
+                region_text or '',
+                *tags,
+            ],
+            weights['cultural'],
+        ),
+    }
+    return _score_and_reason(contributions, weights)
+
+
+def _linked_recipes(story):
+    """Materialize linked recipes from Story.recipe_links (M2M via StoryRecipeLink)."""
+    recipe_links = getattr(story, 'recipe_links', None)
+    if recipe_links is None:
+        return []
+    if hasattr(recipe_links, 'all'):
+        recipe_links = recipe_links.all()
+    return [getattr(link, 'recipe', None) for link in recipe_links if getattr(link, 'recipe', None) is not None]
+
+
+def _weighted_intersection(preferences, candidates, weight):
+    matches = preferences & normalize_terms(candidates)
+    return len(matches) * weight
+
+
+def _weighted_text_matches(preferences, text_values, weight):
+    if not preferences:
+        return 0
+    haystack = ' '.join(str(value).lower() for value in text_values if value)
+    matches = 0
+    for term in preferences:
+        if term in haystack:
+            matches += 1
+            continue
+        tokens = _significant_tokens(term)
+        if tokens and any(token in haystack for token in tokens):
+            matches += 1
+    return matches * weight
+
+
+def _significant_tokens(term):
+    stop_words = {'cuisine', 'food', 'dish', 'dishes', 'tradition', 'traditions'}
+    return [
+        token
+        for token in term.replace('-', ' ').split()
+        if len(token) > 2 and token not in stop_words
+    ]
+
+
+def _names_from_related(related):
+    if related is None:
+        return []
+    if hasattr(related, 'all'):
+        related = related.all()
+    return [getattr(item, 'name', None) for item in related]
+
+
+def _score_and_reason(contributions, weights):
+    score = sum(contributions.values())
+    if score <= 0:
+        return 0, None
+    reason_key = max(
+        ('regional', 'dietary', 'event', 'cultural'),
+        key=lambda key: (contributions[key], weights[key]),
+    )
+    return score, RANK_REASONS[reason_key]
+
+
+def _timestamp(value):
+    if not value:
+        return 0
+    if isinstance(value, datetime):
+        return value.timestamp()
+    try:
+        return datetime.fromisoformat(str(value).replace('Z', '+00:00')).timestamp()
+    except ValueError:
+        return 0

--- a/app/backend/apps/common/tests/test_personalization_refinement.py
+++ b/app/backend/apps/common/tests/test_personalization_refinement.py
@@ -1,0 +1,81 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from rest_framework.test import APIClient
+
+from apps.common.personalization import has_profile_terms
+from apps.recipes.models import Recipe, Region
+from apps.stories.models import Story, StoryRecipeLink
+
+User = get_user_model()
+
+
+class PersonalizationRefinementTest(TestCase):
+    """End-to-end coverage for opt-out, anonymous behavior, and the
+    recommendations endpoint introduced alongside ranking."""
+
+    def setUp(self):
+        self.client = APIClient()
+        self.region, _ = Region.objects.get_or_create(name='Mediterranean')
+        self.user_with_profile = User.objects.create_user(
+            username='profi',
+            email='profi@example.com',
+            password='password',
+            regional_ties=['Mediterranean'],
+            cultural_interests=['Pasta'],
+        )
+        self.user_no_profile = User.objects.create_user(
+            username='noprofi',
+            email='noprofi@example.com',
+            password='password',
+        )
+        self.recipe = Recipe.objects.create(
+            title='Mediterranean Pasta',
+            description='Classic pasta',
+            region=self.region,
+            author=self.user_no_profile,
+            is_published=True,
+        )
+        self.story = Story.objects.create(
+            title='My Pasta Story',
+            body='I love pasta',
+            author=self.user_no_profile,
+            region=self.region,
+            is_published=True,
+        )
+        StoryRecipeLink.objects.create(story=self.story, recipe=self.recipe, order=0)
+
+    def test_anonymous_user_no_ranking(self):
+        response = self.client.get('/api/recipes/')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('results', response.data)
+        for item in response.data['results']:
+            self.assertEqual(item.get('rank_score', 0), 0)
+
+    def test_personalize_opt_out(self):
+        self.client.force_authenticate(user=self.user_with_profile)
+
+        res_on = self.client.get('/api/recipes/')
+        res_off = self.client.get('/api/recipes/?personalize=0')
+
+        self.assertEqual(res_on.status_code, 200)
+        self.assertEqual(res_off.status_code, 200)
+
+        self.assertGreater(res_on.data['results'][0]['rank_score'], 0)
+        self.assertEqual(res_off.data['results'][0]['rank_score'], 0)
+
+    def test_story_response_shape_is_paginated(self):
+        response = self.client.get('/api/stories/')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('count', response.data)
+        self.assertIn('results', response.data)
+        self.assertIsInstance(response.data['results'], list)
+
+    def test_has_profile_terms_utility(self):
+        self.assertTrue(has_profile_terms(self.user_with_profile))
+        self.assertFalse(has_profile_terms(self.user_no_profile))
+
+    def test_recommendations_limit_and_surface(self):
+        response = self.client.get('/api/recommendations/?limit=1&surface=map')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data['results']), 1)
+        self.assertEqual(response.data['surface'], 'map')

--- a/app/backend/apps/common/tests_personalization.py
+++ b/app/backend/apps/common/tests_personalization.py
@@ -1,0 +1,183 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from apps.common.personalization import (
+    rank_items,
+    score_cultural_content,
+    score_recipe,
+    score_story,
+)
+from apps.cultural_content.models import CulturalContent
+from apps.recipes.models import DietaryTag, EventTag, Recipe, Region, Religion
+from apps.stories.models import Story, StoryRecipeLink
+
+User = get_user_model()
+
+
+class PersonalizationScoringTest(TestCase):
+    def setUp(self):
+        self.author = User.objects.create_user(
+            email='author@example.com', username='author', password='Pass123!'
+        )
+        self.aegean, _ = Region.objects.get_or_create(name='Aegean')
+        self.black_sea, _ = Region.objects.get_or_create(name='Black Sea')
+        self.halal, _ = DietaryTag.objects.get_or_create(
+            name='Halal', defaults={'is_approved': True}
+        )
+        self.ramadan, _ = EventTag.objects.get_or_create(
+            name='Ramadan', defaults={'is_approved': True}
+        )
+        self.islam, _ = Religion.objects.get_or_create(name='Islam')
+
+    def test_profileless_user_scores_zero(self):
+        recipe = Recipe.objects.create(
+            title='Aegean Pilaf',
+            description='A family table recipe.',
+            region=self.aegean,
+            author=self.author,
+            is_published=True,
+        )
+        score, reason = score_recipe(recipe, self.author)
+        self.assertEqual(score, 0)
+        self.assertIsNone(reason)
+
+    def test_recipe_scoring_is_case_insensitive_and_weighted(self):
+        user = User.objects.create_user(
+            email='fan@example.com',
+            username='fan',
+            password='Pass123!',
+            regional_ties=['aegean'],
+            religious_preferences=['halal'],
+            event_interests=['ramadan'],
+            cultural_interests=['family table'],
+        )
+        recipe = Recipe.objects.create(
+            title='Aegean Pilaf',
+            description='A family table recipe.',
+            region=self.aegean,
+            author=self.author,
+            is_published=True,
+        )
+        recipe.dietary_tags.set([self.halal])
+        recipe.event_tags.set([self.ramadan])
+
+        score, reason = score_recipe(recipe, user)
+
+        self.assertGreater(score, 0)
+        self.assertEqual(reason, 'regional_match')
+
+    def test_recipe_religion_contributes_to_dietary_axis(self):
+        """Religion taxonomy (#388) participates in the dietary axis since
+        religious_preferences captures both dietary religion and religion proper."""
+        user = User.objects.create_user(
+            email='muslim@example.com',
+            username='muslim_user',
+            password='Pass123!',
+            religious_preferences=['islam'],
+        )
+        recipe = Recipe.objects.create(
+            title='Eid Lamb',
+            description='Holiday roast.',
+            author=self.author,
+            is_published=True,
+        )
+        recipe.religions.set([self.islam])
+
+        score, reason = score_recipe(recipe, user)
+        self.assertGreater(score, 0)
+        self.assertEqual(reason, 'dietary_match')
+
+    def test_story_scores_using_direct_region_and_linked_recipe(self):
+        """Story now carries its own region and taxonomy, with linked recipes
+        contributing additional signal via recipe_links (M2M)."""
+        user = User.objects.create_user(
+            email='storyfan@example.com',
+            username='storyfan',
+            password='Pass123!',
+            regional_ties=['Black Sea'],
+        )
+        recipe = Recipe.objects.create(
+            title='Anchovy Rice',
+            description='Coastal recipe.',
+            region=self.black_sea,
+            author=self.author,
+            is_published=True,
+        )
+        story = Story.objects.create(
+            title='Grandma remembers',
+            body='A kitchen memory.',
+            author=self.author,
+            is_published=True,
+        )
+        StoryRecipeLink.objects.create(story=story, recipe=recipe, order=0)
+
+        score, reason = score_story(story, user)
+
+        self.assertGreater(score, 0)
+        self.assertEqual(reason, 'regional_match')
+
+    def test_story_scores_on_direct_region_without_linked_recipe(self):
+        user = User.objects.create_user(
+            email='direct@example.com',
+            username='direct',
+            password='Pass123!',
+            regional_ties=['Aegean'],
+        )
+        story = Story.objects.create(
+            title='Olive harvest',
+            body='Family memory.',
+            author=self.author,
+            region=self.aegean,
+            is_published=True,
+        )
+
+        score, reason = score_story(story, user)
+        self.assertGreater(score, 0)
+        self.assertEqual(reason, 'regional_match')
+
+    def test_cultural_content_scores_on_tags(self):
+        user = User.objects.create_user(
+            email='culture@example.com',
+            username='culture',
+            password='Pass123!',
+            event_interests=['Ramadan'],
+        )
+        content = CulturalContent.objects.create(
+            slug='ramadan-table',
+            kind=CulturalContent.Kind.TRADITION,
+            title='Ramadan Table',
+            body='Shared evening meals.',
+            cultural_tags=['Ramadan'],
+        )
+
+        score, reason = score_cultural_content(content, user)
+
+        self.assertEqual(score, 25)
+        self.assertEqual(reason, 'event_match')
+
+    def test_rank_items_tiebreaks_by_recency_then_id(self):
+        user = User.objects.create_user(
+            email='recent@example.com',
+            username='recent',
+            password='Pass123!',
+            regional_ties=['Aegean'],
+        )
+        older = Recipe.objects.create(
+            title='Older',
+            description='Aegean dish.',
+            region=self.aegean,
+            author=self.author,
+            is_published=True,
+        )
+        newer = Recipe.objects.create(
+            title='Newer',
+            description='Aegean dish.',
+            region=self.aegean,
+            author=self.author,
+            is_published=True,
+        )
+
+        ranked = rank_items([older, newer], user, score_recipe)
+
+        self.assertEqual(ranked[0], newer)
+        self.assertEqual(ranked[1], older)

--- a/app/backend/apps/cultural_content/views.py
+++ b/app/backend/apps/cultural_content/views.py
@@ -2,27 +2,11 @@ from rest_framework import permissions
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from apps.common.personalization import rank_items, score_cultural_content
 from .models import CulturalContent
 from .serializers import CulturalContentCardSerializer
 
 DAILY_LIMIT = 8
-
-
-def _user_tag_set(user):
-    """Concatenate the four onboarding tag axes into a single lowercase set."""
-    if not user or not user.is_authenticated:
-        return set()
-    tags = []
-    for field in ('cultural_interests', 'regional_ties', 'religious_preferences', 'event_interests'):
-        tags.extend(getattr(user, field, []) or [])
-    return {t.strip().lower() for t in tags if isinstance(t, str) and t.strip()}
-
-
-def _score(content, user_tag_set):
-    if not user_tag_set:
-        return 0
-    content_tags = {t.strip().lower() for t in (content.cultural_tags or []) if isinstance(t, str) and t.strip()}
-    return len(content_tags & user_tag_set)
 
 
 class DailyCulturalContentView(APIView):
@@ -37,9 +21,12 @@ class DailyCulturalContentView(APIView):
     permission_classes = [permissions.AllowAny]
 
     def get(self, request):
-        user_tags = _user_tag_set(request.user)
-        items = list(CulturalContent.objects.filter(is_active=True).select_related('region'))
-        # Sort by personalization score (desc) then by creation order (ID desc)
-        items.sort(key=lambda c: (-_score(c, user_tags), -c.id))
+        items = list(
+            CulturalContent.objects
+            .filter(is_active=True)
+            .select_related('region')
+            .order_by('-created_at', '-id')
+        )
+        items = rank_items(items, request.user, score_cultural_content)
         items = items[:DAILY_LIMIT]
         return Response(CulturalContentCardSerializer(items, many=True).data)

--- a/app/backend/apps/recipes/serializers.py
+++ b/app/backend/apps/recipes/serializers.py
@@ -136,6 +136,8 @@ class RecipeSerializer(serializers.ModelSerializer):
         many=True, write_only=True, required=False,
     )
     story_count = serializers.IntegerField(read_only=True, default=0)
+    rank_score = serializers.SerializerMethodField()
+    rank_reason = serializers.SerializerMethodField()
 
     class Meta:
         model = Recipe
@@ -147,8 +149,15 @@ class RecipeSerializer(serializers.ModelSerializer):
             'dietary_tags', 'event_tags', 'religions',
             'dietary_tag_ids', 'event_tag_ids', 'religion_ids',
             'story_count',
+            'rank_score', 'rank_reason',
         ]
         read_only_fields = ['author', 'created_at', 'updated_at']
+
+    def get_rank_score(self, obj):
+        return getattr(obj, 'rank_score', 0)
+
+    def get_rank_reason(self, obj):
+        return getattr(obj, 'rank_reason', None)
 
     def validate(self, data):
         if self.context['request'].method == 'POST':

--- a/app/backend/apps/recipes/views.py
+++ b/app/backend/apps/recipes/views.py
@@ -10,6 +10,8 @@ from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.parsers import MultiPartParser, FormParser, JSONParser
 from apps.common.permissions import IsAuthorOrReadOnly
+from apps.common.pagination import StandardResultsSetPagination
+from apps.common.personalization import rank_items, score_recipe, has_profile_terms
 from .models import (
     Recipe, Ingredient, Unit, Region, Comment, DietaryTag, EventTag, Religion, Vote,
     IngredientSubstitution,
@@ -81,13 +83,6 @@ def apply_content_filters(qs, params):
 def apply_recipe_filters(qs, params):
     return apply_content_filters(qs, params)
 
-from rest_framework.pagination import PageNumberPagination
-
-class StandardResultsSetPagination(PageNumberPagination):
-    page_size = 10
-    page_size_query_param = 'page_size'
-    max_page_size = 100
-
 class RecipeViewSet(viewsets.ModelViewSet):
     """ViewSet for list/detail and management of Recipes."""
     queryset = Recipe.objects.select_related('region', 'author').prefetch_related(
@@ -106,6 +101,21 @@ class RecipeViewSet(viewsets.ModelViewSet):
         if self.action == 'list':
             qs = apply_recipe_filters(qs, self.request.query_params)
         return qs
+
+    def list(self, request, *args, **kwargs):
+        personalize = request.query_params.get('personalize') != '0'
+        if not personalize or not has_profile_terms(request.user):
+            return super().list(request, *args, **kwargs)
+
+        queryset = self.filter_queryset(self.get_queryset())
+        items = rank_items(queryset[:500], request.user, score_recipe)
+
+        page = self.paginate_queryset(items)
+        if page is not None:
+            serializer = self.get_serializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+        serializer = self.get_serializer(items, many=True)
+        return Response(serializer.data)
 
     def perform_create(self, serializer):
         serializer.save(author=self.request.user)

--- a/app/backend/apps/search/urls.py
+++ b/app/backend/apps/search/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
-from .views import GlobalSearchView
+from .views import GlobalSearchView, RecommendationsView
 
 urlpatterns = [
     path('search/', GlobalSearchView.as_view(), name='global_search'),
+    path('recommendations/', RecommendationsView.as_view(), name='recommendations'),
 ]

--- a/app/backend/apps/search/views.py
+++ b/app/backend/apps/search/views.py
@@ -1,10 +1,77 @@
-from rest_framework.views import APIView
-from rest_framework.response import Response
-from rest_framework import status
 from django.db.models import Q
+from rest_framework import permissions, status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.common.personalization import (
+    has_profile_terms,
+    rank_items,
+    rank_payloads,
+    score_recipe,
+    score_story,
+    WEIGHTS,
+)
 from apps.recipes.models import Recipe
 from apps.recipes.views import apply_content_filters
 from apps.stories.models import Story
+
+
+def _serialize_recipe_payload(recipe):
+    return {
+        'result_type': 'recipe',
+        'id': recipe.id,
+        'title': recipe.title,
+        'description': recipe.description[:200],
+        'image': recipe.image.url if recipe.image else None,
+        'region_tag': recipe.region.name if recipe.region else None,
+        'author_username': recipe.author.username,
+        'created_at': recipe.created_at,
+        'rank_score': getattr(recipe, 'rank_score', 0),
+        'rank_reason': getattr(recipe, 'rank_reason', None),
+    }
+
+
+def _serialize_story_payload(story):
+    # Direct region first, then fall back to the first linked recipe's region.
+    links = list(story.recipe_links.all())
+    first_link = links[0] if links else None
+
+    if story.region_id:
+        region_tag = story.region.name
+    elif first_link and first_link.recipe.region:
+        region_tag = first_link.recipe.region.name
+    else:
+        region_tag = None
+
+    return {
+        'result_type': 'story',
+        'id': story.id,
+        'title': story.title,
+        'body': story.body[:200],
+        'image': story.image.url if story.image else None,
+        'region_tag': region_tag,
+        'linked_recipe_id': first_link.recipe_id if first_link else None,
+        'author_username': story.author.username,
+        'created_at': story.created_at,
+        'rank_score': getattr(story, 'rank_score', 0),
+        'rank_reason': getattr(story, 'rank_reason', None),
+    }
+
+
+def _recipe_queryset():
+    return Recipe.objects.select_related('region', 'author').prefetch_related(
+        'dietary_tags', 'event_tags', 'religions',
+    ).filter(is_published=True)
+
+
+def _story_queryset():
+    return Story.objects.select_related('author', 'region').prefetch_related(
+        'recipe_links__recipe__region',
+        'recipe_links__recipe__dietary_tags',
+        'recipe_links__recipe__event_tags',
+        'recipe_links__recipe__religions',
+        'dietary_tags', 'event_tags', 'religions',
+    ).filter(is_published=True)
 
 
 class GlobalSearchView(APIView):
@@ -13,55 +80,14 @@ class GlobalSearchView(APIView):
     Public search across Recipes and Stories.
     Returns unified results with type metadata for frontend navigation.
     """
-    permission_classes = []
-    authentication_classes = []
-
-    def _serialize_recipe(self, recipe):
-        return {
-            'result_type': 'recipe',
-            'id': recipe.id,
-            'title': recipe.title,
-            'description': recipe.description[:200],
-            'image': recipe.image.url if recipe.image else None,
-            'region_tag': recipe.region.name if recipe.region else None,
-            'author_username': recipe.author.username,
-            'created_at': recipe.created_at,
-        }
-
-    def _serialize_story(self, story):
-        # Prefer the story's direct region; fall back to its FIRST linked recipe's region
-        links = list(story.recipe_links.all())
-        first_link = links[0] if links else None
-        
-        if story.region_id:
-            region_tag = story.region.name
-        elif first_link and first_link.recipe.region:
-            region_tag = first_link.recipe.region.name
-        else:
-            region_tag = None
-
-        return {
-            'result_type': 'story',
-            'id': story.id,
-            'title': story.title,
-            'body': story.body[:200],
-            'region_tag': region_tag,
-            'linked_recipe_id': first_link.recipe_id if first_link else None,
-            'author_username': story.author.username,
-            'created_at': story.created_at,
-        }
+    permission_classes = [permissions.AllowAny]
 
     def get(self, request):
         query = request.query_params.get('q', '').strip()
-        region_name = request.query_params.get('region', '').strip()
         language = request.query_params.get('language', '').strip()
 
-        recipes = Recipe.objects.select_related('region', 'author').prefetch_related(
-            'dietary_tags', 'event_tags', 'religions',
-        ).filter(is_published=True)
-        stories = Story.objects.select_related('author', 'region').prefetch_related(
-            'recipe_links__recipe__region', 'dietary_tags', 'event_tags', 'religions',
-        ).filter(is_published=True)
+        recipes = _recipe_queryset()
+        stories = _story_queryset()
 
         if query:
             recipes = recipes.filter(Q(title__icontains=query) | Q(description__icontains=query))
@@ -74,11 +100,79 @@ class GlobalSearchView(APIView):
         recipes = apply_content_filters(recipes, request.query_params)
         stories = apply_content_filters(stories, request.query_params)
 
-        recipe_results = [self._serialize_recipe(r) for r in recipes]
-        story_results = [self._serialize_story(s) for s in stories]
+        personalize = request.query_params.get('personalize') != '0'
+        use_ranking = personalize and has_profile_terms(request.user)
+
+        if use_ranking:
+            ranked_recipes = rank_items(recipes[:500], request.user, score_recipe)
+            ranked_stories = rank_items(stories[:500], request.user, score_story)
+        else:
+            ranked_recipes = recipes[:100]
+            ranked_stories = stories[:100]
+
+        recipe_results = [_serialize_recipe_payload(r) for r in ranked_recipes]
+        story_results = [_serialize_story_payload(s) for s in ranked_stories]
+        unified = rank_payloads(recipe_results + story_results)
 
         return Response({
             'recipes': recipe_results,
             'stories': story_results,
+            'results': unified,
             'total_count': len(recipe_results) + len(story_results),
         }, status=status.HTTP_200_OK)
+
+
+class RecommendationsView(APIView):
+    """GET /api/recommendations/?surface=feed|explore|map|recs&limit=10
+
+    Returns a single unified ranked feed across recipes and stories.
+    `surface` adjusts the ranking weights: map biases toward regional matches,
+    others use the default weights.
+    """
+    permission_classes = [permissions.AllowAny]
+
+    def get(self, request):
+        surface = (request.query_params.get('surface') or 'feed').strip()
+        limit = _bounded_limit(request.query_params.get('limit'), default=10, maximum=50)
+
+        recipes = _recipe_queryset()
+        stories = _story_queryset()
+
+        personalize = request.query_params.get('personalize') != '0'
+        use_ranking = personalize and has_profile_terms(request.user)
+
+        weights = dict(WEIGHTS)
+        if surface == 'map':
+            weights['regional'] = int(weights['regional'] * 1.5)
+
+        if use_ranking:
+            ranked_recipes = rank_items(
+                recipes[:500], request.user, score_recipe,
+                scorer_kwargs={'weights': weights},
+            )
+            ranked_stories = rank_items(
+                stories[:500], request.user, score_story,
+                scorer_kwargs={'weights': weights},
+            )
+        else:
+            ranked_recipes = recipes[:limit]
+            ranked_stories = stories[:limit]
+
+        results = rank_payloads(
+            [_serialize_recipe_payload(r) for r in ranked_recipes]
+            + [_serialize_story_payload(s) for s in ranked_stories]
+        )[:limit]
+
+        return Response({
+            'surface': surface,
+            'results': results,
+            'total_count': len(results),
+        }, status=status.HTTP_200_OK)
+
+
+def _bounded_limit(raw_value, *, default, maximum):
+    try:
+        value = int(raw_value)
+    except (TypeError, ValueError):
+        return default
+    return min(max(value, 1), maximum)

--- a/app/backend/apps/stories/serializers.py
+++ b/app/backend/apps/stories/serializers.py
@@ -55,6 +55,9 @@ class StorySerializer(serializers.ModelSerializer):
     # Expose region name for frontend display (string, not FK id)
     region_name = serializers.SerializerMethodField()
 
+    rank_score = serializers.SerializerMethodField()
+    rank_reason = serializers.SerializerMethodField()
+
     class Meta:
         model = Story
         fields = [
@@ -65,9 +68,16 @@ class StorySerializer(serializers.ModelSerializer):
             'dietary_tags', 'event_tags', 'religions',
             'dietary_tag_ids', 'event_tag_ids', 'religion_ids',
             'language', 'region', 'region_name',
-            'is_published', 'created_at', 'updated_at'
+            'is_published', 'created_at', 'updated_at',
+            'rank_score', 'rank_reason',
         ]
         read_only_fields = ['author', 'created_at', 'updated_at']
+
+    def get_rank_score(self, obj):
+        return getattr(obj, 'rank_score', 0)
+
+    def get_rank_reason(self, obj):
+        return getattr(obj, 'rank_reason', None)
 
     def to_internal_value(self, data):
         """Shim to handle legacy 'linked_recipe' as 'linked_recipe_id'."""

--- a/app/backend/apps/stories/tests.py
+++ b/app/backend/apps/stories/tests.py
@@ -132,10 +132,8 @@ class StoryRetrieveAPITest(APITestCase):
     def test_public_list_shows_published_only(self):
         response = self.client.get(reverse('story-list'))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        # In a real DRF list, it might be in a 'results' key if paginated, 
-        # but the StoryViewSet doesn't specify pagination (defaults to none or global).
-        # Based on previous view_file, it returns a list directly.
-        titles = [s['title'] for s in response.data]
+        results = response.data.get('results', response.data)
+        titles = [s['title'] for s in results]
         self.assertIn("Published Story", titles)
         self.assertNotIn("Draft Story", titles)
 
@@ -154,7 +152,8 @@ class StoryRetrieveAPITest(APITestCase):
     def test_author_can_see_own_drafts(self):
         self.client.force_authenticate(user=self.user)
         response = self.client.get(reverse('story-list'))
-        titles = [s['title'] for s in response.data]
+        results = response.data.get('results', response.data)
+        titles = [s['title'] for s in results]
         self.assertIn("Draft Story", titles)
 
 

--- a/app/backend/apps/stories/views.py
+++ b/app/backend/apps/stories/views.py
@@ -2,18 +2,29 @@ from rest_framework import viewsets, permissions
 from rest_framework.decorators import action
 from rest_framework.parsers import MultiPartParser, FormParser, JSONParser
 from rest_framework.response import Response
+
 from apps.common.permissions import IsAuthorOrReadOnly
+from apps.common.pagination import StandardResultsSetPagination
+from apps.common.personalization import rank_items, score_story, has_profile_terms
 from .models import Story
 from .serializers import StorySerializer
 
+
 class StoryViewSet(viewsets.ModelViewSet):
     """ViewSet for list/detail and management of Stories."""
-    queryset = Story.objects.select_related('author').prefetch_related(
-        'recipe_links__recipe__region', 'region'
+    queryset = Story.objects.select_related('author', 'region').prefetch_related(
+        'recipe_links__recipe__region',
+        'recipe_links__recipe__dietary_tags',
+        'recipe_links__recipe__event_tags',
+        'recipe_links__recipe__religions',
+        'dietary_tags',
+        'event_tags',
+        'religions',
     ).all()
     serializer_class = StorySerializer
     permission_classes = [permissions.IsAuthenticatedOrReadOnly, IsAuthorOrReadOnly]
     parser_classes = [MultiPartParser, FormParser, JSONParser]
+    pagination_class = StandardResultsSetPagination
 
     def get_queryset(self):
         qs = super().get_queryset()
@@ -21,6 +32,21 @@ class StoryViewSet(viewsets.ModelViewSet):
             if not self.request.user.is_authenticated:
                 return qs.filter(is_published=True)
         return qs
+
+    def list(self, request, *args, **kwargs):
+        personalize = request.query_params.get('personalize') != '0'
+        if not personalize or not has_profile_terms(request.user):
+            return super().list(request, *args, **kwargs)
+
+        queryset = self.filter_queryset(self.get_queryset())
+        items = rank_items(queryset[:500], request.user, score_story)
+
+        page = self.paginate_queryset(items)
+        if page is not None:
+            serializer = self.get_serializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+        serializer = self.get_serializer(items, many=True)
+        return Response(serializer.data)
 
     def perform_create(self, serializer):
         serializer.save(author=self.request.user)


### PR DESCRIPTION
## Summary

Brings the orphaned preference-driven personalization work to `main` so #345 can close. The original PR #443 ("Closes #345") merged into `feat/backend/contact-toggle` an hour after that branch had already been squashed to `main`, so #443's commits never reached `main`. This PR re-applies the same logic and adapts it to the post-#379 story-centric model and the Religion taxonomy from #459.

## What ships

New modules:
- `apps/common/personalization.py`: 4-axis weighted scoring (regional 40, dietary 30, event 25, cultural 15) plus `rank_items` / `rank_payloads` helpers and per-axis scorers (`score_recipe`, `score_story`, `score_cultural_content`).
- `apps/common/pagination.py`: shared `StandardResultsSetPagination` (extracted from `recipes/views.py`).
- New endpoint `GET /api/recommendations/?surface={feed,explore,map,recs}&limit=N` with surface-aware weighting (map biases regional matches by 1.5x).

Integration:
- `RecipeViewSet`, `StoryViewSet`, `GlobalSearchView`: cap-then-rank pattern (top 500 from queryset, rank, paginate). `?personalize=0` opts out. Anonymous and profileless users keep the lazy DB-paginated path so existing behavior is preserved.
- `DailyCulturalContentView`: the local `_user_tag_set` / `_score` are replaced by the centralized scorer, so cultural daily uses the same 4-axis weighting as the rest of the app.
- `RecipeSerializer` and `StorySerializer`: `rank_score` and `rank_reason` `SerializerMethodField`s reading attributes attached during ranking.

M2M adaptation (vs the original PR #443):
- `score_story` now reads `story.region`, `story.dietary_tags`, `story.event_tags`, and `story.religions` directly (the story-centric refactor #379 + tag taxonomy #386 / #388 moved these onto Story). Linked recipes are aggregated via `recipe_links` (the M2M through `StoryRecipeLink`) and contribute as additional signal.
- `score_recipe` folds `Recipe.religions` into the dietary axis since `religious_preferences` on the user model captures both dietary-religious values (Halal, Kosher) and religion proper (Islam, Christianity).
- `StoryViewSet` prefetch expanded to cover the new ranking signals, so the scorer evaluates with no extra queries.

Tests:
- 7 unit tests in `apps/common/tests_personalization.py` covering each scorer, religion-on-dietary axis, story scoring with and without linked recipes, and rank tiebreak ordering.
- 5 end-to-end tests in `apps/common/tests/test_personalization_refinement.py` covering anonymous behavior, opt-out, paginated story shape, `has_profile_terms` utility, and the new recommendations endpoint.
- Two existing story list assertions updated to read `response.data.get('results', response.data)` since `StoryViewSet` now paginates.

## Test plan

- [x] `manage.py test apps.common apps.stories apps.search apps.cultural_content` (65 tests, all pass)
- [x] 12 new personalization-specific tests pass
- [x] Pre-existing `apps.recipes.tests_permissions` errors confirmed identical on `main` (issue #419, seed migration UNIQUE collisions, unrelated to this work)
- [ ] Manual smoke after deploy: authenticated user with onboarding profile sees non-zero `rank_score` on `/api/recipes/`, `/api/stories/`, `/api/search/`, `/api/recommendations/`
- [ ] Anonymous request returns 0 `rank_score` and standard ordering

## Notes

- Original commits were authored by @roboticrustacean (`e9e44f8` + `9cacce9`). I rebuilt them on top of current `main` rather than rebasing the conflicting history, since the model shape changed enough that a clean re-apply was simpler than line-by-line conflict resolution. Single squash commit on this branch.
- Mobile PR #454 ("consume personalization ranking on feed and search (#345)") is unblocked by this.

Closes #345.