### PR TITLE
docs: release notes, setup walkthrough, README refresh (#369)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,76 @@
+# genipe — Cross-Generational Recipe & Food Heritage Platform
 
+CMPE 354 / 451 — Group 12 (Spring 2026).
+
+genipe is a recipe and food-heritage platform that pairs traditional
+recipes with the stories behind them. Authors publish recipes (video +
+description + structured ingredients), tell the cultural story that
+goes with them, and readers can search by region, convert units, find
+ingredient substitutions, and reach the author for follow-up questions.
+
+Live at [genipe.app](https://genipe.app).
+
+## Documentation
+
+| File | What's in it |
+|---|---|
+| [`README.md`](README.md) | You are here. |
+| [`SETUP.md`](SETUP.md) | Local dev: clone-to-running for backend, web, and mobile. |
+| [`RELEASE_NOTES.md`](RELEASE_NOTES.md) | What shipped in MVP (2026-04-07) and Final (2026-05-14). |
+| [`ops/PROD.md`](ops/PROD.md) | Production bring-up runbook (docker compose + nginx + Let's Encrypt). |
+| [`ops/ROLLBACK.md`](ops/ROLLBACK.md) | Production rollback procedure. |
+| [`docs/lab9-acceptance-test-traceability.md`](docs/lab9-acceptance-test-traceability.md) | Acceptance criteria → test mapping. |
+| [`docs/lab9-edit-enforcement-audit.md`](docs/lab9-edit-enforcement-audit.md) | Server-side edit enforcement audit (#360). |
+| `CLAUDE.md` | Repo conventions for git, commits, PRs, and review style. |
+
+## Tech stack
+
+| Layer | Technology | Hosting |
+|---|---|---|
+| Backend | Python 3.12, Django 5.2, DRF, JWT (SimpleJWT) | Vultr VPS (docker compose) |
+| Database | PostgreSQL 16 | Vultr VPS (Postgres container) |
+| Web frontend | React 19 (CRA), react-leaflet | Vultr VPS (nginx container) |
+| Mobile | React Native via Expo SDK 54 | Expo + signed APK |
+| Object storage (optional) | S3-compatible (Vultr Object Storage) | Vultr |
+| CI | GitHub Actions (tests + coverage on every PR) | github.com |
+| Auto-deploy | GitHub Actions on push to `main` | Vultr VPS |
+
+## Repository layout
+
+```
+app/
+  backend/    Django project (apps/, config/, fixtures/, requirements.txt)
+  frontend/   React web client
+  mobile/     Expo / React Native client
+docs/         Acceptance and audit docs
+ops/          Production runbooks and nginx config
+.github/      CI workflows (tests, deploy-web, mobile-apk)
+docker-compose.yml             Dev stack (db + backend + web)
+docker-compose.prod.yml        Prod overlay (HTTPS + healthchecks)
+.env.example                   Compose env template
+```
+
+## Getting started
+
+For local development, see [SETUP.md](SETUP.md).
+
+For production deploys, see [ops/PROD.md](ops/PROD.md).
+
+## Team
+
+| Area | Members |
+|---|---|
+| Frontend | Eren Can Özkaya, Mustafa Ocak, Mustafa Çağan İslam, Dağlar Tekşen |
+| Backend | Ahmet Akdağ, Ufuk Altunbulak, Ahmet Ayberk Durak, Emirhan Şimşek, Uygar Apan |
+| DevOps | Mustafa Ocak, Mustafa Çağan İslam, Emirhan Şimşek, Ahmet Akdağ |
+
+Project wiki, requirements, and meeting notes live in the
+[GitHub Wiki](https://github.com/bounswe/bounswe2026group12/wiki).
+
+## Milestones
+
+- MVP (Milestones 1–3) — 2026-04-07. Tag
+  [`v1.0-mvp`](https://github.com/bounswe/bounswe2026group12/releases/tag/v1.0-mvp).
+- Final (Milestones 4–6) — 2026-05-14.
+
+Detailed change log per build is in [RELEASE_NOTES.md](RELEASE_NOTES.md).

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,212 @@
+# Release Notes
+
+genipe.app — Cross-Generational Recipe & Food Heritage Platform.
+
+Two named builds so far: the MVP cut on 2026-04-07 (tag
+[`v1.0-mvp`](https://github.com/bounswe/bounswe2026group12/releases/tag/v1.0-mvp))
+and the Final demo build on 2026-05-14. Issue numbers reference
+[bounswe/bounswe2026group12](https://github.com/bounswe/bounswe2026group12)
+and link to the closed issue or merging PR.
+
+## Final — 2026-05-14
+
+**Theme:** Domain-aware search, ingredient conversion + substitution engine,
+story-centric feed, social interaction (comments, upvotes, contact-author),
+moderation queue, and production deploy hardening.
+
+### Highlights
+
+- Domain-aware recipe search with rich filters (#346, #347, #389).
+- Ingredient hierarchy with substitution suggestions and a generic
+  `/convert` API backed by a per-ingredient density table (#362, #363,
+  #366, #374, #375, #376).
+- Story-centric data model and feed (#379, #380), event + cultural-context
+  Explore surface (#386, #387, #388), and map discovery backend (#381).
+- Comments and Q&A on recipes, helpful/upvote, and contact-author messaging
+  (#332, #334, #335, #336, #337, #338, #339, #340, #341, #342).
+- Cultural onboarding, preference-driven personalization, and a daily
+  cultural content surface (#343, #344, #345, #348, #350).
+- Moderation queue covering ingredient, unit, and dietary-tag user
+  submissions (#361).
+- Server-side edit-enforcement audit closing the gap that previously let
+  non-authors edit content via direct API calls (#360).
+- Notification infrastructure (FCM/APNs + in-app delivery) wired across
+  web, mobile, and backend (#349).
+
+### Backend (M4–M6)
+
+- Comments / Q&A schema and API (#332).
+- Creator notification on new question, reply notification to asker
+  (#335, #336).
+- Helpful / upvote backend (#337).
+- Messaging data model and API (#339).
+- Contactability toggle plumbing (#342).
+- Cultural onboarding schema (#343).
+- Preference-driven personalization signals (#345).
+- Rich filter API (#346).
+- Daily cultural content backend (#348).
+- Notification infrastructure (#349).
+- Ingredient hierarchy model and substitution seed/API (#362, #363, #366).
+- Conversion engine, density table, and `/convert` endpoint (#374, #375,
+  #376).
+- Dynamic shopping list (#373).
+- Story-centric data model (#379).
+- Map discovery backend (#381).
+- Event-based Explore backend (#386), event + cultural context combination
+  (#388), domain-aware search (#389).
+- Realistic mock data seed (#390).
+- Cultural tag moderation (#391).
+- Search latency budget (≤ 2 s) enforced via tests in
+  `app/backend/apps/search/tests_perf.py` (#355).
+- Dropdown latency budget (≤ 1 s) enforced via tests in
+  `app/backend/apps/recipes/tests_dropdown_perf.py` (#356).
+- Save/update latency budget (≤ 2 s) enforced via tests in
+  `app/backend/apps/recipes/tests_save_perf.py` (#357).
+- Unique IDs across recipes and stories (#358).
+- Recipe ↔ story referential integrity (#359).
+- Server-side edit enforcement audit and gap fixes (#360, PR #486).
+- Moderation queue for user submissions (ingredient, unit, dietary tag)
+  with submit / approve / reject endpoints (#361, PR #487).
+
+### Frontend (web, M4–M6)
+
+- Comment UI on recipes (frontend half of #332).
+- Helpful / upvote UI (#338).
+- Contact-author button and messaging screen (#340).
+- Contactability toggle UI (frontend half of #342).
+- Cultural onboarding UI (#344).
+- Preference-driven personalization surfaces (#345).
+- Rich filter UI (#347).
+- Daily cultural content UI (#350).
+- Profile navigation from recipe and story cards (#351).
+- Story-centric feed and detail view (#380).
+- Event-based Explore UI (#387).
+- Domain-aware search wiring (#389).
+- Cultural tag moderation UI (#391).
+
+### Mobile (M4–M6)
+
+- Comment UI on recipes (#334).
+- Notification handling for new questions and replies (#335, #336).
+- Helpful / upvote UI (#338).
+- Contact-author button and messaging screen (#341).
+- Contactability toggle UI (frontend half of #342).
+- Cultural onboarding UI (#344).
+- Rich filter UI (#347).
+- Daily cultural content UI (#350).
+- Profile navigation from cards (#351).
+- Story-centric feed and detail (#380).
+- Event-based Explore UI (#387).
+- Unit toggle UI (#378).
+- Palette swap and accessibility fixes on Profile and Messages (#418, #456).
+
+### Performance budgets
+
+All three are enforced as test cases that fail the build if they regress.
+
+| Surface | Budget | Test file | Issue |
+|---|---|---|---|
+| Search | ≤ 2 s | `app/backend/apps/search/tests_perf.py` | #355 |
+| Dropdown lookups | ≤ 1 s | `app/backend/apps/recipes/tests_dropdown_perf.py` | #356 |
+| Recipe save/update | ≤ 2 s | `app/backend/apps/recipes/tests_save_perf.py` | #357 |
+
+### Infrastructure and DevOps
+
+- CI test pipeline gating backend + frontend tests on every PR (#469,
+  PR #477).
+- CI coverage reporting in the GitHub Actions Summary (PR #479).
+- `docker-compose.prod.yml` overlay with HTTPS via nginx + Let's Encrypt
+  and container-level healthchecks for `db`, `backend`, `web` (#368,
+  PR #485).
+- Production bring-up runbook and CORS / `--force-recreate` fix that
+  unblocked the cutover (PR #476).
+- Mobile signed APK build workflow (`.github/workflows/mobile-apk.yml`).
+- Web auto-deploy on push to `main`
+  (`.github/workflows/deploy-web.yml`).
+
+### Cross-cutting fixes carried into Final
+
+- TD-03 — Authentication race conditions on web + mobile (#394).
+- TD-06 — CI test pipeline (#469).
+- Recipes seed migrations no longer collide on UNIQUE in test DB (#419).
+
+### Known gaps at Final cut
+
+Tracked in Milestone 6 and Milestone 5 as still-open at the time of
+writing; targeted for the post-final iteration:
+
+- M6-01 typography + contrast audit, M6-02 keyboard navigation, M6-03
+  elderly-friendly recipe edit flow (#352, #353, #354).
+- M6-11 auto-save draft & restore (#364), M6-12 signed APK release
+  (#365), M6-13 production web deploy umbrella (#367).
+- Web map discovery UI (#382), mobile map discovery UI (#383), region
+  surfacing and theming (#384, #385).
+- Web substitution UI (#370), web unit toggle UI (#377),
+  available-ingredient check-off (#372).
+
+## MVP — 2026-04-07
+
+Tag: [`v1.0-mvp`](https://github.com/bounswe/bounswe2026group12/releases/tag/v1.0-mvp).
+
+**Theme:** Foundation. Guests can browse the platform, registered users
+can author recipes and stories, basic keyword + region search works
+end-to-end across web and mobile.
+
+### Highlights
+
+- Auth (register, login, JWT refresh, protected routes) on web and mobile.
+- Recipe CRUD with ingredient + unit dropdowns and a custom-submission
+  fallback.
+- Story CRUD with a linked-recipe preview card.
+- Keyword + region search that returns recipes and stories with a friendly
+  empty state.
+- Vultr deploy of the backend and web frontend at
+  [genipe.app](https://genipe.app).
+
+### Milestone 1 — Foundation & Authentication
+
+Requirements 3.0.1, 3.0.2, 3.1.1–3.1.4. 27 issues closed, including:
+
+- Auth database schema (#149), auth API endpoints (#151), endpoint
+  protection (#157).
+- Public endpoints (#147), public routing on web (#145).
+- Auth UI flows, state management, and protected routes on web (#153,
+  #154, #155).
+- Initial mobile app setup (#192) and initial web setup (#194).
+- Test database seed script (#178).
+- Vultr + Nginx + SSL deploy of `genipe.app` (#195).
+- JWT middleware exception logging fix (#251).
+
+### Milestone 2 — Core Recipe Features
+
+Requirements 3.2.1–3.2.11, 3.6.1–3.6.8, 3.7.1–3.7.6. 38 issues closed,
+including:
+
+- Recipe creation API (#156), edit API + author-only authorization (#161).
+- Lookup APIs for ingredients and units (#143), custom-submission API
+  for items not in the dropdown (#144).
+- Media storage setup (#150).
+- Web + mobile selection UI (#146, #226, #227), creation UI (#158, #224,
+  #225), recipe detail view (#159, #222, #223), edit UI (#162, #220,
+  #221), author-only visibility (#163, #218, #219), success notifications
+  (#165, #216, #217), Q&A toggle (#166, #214, #215).
+- Backend test coverage for recipes and authentication (#174, #175).
+
+### Milestone 3 — Search & Stories
+
+Requirements 3.3.1–3.3.9, 3.5.1–3.5.6. 30 issues closed, including:
+
+- Search & filter API (#148).
+- Story database schema (#168) and story API (#169).
+- Web + mobile search UI (#152, #212, #213), results display (#160, #210,
+  #211), empty state (#164, #208, #209).
+- Story creation UI (#170, #206, #207), recipe linking inside story
+  creation (#171, #204, #205), story detail view (#172, #202, #203).
+- Backend test coverage for search and story endpoints (#177).
+
+### Infrastructure at MVP
+
+- Single `docker-compose.yml` running `db` + `backend` + `web` on the
+  Vultr box.
+- Nginx + Let's Encrypt SSL terminating at `genipe.app`.
+- Manual deploy via SSH at MVP cut; auto-deploy workflow followed in M5.

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,0 +1,215 @@
+# Local development setup
+
+A clone-to-running walkthrough for the genipe.app monorepo. Production
+bring-up lives in [`ops/PROD.md`](ops/PROD.md); this file is local dev only.
+
+The repo has three apps:
+
+- `app/backend` — Django + DRF + JWT (Python 3.12).
+- `app/frontend` — React (CRA, React 19, react-leaflet).
+- `app/mobile` — React Native via Expo SDK 54.
+
+You can run them independently. There is no required boot order, though the
+frontends will look empty until the backend is up.
+
+## Prerequisites
+
+- Python 3.12 and `pip`
+- Node.js 20 LTS and `npm`
+- Git
+- Docker Engine 24+ with the Compose v2 plugin (optional, only needed if
+  you want a Postgres parity setup or want to bring up the whole stack)
+- For mobile: the [Expo Go](https://expo.dev/go) app on a phone, or an
+  iOS Simulator / Android Emulator on the host
+
+## Clone and configure
+
+```bash
+git clone https://github.com/bounswe/bounswe2026group12.git
+cd bounswe2026group12
+cp .env.example .env
+```
+
+`.env` only needs to be filled in if you plan to use docker compose or
+S3-compatible media storage. For pure local dev, the defaults baked into
+each app are fine and `.env` can stay as-is.
+
+## Backend (Django)
+
+```bash
+cd app/backend
+python -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+python manage.py migrate
+python manage.py runserver
+```
+
+The dev server listens on http://localhost:8000.
+
+By default the backend uses SQLite (`db.sqlite3` in `app/backend/`)
+because `POSTGRES_HOST` is unset. To run against Postgres instead, see
+[Database (optional Postgres parity)](#database-optional-postgres-parity)
+below.
+
+To create an admin user for the Django admin:
+
+```bash
+python manage.py createsuperuser
+```
+
+To load a starter dataset:
+
+```bash
+python manage.py loaddata fixtures/*.json
+```
+
+## Frontend (web)
+
+In a second terminal:
+
+```bash
+cd app/frontend
+npm ci
+npm start
+```
+
+Opens http://localhost:3000. The web app expects the backend at
+`http://localhost:8000` by default; this is wired through CRA's proxy
+config and the `REACT_APP_API_URL` environment variable.
+
+Override the API URL when needed:
+
+```bash
+REACT_APP_API_URL=http://localhost:8000 npm start
+```
+
+`REACT_APP_API_URL` is baked in at build time, not runtime, so a fresh
+`npm start` is required after changing it.
+
+## Mobile (Expo)
+
+In a third terminal:
+
+```bash
+cd app/mobile
+npm ci
+npx expo start
+```
+
+Then either:
+
+- Scan the QR code with Expo Go on a phone (same Wi-Fi as the host).
+- Press `i` to open the iOS Simulator (macOS, Xcode required).
+- Press `a` to open an Android Emulator (Android Studio required).
+- Press `w` to open in a browser (limited; mobile-only screens may not
+  render correctly).
+
+The mobile client points at the same API URL as web. Configure it in
+`app/mobile/src/config` if you need to override.
+
+## Database (optional Postgres parity)
+
+By default backend tests and `runserver` use SQLite. To match production,
+bring up the whole stack with compose:
+
+```bash
+docker compose up --build
+```
+
+This starts `db`, `backend`, and `web` together. The backend container
+reaches Postgres at `db:5432` over the compose network and runs migrations
+on entry. Web is served at http://localhost.
+
+If you want to point a host-side `runserver` at the compose `db`, the dev
+compose file does not publish port 5432 to the host. Add a one-line
+override (e.g. `docker-compose.override.yml`) that exposes
+`5432:5432` on the `db` service, then set in `.env`:
+
+```
+POSTGRES_HOST=localhost
+POSTGRES_PORT=5432
+POSTGRES_DB=bounswe_db
+POSTGRES_USER=genipe
+POSTGRES_PASSWORD=genipe_mvp_2026
+```
+
+and re-run migrations:
+
+```bash
+cd app/backend
+source venv/bin/activate
+python manage.py migrate
+```
+
+## Running tests
+
+### Backend
+
+```bash
+cd app/backend
+source venv/bin/activate
+python manage.py test
+```
+
+Backend tests run against SQLite regardless of `POSTGRES_HOST` (tests
+inject their own settings). Django's test runner discovers
+`apps/*/tests*.py`.
+
+Coverage matches what CI runs:
+
+```bash
+pip install coverage==7.13.5
+coverage run --source=apps manage.py test
+coverage report --omit='*/migrations/*,*/tests*'
+```
+
+### Frontend
+
+```bash
+cd app/frontend
+npm test -- --watchAll=false
+```
+
+With coverage:
+
+```bash
+npm test -- --watchAll=false --coverage
+```
+
+### Mobile
+
+The mobile app currently has no automated test suite. Smoke testing is
+done by stepping through the app in Expo Go.
+
+## Common issues
+
+- **Port 8000 already in use.** Another `runserver` is alive, or the prod
+  backend container is bound. `lsof -i :8000` to find it.
+- **Port 3000 already in use.** CRA will offer to use the next port; say
+  yes or kill the other process.
+- **Migrations out of sync after `git pull`.** Re-run
+  `python manage.py migrate` inside the backend venv. If a migration was
+  squashed upstream, drop `db.sqlite3` and migrate from scratch.
+- **`leaflet` import errors in tests.** Frontend Jest is configured to
+  transpile `react-leaflet` and `leaflet`. If a new ESM-only dep breaks
+  the test run, extend `jest.transformIgnorePatterns` in
+  `app/frontend/package.json` to include it.
+- **Expo "incompatible Metro version".** Run `npx expo install --fix`
+  inside `app/mobile` to align native dep versions with the SDK.
+- **CORS errors hitting backend from web.** Confirm `DEBUG=True` (which
+  flips CORS to allow-all) or that your origin is listed in
+  `CORS_ALLOWED_ORIGINS` in `.env`.
+- **`pip install` fails on `psycopg2-binary` on macOS arm64.** Install
+  Postgres headers via Homebrew (`brew install libpq`) and retry, or
+  switch to SQLite-only by leaving `POSTGRES_HOST` unset.
+
+## Where to look next
+
+- [`README.md`](README.md) — project overview and links.
+- [`ops/PROD.md`](ops/PROD.md) — production bring-up.
+- [`RELEASE_NOTES.md`](RELEASE_NOTES.md) — what shipped in MVP and Final.
+- [`docs/lab9-acceptance-test-traceability.md`](docs/lab9-acceptance-test-traceability.md)
+  and
+  [`docs/lab9-edit-enforcement-audit.md`](docs/lab9-edit-enforcement-audit.md)
+  — acceptance and edit-enforcement audits.


### PR DESCRIPTION
## Summary
- `RELEASE_NOTES.md` covers MVP (2026-04-07, tag `v1.0-mvp`) and Final (2026-05-14), grouped by surface and backed by closed-issue references.
- `SETUP.md` walks a fresh developer from clone to running backend + frontend + mobile + tests, with Postgres parity and common-issue notes.
- `README.md` (previously empty) now has a project intro, Documentation index, tech-stack table, repo layout, team, and milestone links.

## Test plan
- [x] `RELEASE_NOTES.md` issue numbers and PR refs spot-checked against `gh issue view` / `gh pr view`.
- [x] `SETUP.md` commands cross-checked against `docker-compose.yml`, `.github/workflows/tests.yml`, and the per-app `package.json` / `requirements.txt`.
- [x] All in-repo links resolve: `ops/PROD.md`, `ops/ROLLBACK.md`, `docs/lab9-acceptance-test-traceability.md`, `docs/lab9-edit-enforcement-audit.md`, `RELEASE_NOTES.md`, `SETUP.md`.
- [x] Markdown previews cleanly on GitHub.

## Notes
- Sister PR for `ops/ROLLBACK.md` (#367) is in flight; the README links to it on the assumption the path will match. If that PR lands after this one, the link goes live without further changes here.
- The MVP tag `v1.0-mvp` already exists, so the release-notes back-link is live.
- `.env.example` is already in the repo, so the gap flagged in the prompt is not present.
- M5 / M6 items still open at the time of writing are explicitly listed under "Known gaps at Final cut" rather than silently included.

Closes #369.