### PR TITLE
feat: add public ids for recipes and stories

### DIFF
--- a/app/backend/apps/common/ids.py
+++ b/app/backend/apps/common/ids.py
@@ -1,0 +1,33 @@
+import re
+import secrets
+import time
+
+from django.core.validators import RegexValidator
+
+
+ULID_ALPHABET = '0123456789ABCDEFGHJKMNPQRSTVWXYZ'
+ULID_REGEX = re.compile(r'^[0-9A-HJKMNP-TV-Z]{26}$')
+
+validate_ulid = RegexValidator(
+    regex=ULID_REGEX.pattern,
+    message='Enter a valid ULID.',
+)
+
+
+def generate_ulid(timestamp_ms=None):
+    """Generate a 26-character ULID using timestamp + random bits."""
+    if timestamp_ms is None:
+        timestamp_ms = int(time.time() * 1000)
+
+    if timestamp_ms < 0 or timestamp_ms >= 2**48:
+        raise ValueError('ULID timestamp must fit in 48 bits.')
+
+    value = (timestamp_ms << 80) | secrets.randbits(80)
+    chars = []
+    for shift in range(125, -1, -5):
+        chars.append(ULID_ALPHABET[(value >> shift) & 0x1F])
+    return ''.join(chars)
+
+
+def is_ulid(value):
+    return isinstance(value, str) and ULID_REGEX.fullmatch(value) is not None

--- a/app/backend/apps/common/tests/test_ids.py
+++ b/app/backend/apps/common/tests/test_ids.py
@@ -1,0 +1,20 @@
+from django.test import SimpleTestCase
+
+from apps.common.ids import ULID_REGEX, generate_ulid
+
+
+class ULIDGeneratorTests(SimpleTestCase):
+    def test_generated_id_has_expected_length(self):
+        self.assertEqual(len(generate_ulid()), 26)
+
+    def test_generated_id_matches_ulid_alphabet(self):
+        self.assertRegex(generate_ulid(), ULID_REGEX)
+
+    def test_generated_ids_do_not_collide_in_large_batch(self):
+        ids = {generate_ulid() for _ in range(10000)}
+        self.assertEqual(len(ids), 10000)
+
+    def test_later_timestamp_sorts_after_earlier_timestamp(self):
+        earlier = generate_ulid(timestamp_ms=1000)
+        later = generate_ulid(timestamp_ms=1001)
+        self.assertLess(earlier, later)

--- a/app/backend/apps/recipes/migrations/0017_recipe_public_id.py
+++ b/app/backend/apps/recipes/migrations/0017_recipe_public_id.py
@@ -1,0 +1,51 @@
+from django.db import migrations, models
+import apps.common.ids as common_ids
+
+
+def backfill_recipe_public_ids(apps, schema_editor):
+    Recipe = apps.get_model('recipes', 'Recipe')
+    used_ids = set(
+        Recipe.objects.exclude(public_id__isnull=True)
+        .exclude(public_id='')
+        .values_list('public_id', flat=True)
+    )
+
+    for recipe in Recipe.objects.filter(public_id__isnull=True):
+        public_id = common_ids.generate_ulid()
+        while public_id in used_ids:
+            public_id = common_ids.generate_ulid()
+        used_ids.add(public_id)
+        recipe.public_id = public_id
+        recipe.save(update_fields=['public_id'])
+
+
+def clear_recipe_public_ids(apps, schema_editor):
+    Recipe = apps.get_model('recipes', 'Recipe')
+    Recipe.objects.update(public_id=None)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('recipes', '0016_merge_20260509_1145'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='recipe',
+            name='public_id',
+            field=models.CharField(editable=False, max_length=26, null=True),
+        ),
+        migrations.RunPython(backfill_recipe_public_ids, clear_recipe_public_ids),
+        migrations.AlterField(
+            model_name='recipe',
+            name='public_id',
+            field=models.CharField(
+                default=common_ids.generate_ulid,
+                editable=False,
+                max_length=26,
+                unique=True,
+                validators=[common_ids.validate_ulid],
+            ),
+        ),
+    ]

