### PR TITLE
feat(devops): validate prod compose, add healthchecks, document bring-up (#368)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,35 @@
+# Copy this file to .env at the repo root and fill in real values before
+# running `docker compose -f docker-compose.yml -f docker-compose.prod.yml up`.
+# Defaults in docker-compose.yml are dev-safe; production deploys MUST override
+# SECRET_KEY, POSTGRES_PASSWORD, ALLOWED_HOSTS, CORS_ALLOWED_ORIGINS, and
+# REACT_APP_API_URL.
+
 # Django
 SECRET_KEY=change-me-in-production
 DEBUG=False
 ALLOWED_HOSTS=localhost,127.0.0.1,backend
+CORS_ALLOWED_ORIGINS=https://example.com,https://www.example.com
 
 # Postgres
 POSTGRES_DB=bounswe_db
 POSTGRES_USER=genipe
 POSTGRES_PASSWORD=change-me
+# Inside the compose network the backend reaches Postgres at host=db:5432.
+# These two are only needed if you run the backend outside compose.
+POSTGRES_HOST=db
+POSTGRES_PORT=5432
 
-# Frontend build-time (baked into the web image)
+# Frontend build-time (baked into the web image). Set this before
+# `docker compose build` — runtime changes are ignored.
 REACT_APP_API_URL=http://localhost
+
+# Optional: S3-compatible object storage (Vultr Object Storage, AWS S3, MinIO).
+# Leave AWS_STORAGE_BUCKET_NAME empty to keep using the local media_data
+# volume. When the bucket name is set, settings.py switches
+# DEFAULT_FILE_STORAGE to S3Boto3Storage and ALL of the keys below become
+# required.
+AWS_STORAGE_BUCKET_NAME=
+AWS_S3_ENDPOINT_URL=
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_S3_REGION_NAME=ewr1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,14 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-genipe_mvp_2026}
       POSTGRES_HOST: db
       POSTGRES_PORT: 5432
+      # Optional S3-compatible object storage. Leave empty to use the local
+      # media_data volume; set AWS_STORAGE_BUCKET_NAME (and the rest) in .env
+      # to switch DEFAULT_FILE_STORAGE to S3Boto3Storage.
+      AWS_STORAGE_BUCKET_NAME: ${AWS_STORAGE_BUCKET_NAME:-}
+      AWS_S3_ENDPOINT_URL: ${AWS_S3_ENDPOINT_URL:-}
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-}
+      AWS_S3_REGION_NAME: ${AWS_S3_REGION_NAME:-ewr1}
     volumes:
       - media_data:/app/media
       - static_data:/app/staticfiles
@@ -34,6 +42,14 @@ services:
       db:
         condition: service_healthy
     restart: unless-stopped
+    # /admin/login/ renders without hitting the DB, so this is a clean
+    # liveness probe for gunicorn. urlopen raises on non-2xx, exiting non-zero.
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/admin/login/')"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 40s
 
   web:
     build:
@@ -46,8 +62,15 @@ services:
       - media_data:/var/www/media:ro
       - static_data:/var/www/django-static:ro
     depends_on:
-      - backend
+      backend:
+        condition: service_healthy
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost/ >/dev/null || exit 1"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 10s
 
 volumes:
   pgdata:

