### PR TITLE
feat(backend): domain-aware search query parsing (#389)

### DIFF
--- a/app/backend/apps/search/query_parser.py
+++ b/app/backend/apps/search/query_parser.py
@@ -1,0 +1,122 @@
+"""Lookup-driven natural-language query parser for domain-aware search (#389).
+
+Tokens from the raw query are matched against approved taxonomy names for
+Region, EventTag, DietaryTag, and Religion (longest-match-first). Matched
+tokens are consumed; the remainder becomes ``cleaned_query`` for the
+existing title/description ``icontains`` lookups.
+
+The parser is deliberately not LLM-driven: the lookup tables are small (tens
+of rows) so we can rebuild the map per request and keep behavior predictable.
+"""
+import re
+
+
+_STOPWORDS = frozenset({'a', 'an', 'the', 'and', 'or', 'with', 'for', 'of', 'in'})
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+
+def _normalize_tokens(text):
+    return _TOKEN_RE.findall(text.lower()) if text else []
+
+
+def _build_lookup_map():
+    """Return ``{tuple_of_tokens: (facet_type, canonical_name)}``.
+
+    Order: Region first so multi-word region names take precedence over any
+    accidental overlap with shorter tag names. Approved tags only.
+    """
+    from apps.recipes.models import Region, EventTag, DietaryTag, Religion
+
+    lookup = {}
+
+    def add(facet_type, name):
+        key = tuple(_normalize_tokens(name))
+        if key and key not in lookup:
+            lookup[key] = (facet_type, name)
+
+    for region in Region.objects.all():
+        add('region', region.name)
+    for event in EventTag.objects.filter(is_approved=True):
+        add('event', event.name)
+    for diet in DietaryTag.objects.filter(is_approved=True):
+        add('diet', diet.name)
+    for religion in Religion.objects.filter(is_approved=True):
+        add('religion', religion.name)
+
+    return lookup
+
+
+def parse_query(raw_query, lookup=None):
+    """Decompose a free-text search query into structured facets.
+
+    Returns a dict with keys ``cleaned_query`` (str), ``region`` (str|None),
+    ``event`` (str|None), ``diets`` (list[str]), ``religions`` (list[str]).
+
+    ``lookup`` is the matching map (see :func:`_build_lookup_map`). When
+    omitted the map is built from the database. Tests pass a fixed map to
+    keep the parser pure and DB-free.
+    """
+    result = {
+        'cleaned_query': '',
+        'region': None,
+        'event': None,
+        'diets': [],
+        'religions': [],
+    }
+
+    if not raw_query or not raw_query.strip():
+        return result
+
+    tokens = _normalize_tokens(raw_query)
+    if not tokens:
+        return result
+
+    if lookup is None:
+        lookup = _build_lookup_map()
+    if not lookup:
+        result['cleaned_query'] = ' '.join(t for t in tokens if t not in _STOPWORDS)
+        return result
+
+    max_phrase_len = max(len(k) for k in lookup)
+    consumed = [False] * len(tokens)
+
+    i = 0
+    while i < len(tokens):
+        matched_length = 0
+        for length in range(min(max_phrase_len, len(tokens) - i), 0, -1):
+            phrase = tuple(tokens[i:i + length])
+            entry = lookup.get(phrase)
+            if entry is None:
+                continue
+
+            facet_type, canonical = entry
+            if facet_type == 'region':
+                if result['region'] is None:
+                    result['region'] = canonical
+            elif facet_type == 'event':
+                if result['event'] is None:
+                    result['event'] = canonical
+            elif facet_type == 'diet':
+                if canonical not in result['diets']:
+                    result['diets'].append(canonical)
+            elif facet_type == 'religion':
+                if canonical not in result['religions']:
+                    result['religions'].append(canonical)
+
+            matched_length = length
+            break
+
+        if matched_length:
+            for k in range(i, i + matched_length):
+                consumed[k] = True
+            i += matched_length
+        else:
+            i += 1
+
+    leftover = [
+        token for idx, token in enumerate(tokens)
+        if not consumed[idx] and token not in _STOPWORDS
+    ]
+    result['cleaned_query'] = ' '.join(leftover)
+    return result

--- a/app/backend/apps/search/tests_domain_aware.py
+++ b/app/backend/apps/search/tests_domain_aware.py
@@ -1,0 +1,168 @@
+"""Endpoint tests for domain-aware search wiring (#389).
+
+Verifies that GlobalSearchView decomposes natural-language queries into
+facets, respects explicit query params, preserves the legacy behavior when
+nothing matches, and keeps the personalization ranking from #463 active.
+"""
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from apps.recipes.models import DietaryTag, EventTag, Recipe, Region
+
+User = get_user_model()
+
+
+class DomainAwareSearchTests(APITestCase):
+    """Exercises parse_query → apply_content_filters → ranker pipeline."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.url = reverse('global_search')
+
+        # Regions and taxonomy come from seed migrations 0004 / 0013, so we
+        # only fetch — never create — to stay aligned with prod data.
+        cls.balkan = Region.objects.get(name='Balkan')
+        cls.italian = Region.objects.get(name='Italian')
+        cls.wedding = EventTag.objects.get(name='Wedding')
+        cls.funeral = EventTag.objects.get(name='Funeral')
+        cls.vegan = DietaryTag.objects.get(name='Vegan')
+
+        cls.author = User.objects.create_user(
+            email='author@example.com', username='author', password='Pass123!',
+        )
+
+        cls.balkan_wedding_recipe = Recipe.objects.create(
+            title='Honey Cake',
+            description='A celebratory pastry served at family gatherings.',
+            region=cls.balkan, author=cls.author, is_published=True,
+        )
+        cls.balkan_wedding_recipe.event_tags.add(cls.wedding)
+
+        cls.balkan_funeral_recipe = Recipe.objects.create(
+            title='Memorial Bread',
+            description='A simple loaf shared in remembrance.',
+            region=cls.balkan, author=cls.author, is_published=True,
+        )
+        cls.balkan_funeral_recipe.event_tags.add(cls.funeral)
+
+        cls.italian_wedding_recipe = Recipe.objects.create(
+            title='Wedding Soup',
+            description='An Italian classic with tiny meatballs.',
+            region=cls.italian, author=cls.author, is_published=True,
+        )
+        cls.italian_wedding_recipe.event_tags.add(cls.wedding)
+
+        cls.unrelated_recipe = Recipe.objects.create(
+            title='Plain Pasta',
+            description='A weeknight staple.',
+            region=cls.italian, author=cls.author, is_published=True,
+        )
+
+    def test_query_decomposes_region_event_and_text_residual(self):
+        response = self.client.get(self.url, {'q': 'Balkan wedding dishes'})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        parsed = response.data['parsed']
+        self.assertEqual(parsed['region'], 'Balkan')
+        self.assertEqual(parsed['event'], 'Wedding')
+        self.assertEqual(parsed['diets'], [])
+        self.assertEqual(parsed['religions'], [])
+
+        # Only the Balkan + Wedding recipe should pass the facet filter, and
+        # its description contains "gatherings" which doesn't include
+        # "dishes" - residual text matching narrows further. Verify that the
+        # recipe is excluded if its title/description doesn't include "dishes".
+        recipe_titles = {r['title'] for r in response.data['recipes']}
+        self.assertNotIn('Plain Pasta', recipe_titles)
+        self.assertNotIn('Memorial Bread', recipe_titles)
+        self.assertNotIn('Wedding Soup', recipe_titles)
+
+    def test_facet_only_query_returns_facet_matches(self):
+        # No residual after parsing - only the facet filter narrows.
+        response = self.client.get(self.url, {'q': 'Balkan wedding'})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        recipe_titles = [r['title'] for r in response.data['recipes']]
+        self.assertEqual(recipe_titles, ['Honey Cake'])
+        self.assertEqual(response.data['parsed']['region'], 'Balkan')
+        self.assertEqual(response.data['parsed']['event'], 'Wedding')
+
+    def test_explicit_region_param_overrides_parser(self):
+        response = self.client.get(self.url, {'q': 'Balkan wedding', 'region': 'Italian'})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        # Parser still echoes what it saw, but the filter step kept the
+        # client-supplied region.
+        self.assertEqual(response.data['parsed']['region'], 'Balkan')
+        recipe_titles = [r['title'] for r in response.data['recipes']]
+        self.assertEqual(recipe_titles, ['Wedding Soup'])
+
+    def test_no_recognized_facet_behaves_like_old_search(self):
+        # "honey" doesn't match any taxonomy entry, so the parser leaves the
+        # query alone and we fall back to plain icontains matching.
+        response = self.client.get(self.url, {'q': 'honey'})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIsNone(response.data['parsed']['region'])
+        self.assertIsNone(response.data['parsed']['event'])
+        recipe_titles = [r['title'] for r in response.data['recipes']]
+        self.assertEqual(recipe_titles, ['Honey Cake'])
+
+    def test_diet_facet_extracted(self):
+        DietaryTag.objects.filter(name='Vegan').update(is_approved=True)
+        # Tag the Italian wedding recipe as vegan to make a unique target.
+        self.italian_wedding_recipe.dietary_tags.add(self.vegan)
+
+        response = self.client.get(self.url, {'q': 'vegan italian wedding'})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['parsed']['diets'], ['Vegan'])
+        self.assertEqual(response.data['parsed']['region'], 'Italian')
+        self.assertEqual(response.data['parsed']['event'], 'Wedding')
+        recipe_titles = [r['title'] for r in response.data['recipes']]
+        self.assertEqual(recipe_titles, ['Wedding Soup'])
+
+    def test_personalization_ranking_still_runs(self):
+        # User with regional_ties=Balkan should see Balkan recipes ranked
+        # above non-Balkan ones, proving the #463 personalizer is active.
+        ranked_user = User.objects.create_user(
+            email='ranked@example.com', username='ranked', password='Pass123!',
+            regional_ties=['Balkan'],
+        )
+        self.client.force_authenticate(user=ranked_user)
+
+        # Use a query with no facet so multiple recipes qualify and ranking
+        # has something to reorder.
+        response = self.client.get(self.url, {'q': 'a'})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        recipes = response.data['recipes']
+        self.assertGreater(len(recipes), 1)
+
+        # Every Balkan-region recipe should outrank every Italian one.
+        balkan_scores = [r['rank_score'] for r in recipes if r['region_tag'] == 'Balkan']
+        italian_scores = [r['rank_score'] for r in recipes if r['region_tag'] == 'Italian']
+        self.assertTrue(balkan_scores)
+        self.assertTrue(italian_scores)
+        self.assertGreater(min(balkan_scores), max(italian_scores))
+
+    def test_response_includes_parsed_echo(self):
+        response = self.client.get(self.url, {'q': 'Balkan wedding dishes'})
+
+        self.assertIn('parsed', response.data)
+        self.assertEqual(
+            set(response.data['parsed'].keys()),
+            {'region', 'event', 'diets', 'religions'},
+        )
+
+    def test_empty_query_still_returns_parsed_block(self):
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        parsed = response.data['parsed']
+        self.assertIsNone(parsed['region'])
+        self.assertIsNone(parsed['event'])
+        self.assertEqual(parsed['diets'], [])
+        self.assertEqual(parsed['religions'], [])

--- a/app/backend/apps/search/tests_query_parser.py
+++ b/app/backend/apps/search/tests_query_parser.py
@@ -1,0 +1,148 @@
+"""Pure-Python tests for the domain-aware query parser (#389).
+
+These tests bypass the database by passing a fixed lookup map directly to
+``parse_query``. Behavior of ``_build_lookup_map`` (DB-bound) is exercised
+indirectly by the endpoint tests in ``tests_domain_aware``.
+"""
+import unittest
+
+from apps.search.query_parser import parse_query
+
+
+def _lookup():
+    """Mirror what ``_build_lookup_map`` would emit, sans DB."""
+    return {
+        # Regions (multi-word entries included)
+        ('balkan',): ('region', 'Balkan'),
+        ('italian',): ('region', 'Italian'),
+        ('eastern', 'european'): ('region', 'Eastern European'),
+        ('black', 'sea'): ('region', 'Black Sea'),
+        # Events
+        ('wedding',): ('event', 'Wedding'),
+        ('funeral',): ('event', 'Funeral'),
+        ('religious', 'holiday'): ('event', 'Religious Holiday'),
+        # Diets
+        ('vegan',): ('diet', 'Vegan'),
+        ('halal',): ('diet', 'Halal'),
+        ('gluten', 'free'): ('diet', 'Gluten-Free'),
+        # Religions
+        ('islam',): ('religion', 'Islam'),
+        ('christianity',): ('religion', 'Christianity'),
+    }
+
+
+class ParseQueryTests(unittest.TestCase):
+
+    def test_empty_query_returns_empty_result(self):
+        result = parse_query('', lookup=_lookup())
+        self.assertEqual(result['cleaned_query'], '')
+        self.assertIsNone(result['region'])
+        self.assertIsNone(result['event'])
+        self.assertEqual(result['diets'], [])
+        self.assertEqual(result['religions'], [])
+
+    def test_none_query_returns_empty_result(self):
+        result = parse_query(None, lookup=_lookup())
+        self.assertEqual(result['cleaned_query'], '')
+
+    def test_whitespace_only_query(self):
+        result = parse_query('   ', lookup=_lookup())
+        self.assertEqual(result['cleaned_query'], '')
+        self.assertIsNone(result['region'])
+
+    def test_single_facet_region(self):
+        result = parse_query('balkan', lookup=_lookup())
+        self.assertEqual(result['region'], 'Balkan')
+        self.assertEqual(result['cleaned_query'], '')
+
+    def test_single_facet_event(self):
+        result = parse_query('wedding', lookup=_lookup())
+        self.assertEqual(result['event'], 'Wedding')
+        self.assertIsNone(result['region'])
+
+    def test_single_facet_diet(self):
+        result = parse_query('vegan', lookup=_lookup())
+        self.assertEqual(result['diets'], ['Vegan'])
+
+    def test_single_facet_religion(self):
+        result = parse_query('islam', lookup=_lookup())
+        self.assertEqual(result['religions'], ['Islam'])
+
+    def test_multi_facet_region_event_with_residual(self):
+        result = parse_query('Balkan wedding dishes', lookup=_lookup())
+        self.assertEqual(result['region'], 'Balkan')
+        self.assertEqual(result['event'], 'Wedding')
+        self.assertEqual(result['cleaned_query'], 'dishes')
+
+    def test_multi_word_region_longest_match_first(self):
+        # "Eastern European" must beat any shorter prefix.
+        result = parse_query('eastern european stew', lookup=_lookup())
+        self.assertEqual(result['region'], 'Eastern European')
+        self.assertEqual(result['cleaned_query'], 'stew')
+
+    def test_multi_word_region_with_event(self):
+        result = parse_query('black sea wedding cake', lookup=_lookup())
+        self.assertEqual(result['region'], 'Black Sea')
+        self.assertEqual(result['event'], 'Wedding')
+        self.assertEqual(result['cleaned_query'], 'cake')
+
+    def test_case_insensitive(self):
+        result = parse_query('BALKAN Wedding DISHES', lookup=_lookup())
+        self.assertEqual(result['region'], 'Balkan')
+        self.assertEqual(result['event'], 'Wedding')
+        self.assertEqual(result['cleaned_query'], 'dishes')
+
+    def test_no_match_passthrough(self):
+        result = parse_query('grandmother special pie', lookup=_lookup())
+        self.assertIsNone(result['region'])
+        self.assertIsNone(result['event'])
+        self.assertEqual(result['diets'], [])
+        self.assertEqual(result['religions'], [])
+        self.assertEqual(result['cleaned_query'], 'grandmother special pie')
+
+    def test_punctuation_is_stripped(self):
+        result = parse_query('Balkan, wedding! dishes.', lookup=_lookup())
+        self.assertEqual(result['region'], 'Balkan')
+        self.assertEqual(result['event'], 'Wedding')
+        self.assertEqual(result['cleaned_query'], 'dishes')
+
+    def test_stopwords_dropped_from_residual(self):
+        result = parse_query('vegan and halal', lookup=_lookup())
+        self.assertEqual(result['diets'], ['Vegan', 'Halal'])
+        self.assertEqual(result['cleaned_query'], '')
+
+    def test_multiple_diets(self):
+        result = parse_query('vegan halal recipes', lookup=_lookup())
+        self.assertEqual(result['diets'], ['Vegan', 'Halal'])
+        self.assertEqual(result['cleaned_query'], 'recipes')
+
+    def test_diet_with_hyphenated_canonical_name(self):
+        result = parse_query('gluten free wedding cake', lookup=_lookup())
+        self.assertEqual(result['diets'], ['Gluten-Free'])
+        self.assertEqual(result['event'], 'Wedding')
+        self.assertEqual(result['cleaned_query'], 'cake')
+
+    def test_first_region_wins_over_subsequent_regions(self):
+        result = parse_query('balkan italian wedding', lookup=_lookup())
+        self.assertEqual(result['region'], 'Balkan')
+        self.assertEqual(result['event'], 'Wedding')
+        # Both region tokens consumed; residual is empty.
+        self.assertEqual(result['cleaned_query'], '')
+
+    def test_religion_and_event_together(self):
+        result = parse_query('islam religious holiday food', lookup=_lookup())
+        self.assertEqual(result['religions'], ['Islam'])
+        self.assertEqual(result['event'], 'Religious Holiday')
+        self.assertEqual(result['cleaned_query'], 'food')
+
+    def test_returns_independent_lists(self):
+        # Ensure the default-list pattern in result init does not leak state
+        # between calls.
+        first = parse_query('vegan', lookup=_lookup())
+        second = parse_query('halal', lookup=_lookup())
+        self.assertEqual(first['diets'], ['Vegan'])
+        self.assertEqual(second['diets'], ['Halal'])
+
+
+if __name__ == '__main__':  # pragma: no cover
+    unittest.main()

--- a/app/backend/apps/search/views.py
+++ b/app/backend/apps/search/views.py
@@ -13,6 +13,7 @@ from apps.common.personalization import (
 )
 from apps.recipes.models import Recipe
 from apps.recipes.views import apply_content_filters
+from apps.search.query_parser import parse_query
 from apps.stories.models import Story
 
 
@@ -86,26 +87,63 @@ class GlobalSearchView(APIView):
         query = request.query_params.get('q', '').strip()
         language = request.query_params.get('language', '').strip()
 
+        parsed = parse_query(query)
+        has_facets = bool(
+            parsed['region'] or parsed['event']
+            or parsed['diets'] or parsed['religions']
+        )
+
+        # Inject parsed facets into a working copy of query_params, but never
+        # override values the client already supplied (#389).
+        params = request.query_params.copy()
+        if parsed['region'] and not params.get('region'):
+            params['region'] = parsed['region']
+        if parsed['event'] and not params.get('event'):
+            params['event'] = parsed['event']
+        if parsed['diets'] and not params.get('diet'):
+            params['diet'] = ','.join(parsed['diets'])
+        if parsed['religions'] and not params.get('religion'):
+            params['religion'] = ','.join(parsed['religions'])
+
+        # Keep the existing free-text behavior when no facet matched, so plain
+        # keyword search is byte-for-byte identical to the pre-#389 endpoint.
+        text_query = parsed['cleaned_query'] if has_facets else query
+
         recipes = _recipe_queryset()
         stories = _story_queryset()
 
-        if query:
-            recipes = recipes.filter(Q(title__icontains=query) | Q(description__icontains=query))
-            stories = stories.filter(Q(title__icontains=query) | Q(body__icontains=query))
+        if text_query:
+            recipes = recipes.filter(Q(title__icontains=text_query) | Q(description__icontains=text_query))
+            stories = stories.filter(Q(title__icontains=text_query) | Q(body__icontains=text_query))
 
         if language:
             recipes = recipes.filter(author__preferred_language__iexact=language)
             stories = stories.filter(author__preferred_language__iexact=language)
 
-        recipes = apply_content_filters(recipes, request.query_params)
-        stories = apply_content_filters(stories, request.query_params)
+        recipes = apply_content_filters(recipes, params)
+        stories = apply_content_filters(stories, params)
 
         personalize = request.query_params.get('personalize') != '0'
         use_ranking = personalize and has_profile_terms(request.user)
 
+        # Light bias toward regional/event matches when the parser surfaced
+        # them, so tag-aligned items outrank items that only matched on the
+        # residual free text.
+        weights = dict(WEIGHTS)
+        if parsed['region']:
+            weights['regional'] = int(weights['regional'] * 1.5)
+        if parsed['event']:
+            weights['event'] = int(weights['event'] * 1.5)
+
         if use_ranking:
-            ranked_recipes = rank_items(recipes[:500], request.user, score_recipe)
-            ranked_stories = rank_items(stories[:500], request.user, score_story)
+            ranked_recipes = rank_items(
+                recipes[:500], request.user, score_recipe,
+                scorer_kwargs={'weights': weights},
+            )
+            ranked_stories = rank_items(
+                stories[:500], request.user, score_story,
+                scorer_kwargs={'weights': weights},
+            )
         else:
             ranked_recipes = recipes[:100]
             ranked_stories = stories[:100]
@@ -119,6 +157,12 @@ class GlobalSearchView(APIView):
             'stories': story_results,
             'results': unified,
             'total_count': len(recipe_results) + len(story_results),
+            'parsed': {
+                'region': parsed['region'],
+                'event': parsed['event'],
+                'diets': parsed['diets'],
+                'religions': parsed['religions'],
+            },
         }, status=status.HTTP_200_OK)
 
 


### PR DESCRIPTION
## Summary
- Lookup-driven query parser extracts region / event / diet / religion facets from natural-language search queries.
- `GlobalSearchView` injects parsed facets into the existing filter pipeline; cleaned residual query feeds title/body matching.
- Parsed facets echoed in the response for client debug, and the personalization scorer from #463 gets a small region/event weight boost when those facets came from the parser.

## Test plan
- [x] `python manage.py test apps.search -v 2` (45 tests, all green)
- [x] `python manage.py test apps.recipes` (same 3F/19E baseline as `origin/main`, see Notes)
- [x] new tests: 19 parser unit cases + 8 endpoint-level decomposition cases
- [ ] manual smoke: `curl ".../api/search/?q=Balkan%20wedding%20dishes"`

## Notes
- Parser is lookup-driven, not LLM-driven, to keep latency bounded and behavior predictable. Multi-word region names (e.g. "Eastern European", "Black Sea") handled via longest-match-first.
- Explicit query params still win over parsed facets; we never override user intent.
- Parser tests pass a fixed in-memory lookup map so the matching logic stays DB-free.
- `apps.recipes` shows the same 3 failures + 19 errors on this branch as on `origin/main`. They are the seed-migration flakiness tracked in #419 (Ingredient/Unit unique-constraint and lookup-ordering issues), unrelated to this change. Per the prompt I am not papering over them.

Closes #389.