--- a/app/backend/apps/recipes/models.py
+++ b/app/backend/apps/recipes/models.py
@@ -1,5 +1,6 @@
 from django.db import models
 from django.conf import settings
+from apps.common.ids import generate_ulid, validate_ulid
 
 class CulturalModerationMixin(models.Model):
     """Audit fields for cultural-tag moderation (#391).
@@ -116,6 +117,13 @@ class Religion(CulturalModerationMixin, models.Model):
 
 class Recipe(models.Model):
     """Core Recipe model."""
+    public_id = models.CharField(
+        max_length=26,
+        unique=True,
+        editable=False,
+        default=generate_ulid,
+        validators=[validate_ulid],
+    )
     title = models.CharField(max_length=255)
     description = models.TextField()
     image = models.ImageField(upload_to='recipes/images/', null=True, blank=True)

--- a/app/backend/apps/recipes/serializers.py
+++ b/app/backend/apps/recipes/serializers.py
@@ -183,7 +183,7 @@ class RecipeSerializer(serializers.ModelSerializer):
     class Meta:
         model = Recipe
         fields = [
-            'id', 'title', 'description', 'image', 'video',
+            'id', 'public_id', 'title', 'description', 'image', 'video',
             'region', 'region_name', 'author', 'author_username', 'qa_enabled',
             'is_published', 'created_at', 'updated_at',
             'ingredients', 'ingredients_write',
@@ -192,7 +192,7 @@ class RecipeSerializer(serializers.ModelSerializer):
             'story_count',
             'rank_score', 'rank_reason',
         ]
-        read_only_fields = ['author', 'created_at', 'updated_at']
+        read_only_fields = ['public_id', 'author', 'created_at', 'updated_at']
 
     def get_rank_score(self, obj):
         return getattr(obj, 'rank_score', 0)

--- a/app/backend/apps/recipes/tests.py
+++ b/app/backend/apps/recipes/tests.py
@@ -3,6 +3,7 @@ from rest_framework import status
 from django.urls import reverse
 from .models import Recipe, Region, Ingredient, Unit, RecipeIngredient
 from apps.stories.models import Story
+from apps.common.ids import ULID_REGEX
 from django.contrib.auth import get_user_model
 
 User = get_user_model()
@@ -99,8 +100,25 @@ class RecipeCreateAPITest(APITestCase):
         response = self.client.post(self.url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(response.data['title'], "Hummus")
+        self.assertIsInstance(response.data['id'], int)
+        self.assertRegex(response.data['public_id'], ULID_REGEX)
         self.assertEqual(response.data['author_username'], "chef")
         self.assertEqual(len(response.data['ingredients']), 1)
+
+    def test_created_recipes_have_distinct_public_ids(self):
+        data = {
+            "title": "Hummus",
+            "description": "Creamy chickpea dip",
+            "ingredients_write": [
+                {"ingredient": self.ingredient.id, "amount": "200.00", "unit": self.unit.id}
+            ]
+        }
+        first = self.client.post(self.url, data, format='json')
+        second_data = {**data, "title": "Second Hummus"}
+        second = self.client.post(self.url, second_data, format='json')
+        self.assertEqual(first.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(second.status_code, status.HTTP_201_CREATED)
+        self.assertNotEqual(first.data['public_id'], second.data['public_id'])
 
     def test_create_recipe_missing_title(self):
         data = {
@@ -290,3 +308,12 @@ class RecipePublishAPITest(APITestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertTrue(response.data['is_published'])
+
+    def test_recipe_detail_accepts_public_id(self):
+        self.recipe.is_published = True
+        self.recipe.save()
+        url = reverse('recipe-detail', kwargs={'pk': self.recipe.public_id})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['id'], self.recipe.id)
+        self.assertEqual(response.data['public_id'], self.recipe.public_id)

--- a/app/backend/apps/recipes/views.py
+++ b/app/backend/apps/recipes/views.py
@@ -11,6 +11,7 @@ from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.parsers import MultiPartParser, FormParser, JSONParser
 from rest_framework.views import APIView
+from apps.common.ids import is_ulid
 from apps.common.permissions import IsAuthorOrReadOnly
 from apps.common.pagination import StandardResultsSetPagination
 from apps.common.personalization import rank_items, score_recipe, has_profile_terms
@@ -100,6 +101,14 @@ class RecipeViewSet(viewsets.ModelViewSet):
     permission_classes = [permissions.IsAuthenticatedOrReadOnly, IsAuthorOrReadOnly]
     parser_classes = [MultiPartParser, FormParser, JSONParser]
     pagination_class = StandardResultsSetPagination
+
+    def get_object(self):
+        queryset = self.filter_queryset(self.get_queryset())
+        lookup_value = self.kwargs.get(self.lookup_url_kwarg or self.lookup_field)
+        lookup = {'public_id': lookup_value} if is_ulid(lookup_value) else {'pk': lookup_value}
+        obj = get_object_or_404(queryset, **lookup)
+        self.check_object_permissions(self.request, obj)
+        return obj
 
     def get_queryset(self):
         qs = super().get_queryset()

--- a/app/backend/apps/stories/migrations/0009_story_public_id.py
+++ b/app/backend/apps/stories/migrations/0009_story_public_id.py
@@ -1,0 +1,51 @@
+from django.db import migrations, models
+import apps.common.ids as common_ids
+
+
+def backfill_story_public_ids(apps, schema_editor):
+    Story = apps.get_model('stories', 'Story')
+    used_ids = set(
+        Story.objects.exclude(public_id__isnull=True)
+        .exclude(public_id='')
+        .values_list('public_id', flat=True)
+    )
+
+    for story in Story.objects.filter(public_id__isnull=True):
+        public_id = common_ids.generate_ulid()
+        while public_id in used_ids:
+            public_id = common_ids.generate_ulid()
+        used_ids.add(public_id)
+        story.public_id = public_id
+        story.save(update_fields=['public_id'])
+
+
+def clear_story_public_ids(apps, schema_editor):
+    Story = apps.get_model('stories', 'Story')
+    Story.objects.update(public_id=None)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('stories', '0008_story_dietary_tags_story_event_tags_story_religions'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='story',
+            name='public_id',
+            field=models.CharField(editable=False, max_length=26, null=True),
+        ),
+        migrations.RunPython(backfill_story_public_ids, clear_story_public_ids),
+        migrations.AlterField(
+            model_name='story',
+            name='public_id',
+            field=models.CharField(
+                default=common_ids.generate_ulid,
+                editable=False,
+                max_length=26,
+                unique=True,
+                validators=[common_ids.validate_ulid],
+            ),
+        ),
+    ]

--- a/app/backend/apps/stories/models.py
+++ b/app/backend/apps/stories/models.py
@@ -1,5 +1,6 @@
 from django.db import models
 from django.conf import settings
+from apps.common.ids import generate_ulid, validate_ulid
 from apps.recipes.models import Recipe, Region, DietaryTag, EventTag, Religion
 
 class StoryRecipeLink(models.Model):
@@ -20,6 +21,13 @@ class Story(models.Model):
     can be tagged independently of a linked recipe. If `region` is null but
     `linked_recipe` exists, the map API will fall back to the recipe's region.
     """
