### PR TITLE
fix(mobile): unwrap paginated /api/stories/ via fetchStoriesList helper (#488)

### DIFF
--- a/app/mobile/src/screens/HomeScreen.tsx
+++ b/app/mobile/src/screens/HomeScreen.tsx
@@ -4,7 +4,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { useEffect, useMemo, useState } from 'react';
 import { shadows, tokens } from '../theme';
 import { fetchRecipesList } from '../services/recipeService';
-import { apiGetJson } from '../services/httpClient';
+import { fetchStoriesList } from '../services/storyService';
 import { fetchDailyCultural } from '../services/dailyCulturalService';
 import { fetchRecommendations, type RecommendationItem } from '../services/recommendationsService';
 import { DailyCulturalSection } from '../components/home/DailyCulturalSection';
@@ -30,18 +30,13 @@ export default function HomeScreen({ navigation }: Props) {
     void (async () => {
       try {
         const [storyData, recipeData, dailyData, recsData] = await Promise.all([
-          apiGetJson<any>('/api/stories/'),
+          fetchStoriesList(),
           fetchRecipesList(),
           fetchDailyCultural(),
           fetchRecommendations('feed', 10).catch(() => [] as RecommendationItem[]),
         ]);
         if (cancelled) return;
-        const storyList = Array.isArray(storyData)
-          ? storyData
-          : storyData && Array.isArray(storyData.results)
-            ? storyData.results
-            : [];
-        setStories(storyList);
+        setStories(Array.isArray(storyData) ? storyData : []);
         setRecipes(Array.isArray(recipeData) ? recipeData : []);
         setDaily(Array.isArray(dailyData) ? dailyData : []);
         setRecommendations(Array.isArray(recsData) ? recsData : []);

--- a/app/mobile/src/screens/UserProfileScreen.tsx
+++ b/app/mobile/src/screens/UserProfileScreen.tsx
@@ -6,8 +6,8 @@ import { ErrorView } from '../components/ui/ErrorView';
 import { LoadingView } from '../components/ui/LoadingView';
 import { useAuth } from '../context/AuthContext';
 import type { RootStackParamList } from '../navigation/types';
-import { apiGetJson } from '../services/httpClient';
 import { fetchRecipesList } from '../services/recipeService';
+import { fetchStoriesList } from '../services/storyService';
 import { shadows, tokens } from '../theme';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'UserProfile'>;
@@ -46,11 +46,11 @@ export default function UserProfileScreen({ route, navigation }: Props) {
       try {
         const [recipeList, storyList] = await Promise.all([
           fetchRecipesList(),
-          apiGetJson<ListItem[]>('/api/stories/'),
+          fetchStoriesList(),
         ]);
         if (cancelled) return;
         setRecipes(Array.isArray(recipeList) ? recipeList : []);
-        setStories(Array.isArray(storyList) ? storyList : []);
+        setStories(Array.isArray(storyList) ? (storyList as ListItem[]) : []);
       } catch (e) {
         if (!cancelled) {
           setRecipes([]);

--- a/app/mobile/src/services/storyService.ts
+++ b/app/mobile/src/services/storyService.ts
@@ -53,6 +53,16 @@ function unwrapStoriesPayload(data: unknown): any[] {
   return [];
 }
 
+/**
+ * Fetch the raw story list, transparently handling both raw arrays and the
+ * DRF-paginated `{results}` envelope. Returns the API objects untouched so
+ * callers can read `author`, `linked_recipe`, `image`, etc. directly.
+ */
+export async function fetchStoriesList(): Promise<any[]> {
+  const data = await apiGetJson<unknown>(`/api/stories/`);
+  return unwrapStoriesPayload(data);
+}
+
 /** Stories where `linked_recipe` matches the given recipe id. Filters client-side. */
 export async function fetchStoriesForRecipe(recipeId: string | number): Promise<StoryListItem[]> {
   const data = await apiGetJson<unknown>(`/api/stories/`);


### PR DESCRIPTION
## Summary
Fix for #488. Stories were empty on Home and UserProfile because both screens called `apiGetJson('/api/stories/')` and assumed an array, but the backend returns DRF-paginated `{count, results}`.

## Files
- `services/storyService.ts` — new `fetchStoriesList()` that handles both raw arrays and `{results}` envelopes
- `screens/HomeScreen.tsx` — call `fetchStoriesList()`, drop the inline unwrap
- `screens/UserProfileScreen.tsx` — same swap

## Test
- `npx tsc --noEmit` clean
- Local docker stack from `LOCAL_DEV.md`: Home shows the 16 stories; UserProfile shows the user's stories.

## Notes
- Out of scope: lazy-loading via `next` cursor, and making `apiGetJson` itself pagination-aware (would silently drop `count/next/previous` metadata).

Closes #488