### PR TITLE
chore(backend): trace Lab 9 backend acceptance tests + fill scenario gaps (#472)

### DIFF
--- a/app/backend/apps/recipes/tests_comments.py
+++ b/app/backend/apps/recipes/tests_comments.py
@@ -66,25 +66,53 @@ class CommentQuestionAPITests(APITestCase):
         self.assertEqual(Comment.objects.count(), 0)
 
     def test_qa_enabled_logic(self):
-        """Check qa_enabled flag when posting QUESTION."""
+        """TC_API_QA_005 - POST comment 403 when qa_enabled=false.
+
+        Designer: Uygar Apan (gh: roboticrustacean). Lab 9 acceptance test.
+        Requirements: 3.4.1, 3.2.1.
+
+        Walks the full Lab 9 flow:
+        1) non-author Bob POSTs a QUESTION on a recipe with qa_enabled=False
+           and gets 403;
+        2) the recipe author flips qa_enabled to True;
+        3) Bob retries the same POST and gets 201.
+        Also verifies COMMENTs remain allowed regardless of the flag (the
+        toggle scopes to QUESTION posts only).
+        """
         self.client.force_authenticate(user=self.user1)
-        
+
         # Recipe 1 has qa_enabled=True
         url1 = f'/api/recipes/{self.recipe1.id}/comments/'
         data1 = {'body': 'A question?', 'type': 'QUESTION'}
         response1 = self.client.post(url1, data1)
         self.assertEqual(response1.status_code, status.HTTP_201_CREATED)
-        
-        # Recipe 2 has qa_enabled=False
+
+        # Recipe 2 has qa_enabled=False; user1 (Bob, non-author of recipe2)
+        # should be blocked from posting a QUESTION there.
         url2 = f'/api/recipes/{self.recipe2.id}/comments/'
         data2 = {'body': 'A question?', 'type': 'QUESTION'}
         response2 = self.client.post(url2, data2)
         self.assertEqual(response2.status_code, status.HTTP_403_FORBIDDEN)
-        
-        # Recipe 2 allows COMMENT despite qa_enabled=False
+
+        # Recipe 2 allows COMMENT despite qa_enabled=False.
         data3 = {'body': 'A comment.', 'type': 'COMMENT'}
         response3 = self.client.post(url2, data3)
         self.assertEqual(response3.status_code, status.HTTP_201_CREATED)
+
+        # The author of recipe 2 (user2) flips qa_enabled to True.
+        self.client.force_authenticate(user=self.user2)
+        toggle = self.client.patch(
+            f'/api/recipes/{self.recipe2.id}/',
+            {'qa_enabled': True},
+            format='json',
+        )
+        self.assertEqual(toggle.status_code, status.HTTP_200_OK)
+        self.assertTrue(toggle.data['qa_enabled'])
+
+        # Bob retries the original QUESTION post and now succeeds.
+        self.client.force_authenticate(user=self.user1)
+        retry = self.client.post(url2, data2)
+        self.assertEqual(retry.status_code, status.HTTP_201_CREATED)
 
     def test_reply_flow_and_validation(self):
         """Test reply flow and parent_comment cross-recipe validation."""

--- a/app/backend/apps/recipes/tests_custom_submission_api.py
+++ b/app/backend/apps/recipes/tests_custom_submission_api.py
@@ -22,11 +22,73 @@ class CustomSubmissionApiTests(APITestCase):
         self.unit_list_url = reverse('unit-list')
 
     def test_authenticated_user_can_submit_a_new_ingredient(self):
+        """TC_API_ING_003 - Ingredient submission half (pending state).
+
+        Designer: Ahmet Ayberk Durak. Lab 9 acceptance test.
+        Requirements: 3.7.4, 4.4.2.
+
+        The full pending-then-approved flow is covered by
+        test_ingredient_pending_then_approved_flow below.
+        """
         response = self.client.post(self.ingredient_list_url, {'name': '  Smoked Paprika  '})
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(response.data['name'], 'Smoked Paprika')
         self.assertFalse(response.data['is_approved'])
+
+    def test_ingredient_pending_then_approved_flow(self):
+        """TC_API_ING_003 - Full ingredient moderation flow.
+
+        Designer: Ahmet Ayberk Durak. Lab 9 acceptance test.
+        Requirements: 3.7.4, 4.4.2.
+
+        Walks the full flow end-to-end:
+        1) regular user submits an ingredient (lands is_approved=False, hidden
+           from the public list);
+        2) admin PATCHes is_approved=True via the IngredientViewSet
+           ModeratedLookupViewSet admin-write path;
+        3) the ingredient is now visible in the public list.
+        """
+        admin = User.objects.create_superuser(
+            email='admin-ing@example.com',
+            username='admin-ing',
+            password='AdminPass123!',
+        )
+
+        submit = self.client.post(
+            self.ingredient_list_url, {'name': 'Lab9 Sumac'}
+        )
+        self.assertEqual(submit.status_code, status.HTTP_201_CREATED)
+        ingredient_id = submit.data['id']
+        self.assertFalse(submit.data['is_approved'])
+
+        anon_client = self.client_class()
+        pending_list = anon_client.get(self.ingredient_list_url)
+        self.assertEqual(pending_list.status_code, status.HTTP_200_OK)
+        pending_results = pending_list.data
+        if isinstance(pending_results, dict):
+            pending_results = pending_results.get('results', [])
+        self.assertNotIn(
+            'Lab9 Sumac', [item['name'] for item in pending_results]
+        )
+
+        self.client.force_authenticate(user=admin)
+        approve = self.client.patch(
+            f'{self.ingredient_list_url}{ingredient_id}/',
+            {'is_approved': True},
+        )
+        self.assertEqual(approve.status_code, status.HTTP_200_OK)
+        self.assertTrue(approve.data['is_approved'])
+
+        self.client.force_authenticate(user=self.user)
+        public_list = anon_client.get(self.ingredient_list_url)
+        self.assertEqual(public_list.status_code, status.HTTP_200_OK)
+        public_results = public_list.data
+        if isinstance(public_results, dict):
+            public_results = public_results.get('results', [])
+        self.assertIn(
+            'Lab9 Sumac', [item['name'] for item in public_results]
+        )
 
     def test_authenticated_user_can_submit_a_new_unit(self):
         response = self.client.post(self.unit_list_url, {'name': '  TestUnit-zeta '})

--- a/app/backend/apps/recipes/tests_permissions.py
+++ b/app/backend/apps/recipes/tests_permissions.py
@@ -48,10 +48,25 @@ class PermissionTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_non_author_cannot_edit_recipe(self):
+        """TC_API_REC_002 - Non-author cannot PATCH another user's recipe.
+
+        Designer: Ufuk Altunbulak. Lab 9 acceptance test.
+        Requirements: 3.2.5, 4.4.1.
+
+        Asserts HTTP 403 on the unauthorized PATCH and verifies that a
+        subsequent GET still returns the original title (IDOR-prevention
+        coverage).
+        """
+        original_title = self.recipe.title
         self.client.force_authenticate(user=self.user2)
         data = {"title": "Stolen Title"}
         response = self.client.patch(f'/api/recipes/{self.recipe.id}/', data)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        self.client.force_authenticate(user=self.user1)
+        get_response = self.client.get(f'/api/recipes/{self.recipe.id}/')
+        self.assertEqual(get_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(get_response.data['title'], original_title)
 
     def test_unauthenticated_can_list_ingredients(self):
         response = self.client.get('/api/ingredients/')

--- a/app/backend/apps/stories/tests.py
+++ b/app/backend/apps/stories/tests.py
@@ -33,12 +33,32 @@ class StoryCreateAPITest(APITestCase):
         self.assertEqual(response.data['author_username'], "author")
 
     def test_create_story_with_linked_recipe_legacy(self):
-        """Test backward compatibility: sending 'linked_recipe' as single ID."""
+        """TC_API_STORY_004 - Story creation with linked recipe (bidirectional).
+
+        Designer: Emirhan Simsek. Lab 9 acceptance test.
+        Requirements: 3.5.1, 3.5.2, 3.5.3, 3.5.4, 3.3.9.
+
+        Asserts the legacy linked_recipe write path returns the recipe ID and
+        title in the read shape, that the new linked_recipes array reflects
+        the link, and that the back-reference is observable from the recipe
+        side (the recipe's story_count goes up and the model-level reverse
+        relation Recipe.linked_stories includes the new story).
+
+        Lab 9 cited a hypothetical Recipe.linkedStories[] field; the current
+        serializer exposes the back-link as story_count plus the reverse
+        manager. This assertion is the surviving bidirectional contract.
+        """
         self.client.force_authenticate(user=self.user)
+
+        recipe_before = self.client.get(reverse('recipe-detail', kwargs={'pk': self.recipe.id}))
+        self.assertEqual(recipe_before.status_code, status.HTTP_200_OK)
+        story_count_before = recipe_before.data['story_count']
+
         data = {
             "title": "Baklava Story",
             "body": "How I learned to make baklava",
-            "linked_recipe": self.recipe.id
+            "linked_recipe": self.recipe.id,
+            "is_published": True,
         }
         response = self.client.post(self.url, data)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -46,6 +66,16 @@ class StoryCreateAPITest(APITestCase):
         self.assertEqual(response.data['recipe_title'], "Baklava")
         self.assertEqual(len(response.data['linked_recipes']), 1)
         self.assertEqual(response.data['linked_recipes'][0]['recipe_id'], self.recipe.id)
+
+        new_story_id = response.data['id']
+        recipe_after = self.client.get(reverse('recipe-detail', kwargs={'pk': self.recipe.id}))
+        self.assertEqual(recipe_after.status_code, status.HTTP_200_OK)
+        self.assertEqual(recipe_after.data['story_count'], story_count_before + 1)
+
+        self.assertTrue(
+            self.recipe.linked_stories.filter(id=new_story_id).exists(),
+            "Recipe.linked_stories reverse relation must include the new story",
+        )
 
     def test_create_story_with_multiple_recipes(self):
         """Test new capability: sending 'linked_recipe_ids' as array."""

--- a/app/backend/apps/users/tests.py
+++ b/app/backend/apps/users/tests.py
@@ -108,11 +108,35 @@ class LoginTest(APITestCase):
         )
 
     def test_login_success(self):
+        """TC_API_AUTH_001 - Login returns valid JWT.
+
+        Designer: Ahmet Akdag. Lab 9 acceptance test.
+        Requirements: 3.0.2, 3.1.1.
+
+        Asserts HTTP 200, that the response contains both access and refresh
+        tokens, and that the access token decodes against the configured
+        signing key with a user_id claim matching the registered user and an
+        exp claim within the configured ACCESS_TOKEN_LIFETIME.
+        """
+        import time
+        import jwt
+        from django.conf import settings
+
         data = {"email": "login@example.com", "password": "StrongPass123!"}
         response = self.client.post('/api/auth/login/', data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn('access', response.data)
         self.assertIn('refresh', response.data)
+
+        access = response.data['access']
+        decoded = jwt.decode(access, settings.SECRET_KEY, algorithms=['HS256'])
+        # SimpleJWT stringifies the user_id claim; compare as string.
+        self.assertEqual(str(decoded['user_id']), str(self.user.id))
+
+        now = int(time.time())
+        self.assertGreater(decoded['exp'], now)
+        lifetime_seconds = int(settings.SIMPLE_JWT['ACCESS_TOKEN_LIFETIME'].total_seconds())
+        self.assertLessEqual(decoded['exp'] - now, lifetime_seconds + 5)
 
     def test_login_wrong_password(self):
         data = {"email": "login@example.com", "password": "WrongPass999!"}

--- a/docs/lab9-acceptance-test-traceability.md
+++ b/docs/lab9-acceptance-test-traceability.md
@@ -1,0 +1,31 @@
+# Lab 9 - Backend acceptance test traceability
+
+This document maps each TC_API_* test ID from the [Lab 9 Report](https://github.com/bounswe/bounswe2026group12/wiki/Lab-%239-Report)
+to the actual test method that backs it. Every test here carries an in-source docstring with the same TC_API_* ID and requirement IDs.
+
+| TC_API_* | Designer | File | Class::Method | Requirements | Status |
+|---|---|---|---|---|---|
+| TC_API_AUTH_001 | Ahmet Akdag | apps/users/tests.py | LoginTest::test_login_success | 3.0.2, 3.1.1 | Pass (gap-filled) |
+| TC_API_REC_002 | Ufuk Altunbulak | apps/recipes/tests_permissions.py | PermissionTests::test_non_author_cannot_edit_recipe | 3.2.5, 4.4.1 | Pass (gap-filled) |
+| TC_API_ING_003 | Ahmet Ayberk Durak | apps/recipes/tests_custom_submission_api.py | CustomSubmissionApiTests::test_ingredient_pending_then_approved_flow | 3.7.4, 4.4.2 | Pass (gap-filled) |
+| TC_API_STORY_004 | Emirhan Simsek | apps/stories/tests.py | StoryCreateAPITest::test_create_story_with_linked_recipe_legacy | 3.5.1, 3.5.2, 3.5.3, 3.5.4, 3.3.9 | Pass (gap-filled) |
+| TC_API_QA_005 | Uygar Apan (gh: roboticrustacean) | apps/recipes/tests_comments.py | CommentQuestionAPITests::test_qa_enabled_logic | 3.4.1, 3.2.1 | Pass (gap-filled) |
+
+## Notes on path divergence
+
+Lab 9's report cites file paths under hypothetical apps (`apps/ingredients/...`, `apps/comments/...`, `apps/users/tests/`).
+The actual app structure keeps Ingredient and Comment models inside `apps.recipes`, and `apps.users` uses a single
+`tests.py`. The test methods named in this matrix carry docstring traceability so the Lab 9 commitment is verifiable
+in source even where the path is different.
+
+Lab 9 also cited a hypothetical `linkedStories[]` field on the Recipe API response for TC_API_STORY_004. The Recipe
+serializer post-#458 exposes the back-link as `story_count` (counting published linked stories) plus the model-level
+reverse manager `Recipe.linked_stories`. The TC_API_STORY_004 test asserts both, so the bidirectional contract is
+verifiable.
+
+## How to verify
+
+```bash
+cd app/backend && python manage.py test apps.users apps.recipes apps.stories -v 2
+grep -rn "TC_API_AUTH_001\|TC_API_REC_002\|TC_API_ING_003\|TC_API_STORY_004\|TC_API_QA_005" apps/
+```


### PR DESCRIPTION
## Summary
- Each of the 5 TC_API_* tests committed in Lab 9 (AUTH_001, REC_002, ING_003, STORY_004, QA_005) now carries an in-source docstring with the Lab 9 ID, designer, and requirement IDs.
- Where current coverage was partial (JWT decode + claim assertions, post-403 unchanged-recipe verification, full ingredient pending->approve flow, bidirectional story-recipe back-link, qa_enabled toggle-and-retry leg), the existing tests have been extended.
- New \`docs/lab9-acceptance-test-traceability.md\` maps each TC_API_* to its real file/class/method so the Final Milestone Report can cite Lab 9 with a verifiable link.

## Test plan
- [x] \`python manage.py test apps.users apps.recipes apps.stories -v 2\` green (211 tests, all pass)
- [x] \`grep -rn "TC_API_" app/backend/apps/ docs/\` returns all 5 IDs across test docstrings + traceability doc

## Notes
- Lab 9's hypothetical file paths (\`apps/ingredients/...\`, \`apps/comments/...\`, \`apps/users/tests/...\`) don't match the actual app layout. The traceability doc explicitly records the divergence and points at the real paths. We did not rename existing test methods to match Lab 9's literal strings, that would be churn for no value. The docstring trace is what makes the commitment verifiable.
- Lab 9 also cited a hypothetical \`linkedStories[]\` field on the Recipe API response for STORY_004. The current Recipe serializer (post-#458) exposes the back-link as \`story_count\` plus the model-level reverse manager \`Recipe.linked_stories\`. Both are asserted in the test.
- Frontend Cypress tests (TC_UI_006 -> 009) are not in scope; they belong to the frontend cohort.
- CI gating for these tests is tracked separately under #469.

Closes #472.