+    public_id = models.CharField(
+        max_length=26,
+        unique=True,
+        editable=False,
+        default=generate_ulid,
+        validators=[validate_ulid],
+    )
     title = models.CharField(max_length=255)
     summary = models.TextField(blank=True, default='')
     body = models.TextField()

--- a/app/backend/apps/stories/serializers.py
+++ b/app/backend/apps/stories/serializers.py
@@ -61,7 +61,7 @@ class StorySerializer(serializers.ModelSerializer):
     class Meta:
         model = Story
         fields = [
-            'id', 'title', 'summary', 'body', 'image', 'author', 'author_username',
+            'id', 'public_id', 'title', 'summary', 'body', 'image', 'author', 'author_username',
             'linked_recipe', 'recipe_title',    # backward compat (read)
             'linked_recipes',                   # new array (read)
             'linked_recipe_id', 'linked_recipe_ids',  # write aliases
@@ -71,7 +71,7 @@ class StorySerializer(serializers.ModelSerializer):
             'is_published', 'created_at', 'updated_at',
             'rank_score', 'rank_reason',
         ]
-        read_only_fields = ['author', 'created_at', 'updated_at']
+        read_only_fields = ['public_id', 'author', 'created_at', 'updated_at']
 
     def get_rank_score(self, obj):
         return getattr(obj, 'rank_score', 0)

