### PR TITLE
fix(devops): pass CORS_ALLOWED_ORIGINS to backend and force-recreate on deploy

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -47,6 +47,8 @@ jobs:
               echo 'ALLOWED_HOSTS=genipe.app,www.genipe.app,45.76.34.210,localhost,backend' >> .env
             grep -q '^REACT_APP_API_URL=' .env || \
               echo 'REACT_APP_API_URL=https://genipe.app' >> .env
+            grep -q '^CORS_ALLOWED_ORIGINS=' .env || \
+              echo 'CORS_ALLOWED_ORIGINS=https://genipe.app,https://www.genipe.app' >> .env
 
             # Build images first. If this fails, nothing on the running host
             # is touched — legacy stack keeps serving.
@@ -73,7 +75,10 @@ jobs:
 
             # Bring up the compose stack. The backend entrypoint runs migrate
             # and collectstatic automatically before gunicorn starts.
-            docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+            # --force-recreate guards against stale containers that survive a
+            # config change (e.g. when the prod overlay adds ports or volumes
+            # that compose's normal diff misses on already-running containers).
+            docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --force-recreate
 
             # Smoke test: give services 15s to settle then hit the domain.
             # If this fails, dump last 100 lines of logs and exit non-zero so

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
       SECRET_KEY: ${SECRET_KEY:-dev-insecure-secret-do-not-use-in-prod}
       DEBUG: ${DEBUG:-False}
       ALLOWED_HOSTS: ${ALLOWED_HOSTS:-localhost,127.0.0.1,backend}
+      CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-https://genipe.app,https://www.genipe.app}
       POSTGRES_DB: ${POSTGRES_DB:-bounswe_db}
       POSTGRES_USER: ${POSTGRES_USER:-genipe}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-genipe_mvp_2026}


### PR DESCRIPTION
## Summary
- Add `CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-https://genipe.app,https://www.genipe.app}` to the backend service's `environment` block in `docker-compose.yml`. Was missing entirely; backend was crashlooping with `corsheaders.E013: Origin '' in CORS_ALLOWED_ORIGINS is missing scheme or netloc` whenever the container actually got recreated against the current image, because `os.getenv('CORS_ALLOWED_ORIGINS', '').split(',')` resolved to `['']`.
- Append `CORS_ALLOWED_ORIGINS=https://genipe.app,https://www.genipe.app` to the root `.env` on first deploy if missing (idempotent, mirrors the existing `ALLOWED_HOSTS` and `REACT_APP_API_URL` lines in `deploy-web.yml`).
- Switch the deploy workflow's `docker compose ... up -d` to `up -d --force-recreate`. Today's outage came from the web container being created weeks ago without the `docker-compose.prod.yml` overlay, so 443 was never bound. Compose's normal diff doesn't recreate that container even when ports or volumes are added to the overlay later, which is the real root cause behind 5 consecutive failed deploys today.

## Test plan
- [x] Applied the equivalent edits live on prod (sed-injected the env line, force-recreated backend) — backend now booted past the system check, gunicorn listening on `:8000`, and external smoke `https://genipe.app/`, `/api/recipes/`, `/api/search/?q=mercimek` all return 200.
- [x] `docker compose -f docker-compose.yml -f docker-compose.prod.yml config` shows the merged `web` service binds 443 and mounts `/etc/letsencrypt` + `ops/nginx-prod.conf`. Force-recreate of `web` produced a container with both 80 and 443 host-bound, HTTP-to-HTTPS redirect 301 working.
- [ ] After this merges and the auto-deploy runs, the workflow itself should reach the smoke-test step green for the first time today.

## Notes
- Live prod is healthy as of this PR open. The `sed` patch on the server's `docker-compose.yml` will be overwritten by the next deploy's `git reset --hard origin/main`, but the same change is in this PR, so the next deploy lands an equivalent config — no flapping risk if this gets merged before someone triggers an unrelated deploy.
- Considered also filtering empty strings from the CORS split inside `settings.py` for defense in depth (`[o for o in os.getenv(...).split(',') if o]`). Held off to keep the PR scoped to the deploy/runtime gap; happy to add it as a follow-up if reviewer prefers.
- The deploy workflow's smoke test step has been failing on every push today (#465, #466, #467, #468, #470, #473) because of the unbound 443. Without `--force-recreate`, fixing the underlying compose config alone would not have rescued the running container.