--- a/ops/PROD.md
+++ b/ops/PROD.md
@@ -1,0 +1,152 @@
+# Production bring-up — `docker compose -f docker-compose.yml -f docker-compose.prod.yml`
+
+End-to-end runbook for standing up the genipe.app stack on a clean Ubuntu box.
+The deploy GitHub Action (`.github/workflows/deploy-web.yml`) automates the
+update path on every push to `main`; this doc covers first-time setup, env
+audit, manual updates, and rollback. Server-specific notes (current Vultr box
+IP, legacy systemd state pre-cutover) live in `sunucu_ayarlari.md` at the
+repo root and on the server itself; this file does not duplicate them.
+
+## Prerequisites
+
+- Ubuntu 22.04+ box with root SSH and a public IPv4
+- Domain pointing at the box (A record + AAAA if IPv6)
+- Docker Engine 24+ and the Compose v2 plugin (`docker compose`, not the
+  legacy `docker-compose`)
+- A Let's Encrypt certificate at `/etc/letsencrypt/live/<domain>/` (the prod
+  overlay mounts `/etc/letsencrypt` read-only into the `web` container; nginx
+  inside the container reads `fullchain.pem` and `privkey.pem` from there)
+
+## First-time setup
+
+```bash
+# 1. Install Docker + compose plugin (skip if already present)
+curl -fsSL https://get.docker.com | sh
+apt-get install -y docker-compose-plugin
+
+# 2. Clone the repo
+mkdir -p /root && cd /root
+git clone https://github.com/bounswe/bounswe2026group12.git
+cd bounswe2026group12
+
+# 3. Create the root-level .env
+cp .env.example .env
+$EDITOR .env  # fill SECRET_KEY, POSTGRES_PASSWORD, ALLOWED_HOSTS,
+              # CORS_ALLOWED_ORIGINS, REACT_APP_API_URL
+
+# 4. Obtain a Let's Encrypt cert (one-time; renewal is a separate ops task).
+#    nginx-prod.conf expects /etc/letsencrypt/live/<domain>/{fullchain,privkey}.pem.
+apt-get install -y certbot
+certbot certonly --standalone -d genipe.app -d www.genipe.app
+
+# 5. Bring the stack up
+docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --force-recreate
+
+# 6. Wait for healthchecks (≤60s) and smoke
+docker compose -f docker-compose.yml -f docker-compose.prod.yml ps
+curl -fsS https://genipe.app/
+```
+
+`db`, `backend`, and `web` should all report `(healthy)`. The backend
+entrypoint runs `migrate` and `collectstatic` automatically before gunicorn
+starts; that's covered by the backend healthcheck's 40s `start_period`.
+
+## Required environment variables
+
+Audited against `app/backend/config/settings.py`. Every `os.getenv` /
+`os.environ.get` call is listed. Defaults shown are the ones in
+`docker-compose.yml`; .env values override them.
+
+| Key | Required | Compose default | Notes |
+|---|---|---|---|
+| `SECRET_KEY` | Yes (prod) | dev placeholder | Override with a long random string in prod |
+| `DEBUG` | Yes | `False` | Must be `False` in prod; flips CORS to allow-all when `True` |
+| `ALLOWED_HOSTS` | Yes | `localhost,127.0.0.1,backend` | Comma-separated; include the public domain in prod |
+| `CORS_ALLOWED_ORIGINS` | Yes (prod) | `https://genipe.app,https://www.genipe.app` | Only consulted when `DEBUG=False` |
+| `POSTGRES_DB` | Yes | `bounswe_db` | |
+| `POSTGRES_USER` | Yes | `genipe` | |
+| `POSTGRES_PASSWORD` | Yes (prod) | `genipe_mvp_2026` | Override with a strong secret |
+| `POSTGRES_HOST` | Yes | `db` (compose service name) | Hardcoded in compose; only override outside compose |
+| `POSTGRES_PORT` | Yes | `5432` | Hardcoded in compose |
+| `REACT_APP_API_URL` | Yes (build-time) | `http://localhost` | Baked into the `web` image; set before `compose build` |
+| `AWS_STORAGE_BUCKET_NAME` | No | empty | When set, switches `DEFAULT_FILE_STORAGE` to S3Boto3Storage; otherwise the local `media_data` volume is used |
+| `AWS_S3_ENDPOINT_URL` | If S3 | empty | Required when bucket name is set |
+| `AWS_ACCESS_KEY_ID` | If S3 | empty | Required when bucket name is set |
+| `AWS_SECRET_ACCESS_KEY` | If S3 | empty | Required when bucket name is set |
+| `AWS_S3_REGION_NAME` | If S3 | `ewr1` | Vultr's New Jersey region |
+
+`POSTGRES_HOST` falls back to SQLite when unset (dev/test). The compose
+backend service always has it set to `db`, so prod always uses Postgres.
+
+## Update procedure
+
+`deploy-web.yml` runs this on every push to `main`. To replicate manually:
+
+```bash
+ssh root@<server>
+cd /root/bounswe2026group12
+git fetch origin && git reset --hard origin/main
+docker compose -f docker-compose.yml -f docker-compose.prod.yml build
+docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --force-recreate
+sleep 15
+curl -fsS https://genipe.app/
+```
+
+`--force-recreate` matters: when the prod overlay adds ports or volume mounts
+that compose's normal diff misses on already-running containers, plain `up -d`
+silently keeps the stale container. The deploy workflow learned this the hard
+way during the #476 outage.
+
+If the smoke fails, dump logs:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.prod.yml ps
+docker compose -f docker-compose.yml -f docker-compose.prod.yml logs --tail=100 backend web db
+```
+
+## Rollback
+
+Two layers of rollback are available.
+
+1. **Within compose**: redeploy the previous commit.
+   ```bash
+   git reset --hard <prev-sha>
+   docker compose -f docker-compose.yml -f docker-compose.prod.yml build
+   docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --force-recreate
+   ```
+
+2. **Out of compose, back to legacy systemd + standalone Postgres** — kept
+   warm for one week post-cutover. The exact commands and the legacy
+   `genipe-db` container details are in `sunucu_ayarlari.md` (server-side
+   copy at `/root/bounswe2026group12/sunucu_ayarlari.md`).
+
+The `pgdata` volume is named (`bounswe2026group12_pgdata`) and survives
+`compose down`. Only `compose down -v` would destroy data; do not run that.
+
+## Healthchecks
+
+All three services report container-level health to compose:
+
+- `db`: `pg_isready -U $POSTGRES_USER -d $POSTGRES_DB`, 10s interval
+- `backend`: Python `urllib.request.urlopen("http://localhost:8000/admin/login/")` —
+  the admin login page renders without a DB query, so this is a clean
+  liveness probe for gunicorn. 15s interval, 40s `start_period` to cover
+  migrate + collectstatic.
+- `web`: `wget -qO- http://localhost/`, 10s interval
+
+`backend` waits on `db: service_healthy`; `web` waits on `backend:
+service_healthy`. Compose will not mark the stack up until each dependency
+reports healthy, so the deploy workflow's `curl https://...` smoke test only
+runs against a stack that has already passed container-level checks.
+
+## Validation
+
+This is a config-only change. To validate locally without bringing the stack
+up:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.prod.yml config > /tmp/merged.yml
+```
+
+A clean exit code means the merged config parses. The deploy workflow
+exercises the rest end-to-end on the next push to `main`.


### PR DESCRIPTION
## Summary
- Audited every `os.getenv`/`os.environ.get` in `app/backend/config/settings.py` against compose's `backend.environment` block. The five `AWS_*` keys were read by settings but not passed through; wired them with empty defaults so flipping on S3 storage is now a `.env` edit, not a compose edit. All other keys (`SECRET_KEY`, `DEBUG`, `ALLOWED_HOSTS`, `CORS_ALLOWED_ORIGINS`, `POSTGRES_*`) were already wired post-#476.
- Added healthchecks on `backend` (Python `urllib` GET `/admin/login/`, 40s `start_period` for migrate + collectstatic) and `web` (`wget http://localhost/`). `db` already had `pg_isready`; left untouched.
- Upgraded `web -> backend` `depends_on` from implicit `service_started` to `condition: service_healthy` so nginx waits for gunicorn to be reachable, not just for the container to start.
- New `ops/PROD.md` (152 lines) covers prereqs, first-time bring-up, the env-var table from the audit, manual update procedure mirroring `deploy-web.yml`, and rollback. Cross-references `sunucu_ayarlari.md` for server-specific details rather than duplicating.
- `.env.example` now lists every prod-relevant key the audit surfaced, including `CORS_ALLOWED_ORIGINS` (wired in #476 but never in the example), `POSTGRES_HOST`/`PORT`, and the `AWS_*` block.

## Test plan
- [x] `docker compose -f docker-compose.yml -f docker-compose.prod.yml config` merges cleanly (131-line merged config, exit 0)
- [x] Audit cross-checked: 16 `os.getenv`/`os.environ.get` hits, 14 unique keys, all in the `ops/PROD.md` table
- [ ] Local `compose up` with healthcheck verification deferred (no Docker on this Mac); next `deploy-web.yml` run after merge will exercise it end-to-end

## Notes
- Complements #476 (deploy workflow idempotency); the two together close the post-cutover gaps surfaced during today's outage.
- No Python source touched; this PR is config + docs only.
- `deploy-web.yml`'s `paths:` filter already includes `docker-compose.yml`, `docker-compose.prod.yml`, `ops/**`, and `.env.example`, so a merge to `main` will trigger the deploy and the new healthchecks will go live on the next push.

Closes #368.