--- a/app/backend/apps/stories/tests.py
+++ b/app/backend/apps/stories/tests.py
@@ -3,6 +3,7 @@ from rest_framework import status
 from django.urls import reverse
 from django.contrib.auth import get_user_model
 from django.core.files.uploadedfile import SimpleUploadedFile
+from apps.common.ids import ULID_REGEX
 from apps.recipes.models import Recipe, Region
 from apps.stories.models import Story
 
@@ -29,8 +30,18 @@ class StoryCreateAPITest(APITestCase):
         response = self.client.post(self.url, data)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(response.data['title'], "My Story")
+        self.assertIsInstance(response.data['id'], int)
+        self.assertRegex(response.data['public_id'], ULID_REGEX)
         self.assertEqual(response.data['summary'], "Short intro")
         self.assertEqual(response.data['author_username'], "author")
+
+    def test_created_stories_have_distinct_public_ids(self):
+        self.client.force_authenticate(user=self.user)
+        first = self.client.post(self.url, {"title": "First Story", "body": "First"})
+        second = self.client.post(self.url, {"title": "Second Story", "body": "Second"})
+        self.assertEqual(first.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(second.status_code, status.HTTP_201_CREATED)
+        self.assertNotEqual(first.data['public_id'], second.data['public_id'])
 
     def test_create_story_with_linked_recipe_legacy(self):
         """TC_API_STORY_004 - Story creation with linked recipe (bidirectional).
@@ -173,6 +184,13 @@ class StoryRetrieveAPITest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['title'], "Published Story")
         self.assertIn('updated_at', response.data)
+
+    def test_public_detail_accepts_public_id(self):
+        url = reverse('story-detail', kwargs={'pk': self.published.public_id})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['id'], self.published.id)
+        self.assertEqual(response.data['public_id'], self.published.public_id)
 
     def test_public_detail_draft_404(self):
         url = reverse('story-detail', kwargs={'pk': self.draft.id})

--- a/app/backend/apps/stories/views.py
+++ b/app/backend/apps/stories/views.py
@@ -2,7 +2,9 @@ from rest_framework import viewsets, permissions
 from rest_framework.decorators import action
 from rest_framework.parsers import MultiPartParser, FormParser, JSONParser
 from rest_framework.response import Response
+from django.shortcuts import get_object_or_404
 
+from apps.common.ids import is_ulid
 from apps.common.permissions import IsAuthorOrReadOnly
 from apps.common.pagination import StandardResultsSetPagination
 from apps.common.personalization import rank_items, score_story, has_profile_terms
@@ -25,6 +27,14 @@ class StoryViewSet(viewsets.ModelViewSet):
     permission_classes = [permissions.IsAuthenticatedOrReadOnly, IsAuthorOrReadOnly]
     parser_classes = [MultiPartParser, FormParser, JSONParser]
     pagination_class = StandardResultsSetPagination
+
+    def get_object(self):
+        queryset = self.filter_queryset(self.get_queryset())
+        lookup_value = self.kwargs.get(self.lookup_url_kwarg or self.lookup_field)
+        lookup = {'public_id': lookup_value} if is_ulid(lookup_value) else {'pk': lookup_value}
+        obj = get_object_or_404(queryset, **lookup)
+        self.check_object_permissions(self.request, obj)
+        return obj
 
     def get_queryset(self):
         qs = super().get_queryset()


### PR DESCRIPTION
Adds ULID-based public_id fields for recipes and stories, backfills existing rows via migrations, exposes the IDs in serializers, and supports detail lookup by either integer ID or public ID. Includes collision/format tests and API coverage.

Closes #358