### PR TITLE
feat(devops): coverage reporting in CI Actions Summary (#478)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 # Local equivalents:
-#   cd app/backend && python manage.py test
-#   cd app/frontend && npm test -- --watchAll=false
+#   cd app/backend && coverage run --source=apps manage.py test && coverage report --omit='*/migrations/*,*/tests*'
+#   cd app/frontend && npm test -- --watchAll=false --coverage
 
 name: Tests
 
@@ -34,10 +34,20 @@ jobs:
           cache-dependency-path: app/backend/requirements.txt
 
       - name: Install backend dependencies
-        run: pip install -r requirements.txt
+        run: |
+          pip install -r requirements.txt
+          pip install coverage==7.13.5
 
       - name: Run Django test suite
-        run: python manage.py test --noinput --verbosity=2
+        run: coverage run --source=apps manage.py test --noinput --verbosity=2
+
+      - name: Backend coverage report
+        if: always()
+        run: |
+          echo "## Backend coverage" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          coverage report --omit='*/migrations/*,*/tests*' --skip-empty | tail -25 >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
 
   frontend-tests:
     name: Frontend tests
@@ -63,4 +73,23 @@ jobs:
       - name: Run Jest test suite
         env:
           CI: 'true'
-        run: npm test -- --watchAll=false --ci --passWithNoTests
+        run: npm test -- --watchAll=false --ci --passWithNoTests --coverage --coverageReporters=text --coverageReporters=json-summary
+
+      - name: Frontend coverage report
+        if: always()
+        working-directory: app/frontend
+        run: |
+          if [ -f coverage/coverage-summary.json ]; then
+            echo "## Frontend coverage" >> "$GITHUB_STEP_SUMMARY"
+            echo '| Metric | Pct | Covered / Total |' >> "$GITHUB_STEP_SUMMARY"
+            echo '|---|---|---|' >> "$GITHUB_STEP_SUMMARY"
+            node -e "
+              const t = require('./coverage/coverage-summary.json').total;
+              for (const k of ['statements','branches','functions','lines']) {
+                const m = t[k];
+                console.log(\`| \${k} | \${m.pct.toFixed(2)}% | \${m.covered} / \${m.total} |\`);
+              }
+            " >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Frontend coverage summary not produced (tests likely failed before instrumenting)." >> "$GITHUB_STEP_SUMMARY"
+          fi


### PR DESCRIPTION
## Summary
- Adds `coverage run` + `coverage report` to the backend job, scoped to `apps/`, omitting migrations and test files.
- Adds `--coverage` + `json-summary` reporter to the frontend job and parses the summary into a markdown table on the Actions Summary.
- Both reports run with `if: always()` so reviewers see partial coverage even when a test fails.

## Test plan
- [x] Local: backend `coverage run --source=apps manage.py test && coverage report --omit='*/migrations/*,*/tests*'` -> 90% prod-code coverage at HEAD `4f0804c`
- [x] Local: frontend `npm test -- --coverage --coverageReporters=json-summary` -> 59.1% statements at HEAD `4f0804c`, summary JSON well-formed
- [x] Workflow run on this branch shows both coverage sections in the Actions Summary tab
- [x] Workflow stays under 10 min on cold cache (around 3.5 min total today)

## Notes
- No threshold gate. Frontend at 59% is well below the Lab 9 >= 80% non-functional target; the gap lives in `ExplorePage`, `InboxPage`, `MapPage`, `ThreadPage` and several services. Surfacing the number is step 1; closing the gap is the frontend cohort's follow-up.
- `coverage` is intentionally not in `requirements.txt` to keep prod image lean; it's installed at CI step time only.

Closes #478.