### PR TITLE
feat(mobile): region detail bottom sheet on the map (#385)

### DIFF
--- a/app/mobile/App.tsx
+++ b/app/mobile/App.tsx
@@ -26,6 +26,7 @@ import {
 import { AuthProvider } from './src/context/AuthContext';
 import { ToastProvider } from './src/context/ToastContext';
 import { RootTabsNavigator } from './src/navigation/RootTabsNavigator';
+import { ThemeProvider } from './src/theme';
 
 export default function App() {
   const [fontsLoaded] = useFonts({
@@ -40,14 +41,16 @@ export default function App() {
 
   return (
     <SafeAreaProvider>
-      <AuthProvider>
-        <ToastProvider>
-          <NavigationContainer>
-            <StatusBar style="auto" />
-            <RootTabsNavigator />
-          </NavigationContainer>
-        </ToastProvider>
-      </AuthProvider>
+      <ThemeProvider>
+        <AuthProvider>
+          <ToastProvider>
+            <NavigationContainer>
+              <StatusBar style="auto" />
+              <RootTabsNavigator />
+            </NavigationContainer>
+          </ToastProvider>
+        </AuthProvider>
+      </ThemeProvider>
     </SafeAreaProvider>
   );
 }

--- a/app/mobile/package-lock.json
+++ b/app/mobile/package-lock.json
@@ -22,6 +22,7 @@
         "expo-status-bar": "~3.0.9",
         "react": "19.1.0",
         "react-native": "0.81.5",
+        "react-native-maps": "1.20.1",
         "react-native-safe-area-context": "~5.6.0",
         "react-native-screens": "~4.16.0"
       },
@@ -2753,6 +2754,12 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
@@ -6707,6 +6714,28 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-maps": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/react-native-maps/-/react-native-maps-1.20.1.tgz",
+      "integrity": "sha512-NZI3B5Z6kxAb8gzb2Wxzu/+P2SlFIg1waHGIpQmazDSCRkNoHNY4g96g+xS0QPSaG/9xRBbDNnd2f2/OW6t6LQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.13"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": ">= 17.0.1",
+        "react-native": ">= 0.64.3",
+        "react-native-web": ">= 0.11"
+      },
+      "peerDependenciesMeta": {
+        "react-native-web": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-native-safe-area-context": {

--- a/app/mobile/package.json
+++ b/app/mobile/package.json
@@ -23,6 +23,7 @@
     "expo-status-bar": "~3.0.9",
     "react": "19.1.0",
     "react-native": "0.81.5",
+    "react-native-maps": "1.20.1",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0"
   },

--- a/app/mobile/src/components/map/RegionDetailSheet.tsx
+++ b/app/mobile/src/components/map/RegionDetailSheet.tsx
@@ -1,0 +1,255 @@
+import { useEffect, useState } from 'react';
+import { FlatList, Image, Modal, Pressable, StyleSheet, Text, View } from 'react-native';
+import { fetchRegionContent, type RegionContent, type RegionContentItem } from '../../services/regionContentService';
+import { shadows, tokens, useTheme } from '../../theme';
+
+type Tab = 'recipes' | 'stories';
+
+type Props = {
+  /** Region name to load content for. Null/undefined hides the sheet. */
+  regionName: string | null;
+  onDismiss: () => void;
+  onItemPress: (kind: Tab, id: string) => void;
+};
+
+export function RegionDetailSheet({ regionName, onDismiss, onItemPress }: Props) {
+  const { accent } = useTheme();
+  const [content, setContent] = useState<RegionContent | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [tab, setTab] = useState<Tab>('recipes');
+
+  useEffect(() => {
+    if (!regionName) {
+      setContent(null);
+      setError(null);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    setTab('recipes');
+    fetchRegionContent(regionName)
+      .then((res) => {
+        if (!cancelled) setContent(res);
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : 'Could not load content.');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [regionName]);
+
+  const visible = regionName != null;
+  const items = tab === 'recipes' ? (content?.recipes ?? []) : (content?.stories ?? []);
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      transparent
+      onRequestClose={onDismiss}
+      accessibilityLabel={regionName ? `${regionName} region content` : 'Region content'}
+    >
+      <Pressable style={styles.backdrop} onPress={onDismiss} accessibilityLabel="Close region content">
+        <Pressable style={styles.sheet} onPress={() => undefined}>
+          <View style={[styles.handle, { backgroundColor: accent.accent }]} />
+
+          <View style={styles.header}>
+            <Text style={styles.title} numberOfLines={1} accessibilityRole="header">
+              {regionName ?? ''}
+            </Text>
+            <Pressable
+              onPress={onDismiss}
+              style={({ pressed }) => [styles.closeBtn, pressed && styles.pressed]}
+              accessibilityRole="button"
+              accessibilityLabel="Close"
+            >
+              <Text style={styles.closeText}>Close</Text>
+            </Pressable>
+          </View>
+
+          <View style={styles.tabs}>
+            <TabButton
+              label={`Recipes${content ? ` · ${content.recipes.length}` : ''}`}
+              active={tab === 'recipes'}
+              onPress={() => setTab('recipes')}
+            />
+            <TabButton
+              label={`Stories${content ? ` · ${content.stories.length}` : ''}`}
+              active={tab === 'stories'}
+              onPress={() => setTab('stories')}
+            />
+          </View>
+
+          {loading ? (
+            <View style={styles.centered}>
+              <Text style={styles.muted}>Loading…</Text>
+            </View>
+          ) : error ? (
+            <View style={styles.centered}>
+              <Text style={styles.error}>{error}</Text>
+            </View>
+          ) : items.length === 0 ? (
+            <View style={styles.centered}>
+              <Text style={styles.muted}>
+                No {tab} for {regionName} yet.
+              </Text>
+            </View>
+          ) : (
+            <FlatList
+              data={items}
+              keyExtractor={(it) => it.key}
+              contentContainerStyle={styles.list}
+              renderItem={({ item }) => (
+                <Row item={item} onPress={() => onItemPress(tab, item.id)} />
+              )}
+            />
+          )}
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}
+
+function TabButton({
+  label,
+  active,
+  onPress,
+}: {
+  label: string;
+  active: boolean;
+  onPress: () => void;
+}) {
+  const { accent } = useTheme();
+  return (
+    <Pressable
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.tab,
+        active && { backgroundColor: accent.accent, borderColor: accent.accentBorder },
+        !active && styles.tabInactive,
+        pressed && styles.pressed,
+      ]}
+      accessibilityRole="tab"
+      accessibilityState={{ selected: active }}
+      accessibilityLabel={label}
+    >
+      <Text
+        style={[
+          styles.tabText,
+          active ? { color: accent.accentText } : { color: tokens.colors.text },
+        ]}
+      >
+        {label}
+      </Text>
+    </Pressable>
+  );
+}
+
+function Row({ item, onPress }: { item: RegionContentItem; onPress: () => void }) {
+  return (
+    <Pressable
+      onPress={onPress}
+      style={({ pressed }) => [styles.row, pressed && styles.pressed]}
+      accessibilityRole="button"
+      accessibilityLabel={`Open ${item.title}`}
+    >
+      {item.image ? (
+        <Image source={{ uri: item.image }} style={styles.thumb} resizeMode="cover" />
+      ) : (
+        <View style={[styles.thumb, styles.thumbPlaceholder]}>
+          <Text style={styles.thumbInitial}>{(item.title.charAt(0) || '?').toUpperCase()}</Text>
+        </View>
+      )}
+      <View style={styles.rowBody}>
+        <Text style={styles.rowTitle} numberOfLines={2}>
+          {item.title}
+        </Text>
+        {item.authorUsername ? <Text style={styles.rowMeta}>By {item.authorUsername}</Text> : null}
+      </View>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: tokens.colors.backdrop,
+    justifyContent: 'flex-end',
+  },
+  sheet: {
+    backgroundColor: tokens.colors.bg,
+    borderTopLeftRadius: tokens.radius.xl,
+    borderTopRightRadius: tokens.radius.xl,
+    paddingTop: 8,
+    paddingHorizontal: 16,
+    paddingBottom: 28,
+    maxHeight: '85%',
+    minHeight: '50%',
+    ...shadows.lg,
+  },
+  handle: { alignSelf: 'center', width: 44, height: 5, borderRadius: 999, marginBottom: 12 },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 12,
+    marginBottom: 12,
+  },
+  title: {
+    flex: 1,
+    fontSize: 22,
+    fontWeight: '800',
+    color: tokens.colors.text,
+    fontFamily: tokens.typography.display.fontFamily,
+  },
+  closeBtn: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: tokens.radius.pill,
+    backgroundColor: tokens.colors.bg,
+    borderWidth: 1,
+    borderColor: tokens.colors.surfaceDark,
+  },
+  closeText: { fontSize: 13, fontWeight: '800', color: tokens.colors.text },
+  pressed: { opacity: 0.85 },
+  tabs: { flexDirection: 'row', gap: 8, marginBottom: 12 },
+  tab: {
+    paddingVertical: 8,
+    paddingHorizontal: 14,
+    borderRadius: tokens.radius.pill,
+    borderWidth: 2,
+    ...shadows.sm,
+  },
+  tabInactive: { backgroundColor: tokens.colors.bg, borderColor: tokens.colors.surfaceDark },
+  tabText: { fontSize: 13, fontWeight: '800' },
+  centered: { paddingVertical: 40, alignItems: 'center', justifyContent: 'center' },
+  muted: { fontSize: 14, color: tokens.colors.text },
+  error: { fontSize: 14, color: tokens.colors.error, fontWeight: '700' },
+  list: { paddingBottom: 16, gap: 10 },
+  row: {
+    flexDirection: 'row',
+    gap: 12,
+    padding: 10,
+    borderRadius: tokens.radius.lg,
+    borderWidth: 2,
+    borderColor: tokens.colors.surfaceDark,
+    backgroundColor: tokens.colors.bg,
+    ...shadows.sm,
+  },
+  thumb: { width: 72, height: 72, borderRadius: tokens.radius.md, overflow: 'hidden' },
+  thumbPlaceholder: {
+    backgroundColor: tokens.colors.surfaceDark,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  thumbInitial: { color: tokens.colors.textOnDark, fontSize: 22, fontWeight: '900' },
+  rowBody: { flex: 1, justifyContent: 'center', gap: 4 },
+  rowTitle: { fontSize: 15, fontWeight: '800', color: tokens.colors.text },
+  rowMeta: { fontSize: 12, color: tokens.colors.text },
+});

--- a/app/mobile/src/navigation/PublicStackNavigator.tsx
+++ b/app/mobile/src/navigation/PublicStackNavigator.tsx
@@ -2,6 +2,7 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import HomeScreen from '../screens/HomeScreen';
 import InboxScreen from '../screens/InboxScreen';
 import LoginScreen from '../screens/LoginScreen';
+import MapDiscoveryScreen from '../screens/MapDiscoveryScreen';
 import MessageThreadScreen from '../screens/MessageThreadScreen';
 import OnboardingScreen from '../screens/OnboardingScreen';
 import RecipeCreateScreen from '../screens/RecipeCreateScreen';
@@ -92,6 +93,11 @@ export function PublicStackNavigator() {
         name="Onboarding"
         component={OnboardingScreen}
         options={{ title: 'Cultural Onboarding' }}
+      />
+      <Stack.Screen
+        name="MapDiscovery"
+        component={MapDiscoveryScreen}
+        options={{ title: 'Discover by region' }}
       />
     </Stack.Navigator>
   );

--- a/app/mobile/src/navigation/types.ts
+++ b/app/mobile/src/navigation/types.ts
@@ -19,6 +19,7 @@ export type RootStackParamList = {
     otherUsername?: string;
   };
   Onboarding: undefined;
+  MapDiscovery: undefined;
 };
 
 declare global {

--- a/app/mobile/src/screens/HomeScreen.tsx
+++ b/app/mobile/src/screens/HomeScreen.tsx
@@ -78,6 +78,19 @@ export default function HomeScreen({ navigation }: Props) {
           />
         </View>
 
+        <Pressable
+          onPress={() => navigation.navigate('MapDiscovery')}
+          style={({ pressed }) => [styles.mapEntry, pressed && styles.mapEntryPressed]}
+          accessibilityRole="button"
+          accessibilityLabel="Open map discovery"
+        >
+          <View style={{ flex: 1 }}>
+            <Text style={styles.mapTitle}>Discover by region</Text>
+            <Text style={styles.mapSubtitle}>Tap a pin on the map to focus a region</Text>
+          </View>
+          <Text style={styles.mapArrow}>→</Text>
+        </Pressable>
+
         <DailyCulturalSection items={daily} />
 
         <View style={styles.section}>
@@ -247,6 +260,23 @@ const styles = StyleSheet.create({
     fontFamily: tokens.typography.display.fontFamily,
   },
   searchWrap: { marginBottom: 14 },
+  mapEntry: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    paddingVertical: 14,
+    paddingHorizontal: 16,
+    borderRadius: tokens.radius.xl,
+    backgroundColor: tokens.colors.bg,
+    borderWidth: 2,
+    borderColor: tokens.colors.surfaceDark,
+    marginBottom: 14,
+    ...shadows.md,
+  },
+  mapEntryPressed: { opacity: 0.9 },
+  mapTitle: { fontSize: 16, fontWeight: '800', color: tokens.colors.text },
+  mapSubtitle: { fontSize: 12, color: tokens.colors.text, marginTop: 2 },
+  mapArrow: { fontSize: 22, fontWeight: '900', color: tokens.colors.text },
   searchInput: {
     borderWidth: 2,
     borderColor: tokens.colors.primaryBorder,

--- a/app/mobile/src/screens/MapDiscoveryScreen.tsx
+++ b/app/mobile/src/screens/MapDiscoveryScreen.tsx
@@ -1,0 +1,181 @@
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { useEffect, useState } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import MapView, { Marker } from 'react-native-maps';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { ErrorView } from '../components/ui/ErrorView';
+import { LoadingView } from '../components/ui/LoadingView';
+import type { RootStackParamList } from '../navigation/types';
+import { fetchRegionPins, type RegionPin } from '../services/mapDataService';
+import { INITIAL_MAP_REGION } from '../utils/regionGeo';
+import { shadows, tokens } from '../theme';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'MapDiscovery'>;
+
+export default function MapDiscoveryScreen({ navigation }: Props) {
+  const [pins, setPins] = useState<RegionPin[]>([]);
+  const [focused, setFocused] = useState<RegionPin | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadToken, setReloadToken] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetchRegionPins()
+      .then((res) => {
+        if (!cancelled) setPins(res);
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : 'Could not load map.');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [reloadToken]);
+
+  if (loading) {
+    return (
+      <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
+        <View style={styles.centered}>
+          <LoadingView message="Loading map…" />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (error) {
+    return (
+      <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
+        <View style={styles.padded}>
+          <ErrorView message={error} onRetry={() => setReloadToken((t) => t + 1)} />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
+      <View style={styles.fill}>
+        <MapView
+          style={styles.map}
+          initialRegion={INITIAL_MAP_REGION}
+          onPress={() => setFocused(null)}
+          accessibilityLabel="Region discovery map"
+        >
+          {pins.map((pin) => (
+            <Marker
+              key={pin.id}
+              coordinate={pin.coords}
+              title={pin.name}
+              description={`${pin.recipeCount} ${pin.recipeCount === 1 ? 'recipe' : 'recipes'}`}
+              pinColor={focused?.id === pin.id ? tokens.colors.accentGreen : tokens.colors.primary}
+              onPress={(e) => {
+                e.stopPropagation?.();
+                setFocused(pin);
+              }}
+            />
+          ))}
+        </MapView>
+
+        {focused ? (
+          <View style={styles.summary} pointerEvents="box-none">
+            <View style={styles.summaryCard}>
+              <Text style={styles.summaryRegion}>{focused.name}</Text>
+              <Text style={styles.summaryCount}>
+                {focused.recipeCount} {focused.recipeCount === 1 ? 'recipe' : 'recipes'}
+              </Text>
+              <Pressable
+                onPress={() =>
+                  navigation.navigate('Search', { region: focused.name })
+                }
+                style={({ pressed }) => [styles.cta, pressed && styles.ctaPressed]}
+                accessibilityRole="button"
+                accessibilityLabel={`See ${focused.name} recipes`}
+              >
+                <Text style={styles.ctaText}>See {focused.name} recipes</Text>
+              </Pressable>
+            </View>
+          </View>
+        ) : (
+          <View style={styles.hintWrap} pointerEvents="none">
+            <View style={styles.hintCard}>
+              <Text style={styles.hintText}>Tap a pin to focus a region.</Text>
+            </View>
+          </View>
+        )}
+
+        {pins.length === 0 ? (
+          <View style={styles.hintWrap} pointerEvents="none">
+            <View style={styles.hintCard}>
+              <Text style={styles.hintText}>No mappable regions yet.</Text>
+            </View>
+          </View>
+        ) : null}
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: tokens.colors.bg },
+  fill: { flex: 1 },
+  map: { flex: 1 },
+  centered: { flex: 1, justifyContent: 'center', alignItems: 'center', padding: 20 },
+  padded: { flex: 1, padding: 20, justifyContent: 'center' },
+  summary: {
+    position: 'absolute',
+    left: 16,
+    right: 16,
+    bottom: 24,
+  },
+  summaryCard: {
+    padding: 16,
+    borderRadius: tokens.radius.xl,
+    backgroundColor: tokens.colors.bg,
+    borderWidth: 2,
+    borderColor: tokens.colors.surfaceDark,
+    gap: 8,
+    ...shadows.lg,
+  },
+  summaryRegion: {
+    fontSize: 20,
+    fontWeight: '800',
+    color: tokens.colors.text,
+    fontFamily: tokens.typography.display.fontFamily,
+  },
+  summaryCount: { fontSize: 13, color: tokens.colors.text },
+  cta: {
+    marginTop: 4,
+    paddingVertical: 12,
+    paddingHorizontal: 14,
+    borderRadius: tokens.radius.pill,
+    backgroundColor: tokens.colors.accentGreen,
+    borderWidth: 2,
+    borderColor: tokens.colors.surfaceDark,
+    alignItems: 'center',
+  },
+  ctaPressed: { opacity: 0.9 },
+  ctaText: { color: tokens.colors.textOnDark, fontSize: 15, fontWeight: '800' },
+  hintWrap: {
+    position: 'absolute',
+    top: 16,
+    left: 16,
+    right: 16,
+    alignItems: 'center',
+  },
+  hintCard: {
+    paddingVertical: 8,
+    paddingHorizontal: 14,
+    borderRadius: tokens.radius.pill,
+    backgroundColor: tokens.colors.bg,
+    borderWidth: 1,
+    borderColor: tokens.colors.surfaceDark,
+    ...shadows.sm,
+  },
+  hintText: { fontSize: 13, color: tokens.colors.text, fontWeight: '700' },
+});

--- a/app/mobile/src/screens/MapDiscoveryScreen.tsx
+++ b/app/mobile/src/screens/MapDiscoveryScreen.tsx
@@ -1,8 +1,9 @@
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { useEffect, useState } from 'react';
-import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
 import MapView, { Marker } from 'react-native-maps';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { RegionDetailSheet } from '../components/map/RegionDetailSheet';
 import { ErrorView } from '../components/ui/ErrorView';
 import { LoadingView } from '../components/ui/LoadingView';
 import type { RootStackParamList } from '../navigation/types';
@@ -89,46 +90,24 @@ export default function MapDiscoveryScreen({ navigation }: Props) {
           ))}
         </MapView>
 
-        {focused ? (
-          <View style={styles.summary} pointerEvents="box-none">
-            <View style={[styles.summaryCard, { borderColor: accent.accentBorder }]}>
-              <Text style={styles.summaryRegion}>{focused.name}</Text>
-              <Text style={styles.summaryCount}>
-                {focused.recipeCount} {focused.recipeCount === 1 ? 'recipe' : 'recipes'}
+        {!focused ? (
+          <View style={styles.hintWrap} pointerEvents="none">
+            <View style={styles.hintCard}>
+              <Text style={styles.hintText}>
+                {pins.length === 0 ? 'No mappable regions yet.' : 'Tap a pin to open the region.'}
               </Text>
-              <Pressable
-                onPress={() =>
-                  navigation.navigate('Search', { region: focused.name })
-                }
-                style={({ pressed }) => [
-                  styles.cta,
-                  { backgroundColor: accent.accent, borderColor: accent.accentBorder },
-                  pressed && styles.ctaPressed,
-                ]}
-                accessibilityRole="button"
-                accessibilityLabel={`See ${focused.name} recipes`}
-              >
-                <Text style={[styles.ctaText, { color: accent.accentText }]}>
-                  See {focused.name} recipes
-                </Text>
-              </Pressable>
-            </View>
-          </View>
-        ) : (
-          <View style={styles.hintWrap} pointerEvents="none">
-            <View style={styles.hintCard}>
-              <Text style={styles.hintText}>Tap a pin to focus a region.</Text>
-            </View>
-          </View>
-        )}
-
-        {pins.length === 0 ? (
-          <View style={styles.hintWrap} pointerEvents="none">
-            <View style={styles.hintCard}>
-              <Text style={styles.hintText}>No mappable regions yet.</Text>
             </View>
           </View>
         ) : null}
+
+        <RegionDetailSheet
+          regionName={focused?.name ?? null}
+          onDismiss={() => setFocused(null)}
+          onItemPress={(kind, id) => {
+            if (kind === 'recipes') navigation.navigate('RecipeDetail', { id });
+            else navigation.navigate('StoryDetail', { id });
+          }}
+        />
       </View>
     </SafeAreaView>
   );

--- a/app/mobile/src/screens/MapDiscoveryScreen.tsx
+++ b/app/mobile/src/screens/MapDiscoveryScreen.tsx
@@ -8,7 +8,7 @@ import { LoadingView } from '../components/ui/LoadingView';
 import type { RootStackParamList } from '../navigation/types';
 import { fetchRegionPins, type RegionPin } from '../services/mapDataService';
 import { INITIAL_MAP_REGION } from '../utils/regionGeo';
-import { shadows, tokens } from '../theme';
+import { shadows, tokens, useTheme } from '../theme';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'MapDiscovery'>;
 
@@ -18,6 +18,13 @@ export default function MapDiscoveryScreen({ navigation }: Props) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [reloadToken, setReloadToken] = useState(0);
+  const { accent, setFocusedRegion } = useTheme();
+
+  useEffect(() => {
+    setFocusedRegion(focused?.name ?? null);
+  }, [focused, setFocusedRegion]);
+
+  useEffect(() => () => setFocusedRegion(null), [setFocusedRegion]);
 
   useEffect(() => {
     let cancelled = false;
@@ -73,7 +80,7 @@ export default function MapDiscoveryScreen({ navigation }: Props) {
               coordinate={pin.coords}
               title={pin.name}
               description={`${pin.recipeCount} ${pin.recipeCount === 1 ? 'recipe' : 'recipes'}`}
-              pinColor={focused?.id === pin.id ? tokens.colors.accentGreen : tokens.colors.primary}
+              pinColor={focused?.id === pin.id ? accent.accent : tokens.colors.primary}
               onPress={(e) => {
                 e.stopPropagation?.();
                 setFocused(pin);
@@ -84,7 +91,7 @@ export default function MapDiscoveryScreen({ navigation }: Props) {
 
         {focused ? (
           <View style={styles.summary} pointerEvents="box-none">
-            <View style={styles.summaryCard}>
+            <View style={[styles.summaryCard, { borderColor: accent.accentBorder }]}>
               <Text style={styles.summaryRegion}>{focused.name}</Text>
               <Text style={styles.summaryCount}>
                 {focused.recipeCount} {focused.recipeCount === 1 ? 'recipe' : 'recipes'}
@@ -93,11 +100,17 @@ export default function MapDiscoveryScreen({ navigation }: Props) {
                 onPress={() =>
                   navigation.navigate('Search', { region: focused.name })
                 }
-                style={({ pressed }) => [styles.cta, pressed && styles.ctaPressed]}
+                style={({ pressed }) => [
+                  styles.cta,
+                  { backgroundColor: accent.accent, borderColor: accent.accentBorder },
+                  pressed && styles.ctaPressed,
+                ]}
                 accessibilityRole="button"
                 accessibilityLabel={`See ${focused.name} recipes`}
               >
-                <Text style={styles.ctaText}>See {focused.name} recipes</Text>
+                <Text style={[styles.ctaText, { color: accent.accentText }]}>
+                  See {focused.name} recipes
+                </Text>
               </Pressable>
             </View>
           </View>

--- a/app/mobile/src/services/mapDataService.ts
+++ b/app/mobile/src/services/mapDataService.ts
@@ -1,0 +1,51 @@
+import { apiGetJson } from './httpClient';
+import { coordsForRegion, type LatLng } from '../utils/regionGeo';
+
+export type RegionPin = {
+  id: number;
+  name: string;
+  coords: LatLng;
+  recipeCount: number;
+};
+
+type RawRegion = { id: number | string; name: string };
+
+function unwrapList<T>(data: unknown): T[] {
+  if (Array.isArray(data)) return data as T[];
+  if (data && typeof data === 'object' && Array.isArray((data as { results?: unknown }).results)) {
+    return (data as { results: T[] }).results;
+  }
+  return [];
+}
+
+async function countRecipesForRegion(name: string): Promise<number> {
+  try {
+    const params = new URLSearchParams({ region: name });
+    const data = await apiGetJson<unknown>(`/api/recipes/?${params.toString()}`);
+    const list = unwrapList<unknown>(data);
+    return list.length;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Returns only regions we know how to plot. Unknown ones are dropped — they'll
+ * surface again when `regionGeo.COORDS` learns their coordinates (or when the
+ * backend exposes lat/lng directly).
+ */
+export async function fetchRegionPins(): Promise<RegionPin[]> {
+  const data = await apiGetJson<unknown>('/api/regions/');
+  const regions = unwrapList<RawRegion>(data);
+
+  const plottable = regions
+    .map((r) => {
+      const coords = coordsForRegion(r.name);
+      if (!coords) return null;
+      return { id: Number(r.id), name: r.name, coords };
+    })
+    .filter((r): r is { id: number; name: string; coords: LatLng } => r !== null);
+
+  const counts = await Promise.all(plottable.map((r) => countRecipesForRegion(r.name)));
+  return plottable.map((r, idx) => ({ ...r, recipeCount: counts[idx] }));
+}

--- a/app/mobile/src/services/regionContentService.ts
+++ b/app/mobile/src/services/regionContentService.ts
@@ -1,0 +1,71 @@
+import { apiGetJson } from './httpClient';
+
+export type RegionContentItem = {
+  key: string;
+  id: string;
+  title: string;
+  image: string | null;
+  authorUsername: string | null;
+};
+
+export type RegionContent = {
+  recipes: RegionContentItem[];
+  stories: RegionContentItem[];
+};
+
+type RawRecipe = {
+  id: number | string;
+  title?: string;
+  image?: string | null;
+  author_username?: string | null;
+};
+
+type RawStory = {
+  id: number | string;
+  title?: string;
+  image?: string | null;
+  author_username?: string | null;
+  linked_recipe?: { region?: { name?: string } | string | null } | null;
+  recipe_region?: string;
+};
+
+function unwrap<T>(data: unknown): T[] {
+  if (Array.isArray(data)) return data as T[];
+  if (data && typeof data === 'object' && Array.isArray((data as { results?: unknown }).results)) {
+    return (data as { results: T[] }).results;
+  }
+  return [];
+}
+
+function toItem(kind: 'recipe' | 'story', raw: RawRecipe | RawStory): RegionContentItem {
+  return {
+    key: `${kind}-${raw.id}`,
+    id: String(raw.id),
+    title: typeof raw.title === 'string' ? raw.title : '',
+    image: typeof raw.image === 'string' ? raw.image : null,
+    authorUsername: typeof raw.author_username === 'string' ? raw.author_username : null,
+  };
+}
+
+function storyMatchesRegion(story: RawStory, regionName: string): boolean {
+  const r = story.linked_recipe?.region;
+  if (typeof r === 'string') return r === regionName;
+  if (r && typeof r === 'object' && typeof r.name === 'string') return r.name === regionName;
+  if (typeof story.recipe_region === 'string') return story.recipe_region === regionName;
+  return false;
+}
+
+export async function fetchRegionContent(regionName: string): Promise<RegionContent> {
+  const recipesParams = new URLSearchParams({ region: regionName });
+  const [recipesRaw, storiesRaw] = await Promise.all([
+    apiGetJson<unknown>(`/api/recipes/?${recipesParams.toString()}`).catch(() => null),
+    apiGetJson<unknown>(`/api/stories/`).catch(() => null),
+  ]);
+
+  const recipes = unwrap<RawRecipe>(recipesRaw).map((r) => toItem('recipe', r));
+  const stories = unwrap<RawStory>(storiesRaw)
+    .filter((s) => storyMatchesRegion(s, regionName))
+    .map((s) => toItem('story', s));
+
+  return { recipes, stories };
+}

--- a/app/mobile/src/theme/ThemeContext.tsx
+++ b/app/mobile/src/theme/ThemeContext.tsx
@@ -1,0 +1,40 @@
+import React, { createContext, useCallback, useContext, useMemo, useState } from 'react';
+import { accentForRegion, DEFAULT_REGION_ACCENT, type RegionAccent } from './regionThemes';
+
+type ThemeContextValue = {
+  /** Currently focused region name, or null when no region is in focus. */
+  focusedRegion: string | null;
+  /** Accent palette derived from the focused region. */
+  accent: RegionAccent;
+  /** Set or clear the focused region. */
+  setFocusedRegion: (region: string | null) => void;
+};
+
+const ThemeContext = createContext<ThemeContextValue>({
+  focusedRegion: null,
+  accent: DEFAULT_REGION_ACCENT,
+  setFocusedRegion: () => undefined,
+});
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [focusedRegion, setRegion] = useState<string | null>(null);
+
+  const setFocusedRegion = useCallback((region: string | null) => {
+    setRegion(region);
+  }, []);
+
+  const value = useMemo<ThemeContextValue>(
+    () => ({
+      focusedRegion,
+      accent: accentForRegion(focusedRegion),
+      setFocusedRegion,
+    }),
+    [focusedRegion, setFocusedRegion],
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme(): ThemeContextValue {
+  return useContext(ThemeContext);
+}

--- a/app/mobile/src/theme/index.ts
+++ b/app/mobile/src/theme/index.ts
@@ -1,3 +1,5 @@
 export { tokens } from './tokens';
 export { shadows } from './shadows';
+export { ThemeProvider, useTheme } from './ThemeContext';
+export { accentForRegion, DEFAULT_REGION_ACCENT, type RegionAccent } from './regionThemes';
 

--- a/app/mobile/src/theme/regionThemes.ts
+++ b/app/mobile/src/theme/regionThemes.ts
@@ -1,0 +1,41 @@
+import { tokens } from './tokens';
+
+/**
+ * Region-specific accent overrides. Keys must match `Region.name` strings
+ * returned by `/api/regions/`. Unmapped regions fall back to the default theme.
+ */
+export type RegionAccent = {
+  /** Action / call-to-action background. */
+  accent: string;
+  /** Border on hero elements (cards, sheet handle). */
+  accentBorder: string;
+  /** Text color on top of `accent` fills. */
+  accentText: string;
+};
+
+const DEFAULT_ACCENT: RegionAccent = {
+  accent: tokens.colors.accentGreen,
+  accentBorder: tokens.colors.surfaceDark,
+  accentText: tokens.colors.textOnDark,
+};
+
+const REGION_ACCENTS: Record<string, RegionAccent> = {
+  Aegean: { accent: '#1F6FB2', accentBorder: '#0B3A66', accentText: '#F5FAFF' },
+  'Black Sea': { accent: '#2F5D3A', accentBorder: '#142C1C', accentText: '#F2F8F4' },
+  Anatolian: { accent: '#A86A2C', accentBorder: '#5A3A18', accentText: '#FFF5E8' },
+  Marmara: { accent: '#5C5DAB', accentBorder: '#2A2B65', accentText: '#F2F2FA' },
+  Mediterranean: { accent: '#0F8E8E', accentBorder: '#054242', accentText: '#EAFCFC' },
+  'Southeastern Anatolia': { accent: '#B23A48', accentBorder: '#5C1820', accentText: '#FFEDEF' },
+  Levantine: { accent: '#C77B2B', accentBorder: '#5E3712', accentText: '#FFF1E0' },
+  Persian: { accent: '#7E3F95', accentBorder: '#3A1B47', accentText: '#F8EEFF' },
+  Arabian: { accent: '#C49A2A', accentBorder: '#5E4910', accentText: '#FFF6D5' },
+  Balkan: { accent: '#2A8E5F', accentBorder: '#0F4329', accentText: '#EAF8F1' },
+  Caucasian: { accent: '#6E5E2A', accentBorder: '#33290F', accentText: '#FFF7DC' },
+};
+
+export function accentForRegion(name: string | null | undefined): RegionAccent {
+  if (!name) return DEFAULT_ACCENT;
+  return REGION_ACCENTS[name] ?? DEFAULT_ACCENT;
+}
+
+export const DEFAULT_REGION_ACCENT = DEFAULT_ACCENT;

--- a/app/mobile/src/utils/regionGeo.ts
+++ b/app/mobile/src/utils/regionGeo.ts
@@ -1,0 +1,34 @@
+/**
+ * Approximate centroids for the regions present in our seed data. These are
+ * rough geographic centers used only for placing pins on the discovery map.
+ *
+ * TODO(#383-followup): move to backend (`Region.lat`, `Region.lng`) so the
+ * mobile client doesn't need to know geography.
+ */
+export type LatLng = { latitude: number; longitude: number };
+
+const COORDS: Record<string, LatLng> = {
+  Aegean: { latitude: 38.5, longitude: 27.0 },
+  Anatolian: { latitude: 39.0, longitude: 35.0 },
+  'Black Sea': { latitude: 41.0, longitude: 36.5 },
+  Marmara: { latitude: 40.7, longitude: 28.5 },
+  Mediterranean: { latitude: 36.8, longitude: 31.5 },
+  'Southeastern Anatolia': { latitude: 37.5, longitude: 39.0 },
+  Levantine: { latitude: 33.5, longitude: 35.5 },
+  Persian: { latitude: 32.5, longitude: 53.5 },
+  Arabian: { latitude: 24.0, longitude: 45.0 },
+  Balkan: { latitude: 42.0, longitude: 22.0 },
+  Caucasian: { latitude: 41.7, longitude: 44.8 },
+};
+
+export function coordsForRegion(name: string | null | undefined): LatLng | null {
+  if (!name) return null;
+  return COORDS[name] ?? null;
+}
+
+export const INITIAL_MAP_REGION = {
+  latitude: 38.0,
+  longitude: 35.0,
+  latitudeDelta: 18,
+  longitudeDelta: 22,
+};


### PR DESCRIPTION
## Summary
Region surfacing for #385. Tap a region pin on the map and a sheet slides up with Recipes / Stories tabs scoped to that region. Tap an item to open its detail screen, tap the backdrop or the Close button to dismiss.

## Files
- `services/regionContentService.ts` — fetches `/api/recipes/?region=<name>` and filters stories client-side via `linked_recipe.region`
- `components/map/RegionDetailSheet.tsx` — RN `Modal` based sheet with two tabs and a region-accent fill on the active tab
- `screens/MapDiscoveryScreen.tsx` — replaces the inline summary card with the sheet, keeps focus state in `useTheme`

## Test
- `npx tsc --noEmit` clean
- Local docker stack from `LOCAL_DEV.md`: tapping pins shows recipes and stories grouped by region; tabs switch correctly; close + backdrop dismiss work; opening an item navigates to detail.

## Notes
- Uses RN \`Modal\`, not \`@gorhom/bottom-sheet\` — gorhom v5 needs Reanimated 4 which crashes Expo Go on SDK 54. Plain \`Modal\` works in Expo Go without a dev build. We can swap to gorhom later if/when we move to a dev client.
- Stories don't yet support \`?region=\` server-side, so the service filters them client-side via \`linked_recipe.region\`. Backend can add a region filter on \`StoryViewSet\` later — wire it in then.
- Stacked on #383 (#462) and #384 (#471). Merge those first.

Closes #385