### PR TITLE
feat(frontend): dropdown cache, auto-save drafts, rollback runbook (#356 #364 #367)

### DIFF
--- a/app/frontend/src/__tests__/DraftRestoreBanner.test.jsx
+++ b/app/frontend/src/__tests__/DraftRestoreBanner.test.jsx
@@ -1,0 +1,45 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import DraftRestoreBanner from '../components/DraftRestoreBanner';
+
+describe('DraftRestoreBanner', () => {
+  it('renders nothing when draft is null', () => {
+    const { container } = render(
+      <DraftRestoreBanner draft={null} onRestore={jest.fn()} onDiscard={jest.fn()} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the banner when draft is provided', () => {
+    render(
+      <DraftRestoreBanner
+        draft={{ title: 'Saved' }}
+        onRestore={jest.fn()}
+        onDiscard={jest.fn()}
+      />
+    );
+    expect(screen.getByText(/unsaved draft found/i)).toBeInTheDocument();
+  });
+
+  it('calls onRestore with the draft when Restore is clicked', () => {
+    const onRestore = jest.fn();
+    const draft = { title: 'Saved' };
+    render(
+      <DraftRestoreBanner draft={draft} onRestore={onRestore} onDiscard={jest.fn()} />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /restore/i }));
+    expect(onRestore).toHaveBeenCalledWith(draft);
+  });
+
+  it('calls onDiscard when Discard is clicked', () => {
+    const onDiscard = jest.fn();
+    render(
+      <DraftRestoreBanner
+        draft={{ title: 'x' }}
+        onRestore={jest.fn()}
+        onDiscard={onDiscard}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /discard/i }));
+    expect(onDiscard).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/frontend/src/__tests__/RecipeCreatePage.test.jsx
+++ b/app/frontend/src/__tests__/RecipeCreatePage.test.jsx
@@ -156,3 +156,47 @@ describe('RecipeCreatePage', () => {
     });
   });
 });
+
+describe('RecipeCreatePage — draft auto-save', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    localStorage.clear();
+  });
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it('shows DraftRestoreBanner when a draft exists in localStorage', async () => {
+    localStorage.setItem(
+      'draft:recipe:new',
+      JSON.stringify({ title: 'Saved Title', description: '', region: '', qaEnabled: true, rows: [] })
+    );
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByText(/unsaved draft found/i)).toBeInTheDocument()
+    );
+  });
+
+  it('restores title from draft when Restore is clicked', async () => {
+    localStorage.setItem(
+      'draft:recipe:new',
+      JSON.stringify({ title: 'Draft Title', description: '', region: '', qaEnabled: true, rows: [] })
+    );
+    renderPage();
+    await waitFor(() => screen.getByText(/unsaved draft found/i));
+    fireEvent.click(screen.getByRole('button', { name: /restore/i }));
+    expect(screen.getByLabelText(/title/i).value).toBe('Draft Title');
+  });
+
+  it('hides the banner after Discard is clicked', async () => {
+    localStorage.setItem(
+      'draft:recipe:new',
+      JSON.stringify({ title: 'x', description: '', region: '', qaEnabled: true, rows: [] })
+    );
+    renderPage();
+    await waitFor(() => screen.getByText(/unsaved draft found/i));
+    fireEvent.click(screen.getByRole('button', { name: /discard/i }));
+    expect(screen.queryByText(/unsaved draft found/i)).not.toBeInTheDocument();
+  });
+});

--- a/app/frontend/src/__tests__/RecipeEditPage.test.jsx
+++ b/app/frontend/src/__tests__/RecipeEditPage.test.jsx
@@ -155,3 +155,36 @@ describe('RecipeEditPage', () => {
     });
   });
 });
+
+describe('RecipeEditPage — draft auto-save', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    localStorage.clear();
+  });
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it('shows DraftRestoreBanner when a draft exists for this recipe', async () => {
+    localStorage.setItem(
+      'draft:recipe:1',
+      JSON.stringify({ title: 'Draft Edit', description: 'x', region: '', qaEnabled: false, rows: [] })
+    );
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByText(/unsaved draft found/i)).toBeInTheDocument()
+    );
+  });
+
+  it('restores title from draft when Restore is clicked', async () => {
+    localStorage.setItem(
+      'draft:recipe:1',
+      JSON.stringify({ title: 'Restored Title', description: 'x', region: '', qaEnabled: false, rows: [] })
+    );
+    renderPage();
+    await waitFor(() => screen.getByText(/unsaved draft found/i));
+    fireEvent.click(screen.getByRole('button', { name: /restore/i }));
+    expect(screen.getByLabelText(/title/i).value).toBe('Restored Title');
+  });
+});

--- a/app/frontend/src/__tests__/StoryCreatePage.test.jsx
+++ b/app/frontend/src/__tests__/StoryCreatePage.test.jsx
@@ -123,3 +123,47 @@ describe('StoryCreatePage', () => {
     expect(screen.getByLabelText(/photo/i)).toBeInTheDocument();
   });
 });
+
+describe('StoryCreatePage — draft auto-save', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    localStorage.clear();
+  });
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it('shows DraftRestoreBanner when a draft exists in localStorage', async () => {
+    localStorage.setItem(
+      'draft:story:new',
+      JSON.stringify({ title: 'Draft Story', body: 'Some body', language: 'en', linkedRecipe: null })
+    );
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByText(/unsaved draft found/i)).toBeInTheDocument()
+    );
+  });
+
+  it('restores title from draft when Restore is clicked', async () => {
+    localStorage.setItem(
+      'draft:story:new',
+      JSON.stringify({ title: 'Restored Story', body: 'Body text', language: 'en', linkedRecipe: null })
+    );
+    renderPage();
+    await waitFor(() => screen.getByText(/unsaved draft found/i));
+    fireEvent.click(screen.getByRole('button', { name: /restore/i }));
+    expect(screen.getByLabelText(/title/i).value).toBe('Restored Story');
+  });
+
+  it('hides the banner after Discard is clicked', async () => {
+    localStorage.setItem(
+      'draft:story:new',
+      JSON.stringify({ title: 'x', body: 'y', language: 'en', linkedRecipe: null })
+    );
+    renderPage();
+    await waitFor(() => screen.getByText(/unsaved draft found/i));
+    fireEvent.click(screen.getByRole('button', { name: /discard/i }));
+    expect(screen.queryByText(/unsaved draft found/i)).not.toBeInTheDocument();
+  });
+});

--- a/app/frontend/src/__tests__/StoryEditPage.test.jsx
+++ b/app/frontend/src/__tests__/StoryEditPage.test.jsx
@@ -99,3 +99,36 @@ describe('StoryEditPage', () => {
     );
   });
 });
+
+describe('StoryEditPage — draft auto-save', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    localStorage.clear();
+  });
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it('shows DraftRestoreBanner when a draft exists for this story', async () => {
+    localStorage.setItem(
+      'draft:story:1',
+      JSON.stringify({ title: 'Draft Edit Story', body: 'x', language: 'en', linkedRecipe: null })
+    );
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByText(/unsaved draft found/i)).toBeInTheDocument()
+    );
+  });
+
+  it('restores title from draft when Restore is clicked', async () => {
+    localStorage.setItem(
+      'draft:story:1',
+      JSON.stringify({ title: 'Restored Story Edit', body: 'x', language: 'en', linkedRecipe: null })
+    );
+    renderPage();
+    await waitFor(() => screen.getByText(/unsaved draft found/i));
+    fireEvent.click(screen.getByRole('button', { name: /restore/i }));
+    expect(screen.getByLabelText(/title/i).value).toBe('Restored Story Edit');
+  });
+});

--- a/app/frontend/src/__tests__/recipeService.test.js
+++ b/app/frontend/src/__tests__/recipeService.test.js
@@ -109,3 +109,117 @@ describe('fetchRecipes', () => {
     expect(result).toEqual([{ id: 1, title: 'Baklava' }]);
   });
 });
+
+describe('fetchIngredients — promise cache', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it('calls GET /api/ingredients/ only once on repeated calls', async () => {
+    jest.doMock('../services/api', () => ({
+      apiClient: { get: jest.fn().mockResolvedValue({ data: [{ id: 1, name: 'Salt' }] }) },
+    }));
+    const { fetchIngredients } = require('../services/recipeService');
+    await fetchIngredients();
+    await fetchIngredients();
+    const { apiClient } = require('../services/api');
+    expect(apiClient.get).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns the same data on repeated calls', async () => {
+    jest.doMock('../services/api', () => ({
+      apiClient: { get: jest.fn().mockResolvedValue({ data: [{ id: 2, name: 'Pepper' }] }) },
+    }));
+    const { fetchIngredients } = require('../services/recipeService');
+    const first = await fetchIngredients();
+    const second = await fetchIngredients();
+    expect(first).toEqual(second);
+  });
+
+  it('fires only one request when called concurrently', async () => {
+    jest.doMock('../services/api', () => ({
+      apiClient: { get: jest.fn().mockResolvedValue({ data: [{ id: 1, name: 'Salt' }] }) },
+    }));
+    const { fetchIngredients } = require('../services/recipeService');
+    const [a, b] = await Promise.all([fetchIngredients(), fetchIngredients()]);
+    const { apiClient } = require('../services/api');
+    expect(apiClient.get).toHaveBeenCalledTimes(1);
+    expect(a).toEqual(b);
+  });
+
+  it('retries after a fetch error', async () => {
+    let calls = 0;
+    jest.doMock('../services/api', () => ({
+      apiClient: {
+        get: jest.fn().mockImplementation(() => {
+          calls += 1;
+          if (calls === 1) return Promise.reject(new Error('Network Error'));
+          return Promise.resolve({ data: [{ id: 1, name: 'Salt' }] });
+        }),
+      },
+    }));
+    const { fetchIngredients } = require('../services/recipeService');
+    await expect(fetchIngredients()).rejects.toThrow('Network Error');
+    const result = await fetchIngredients();
+    expect(result[0].name).toBe('Salt');
+    expect(calls).toBe(2);
+  });
+});
+
+describe('fetchUnits — promise cache', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it('calls GET /api/units/ only once on repeated calls', async () => {
+    jest.doMock('../services/api', () => ({
+      apiClient: { get: jest.fn().mockResolvedValue({ data: [{ id: 1, name: 'cup' }] }) },
+    }));
+    const { fetchUnits } = require('../services/recipeService');
+    await fetchUnits();
+    await fetchUnits();
+    const { apiClient } = require('../services/api');
+    expect(apiClient.get).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns the same data on repeated calls', async () => {
+    jest.doMock('../services/api', () => ({
+      apiClient: { get: jest.fn().mockResolvedValue({ data: [{ id: 3, name: 'tbsp' }] }) },
+    }));
+    const { fetchUnits } = require('../services/recipeService');
+    const first = await fetchUnits();
+    const second = await fetchUnits();
+    expect(first).toEqual(second);
+  });
+
+  it('fires only one request when called concurrently', async () => {
+    jest.doMock('../services/api', () => ({
+      apiClient: { get: jest.fn().mockResolvedValue({ data: [{ id: 1, name: 'cup' }] }) },
+    }));
+    const { fetchUnits } = require('../services/recipeService');
+    const [a, b] = await Promise.all([fetchUnits(), fetchUnits()]);
+    const { apiClient } = require('../services/api');
+    expect(apiClient.get).toHaveBeenCalledTimes(1);
+    expect(a).toEqual(b);
+  });
+
+  it('retries after a fetch error', async () => {
+    let calls = 0;
+    jest.doMock('../services/api', () => ({
+      apiClient: {
+        get: jest.fn().mockImplementation(() => {
+          calls += 1;
+          if (calls === 1) return Promise.reject(new Error('Network Error'));
+          return Promise.resolve({ data: [{ id: 1, name: 'g' }] });
+        }),
+      },
+    }));
+    const { fetchUnits } = require('../services/recipeService');
+    await expect(fetchUnits()).rejects.toThrow('Network Error');
+    const result = await fetchUnits();
+    expect(result[0].name).toBe('g');
+    expect(calls).toBe(2);
+  });
+});

--- a/app/frontend/src/__tests__/useDraftAutosave.test.js
+++ b/app/frontend/src/__tests__/useDraftAutosave.test.js
@@ -1,0 +1,75 @@
+import { renderHook, act } from '@testing-library/react';
+import useDraftAutosave from '../hooks/useDraftAutosave';
+
+beforeEach(() => {
+  localStorage.clear();
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.runOnlyPendingTimers();
+  jest.useRealTimers();
+});
+
+describe('useDraftAutosave', () => {
+  it('writes state to localStorage after 1500ms debounce when enabled', () => {
+    const state = { title: 'My Recipe', description: 'Tasty' };
+    renderHook(() => useDraftAutosave('draft:recipe:new', state, { enabled: true }));
+    expect(localStorage.getItem('draft:recipe:new')).toBeNull();
+    act(() => jest.advanceTimersByTime(1500));
+    expect(JSON.parse(localStorage.getItem('draft:recipe:new'))).toEqual(state);
+  });
+
+  it('does not write to localStorage when enabled is false', () => {
+    const state = { title: 'Draft' };
+    renderHook(() => useDraftAutosave('draft:recipe:new', state, { enabled: false }));
+    act(() => jest.advanceTimersByTime(2000));
+    expect(localStorage.getItem('draft:recipe:new')).toBeNull();
+  });
+
+  it('returns savedDraft when a draft exists in localStorage on mount', () => {
+    const existing = { title: 'Old Draft', description: 'Saved' };
+    localStorage.setItem('draft:recipe:new', JSON.stringify(existing));
+    const { result } = renderHook(() =>
+      useDraftAutosave('draft:recipe:new', {}, { enabled: true })
+    );
+    expect(result.current.savedDraft).toEqual(existing);
+  });
+
+  it('returns null savedDraft when no draft exists in localStorage', () => {
+    const { result } = renderHook(() =>
+      useDraftAutosave('draft:story:new', {}, { enabled: true })
+    );
+    expect(result.current.savedDraft).toBeNull();
+  });
+
+  it('clearDraft removes the key from localStorage', () => {
+    localStorage.setItem('draft:recipe:new', JSON.stringify({ title: 'x' }));
+    const { result } = renderHook(() =>
+      useDraftAutosave('draft:recipe:new', {}, { enabled: true })
+    );
+    act(() => result.current.clearDraft());
+    expect(localStorage.getItem('draft:recipe:new')).toBeNull();
+  });
+
+  it('clearDraft sets savedDraft to null', () => {
+    localStorage.setItem('draft:recipe:new', JSON.stringify({ title: 'x' }));
+    const { result } = renderHook(() =>
+      useDraftAutosave('draft:recipe:new', {}, { enabled: true })
+    );
+    act(() => result.current.clearDraft());
+    expect(result.current.savedDraft).toBeNull();
+  });
+
+  it('debounces: multiple rapid state changes result in one write', () => {
+    let state = { title: 'v1' };
+    const { rerender } = renderHook(
+      ({ s }) => useDraftAutosave('draft:recipe:new', s, { enabled: true }),
+      { initialProps: { s: state } }
+    );
+    rerender({ s: { title: 'v2' } });
+    rerender({ s: { title: 'v3' } });
+    act(() => jest.advanceTimersByTime(1500));
+    expect(JSON.parse(localStorage.getItem('draft:recipe:new'))).toEqual({ title: 'v3' });
+  });
+});

--- a/app/frontend/src/components/DraftRestoreBanner.css
+++ b/app/frontend/src/components/DraftRestoreBanner.css
@@ -1,0 +1,18 @@
+.draft-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.6rem 1rem;
+  margin-bottom: 1rem;
+  background: #fff8e1;
+  border: 1px solid #f9a825;
+  border-radius: 6px;
+  font-size: 0.9rem;
+  color: #5d4037;
+}
+
+.draft-banner-actions {
+  display: flex;
+  gap: 0.5rem;
+}

--- a/app/frontend/src/components/DraftRestoreBanner.jsx
+++ b/app/frontend/src/components/DraftRestoreBanner.jsx
@@ -1,0 +1,26 @@
+import './DraftRestoreBanner.css';
+
+export default function DraftRestoreBanner({ draft, onRestore, onDiscard }) {
+  if (!draft) return null;
+  return (
+    <div className="draft-banner" role="alert">
+      <span>Unsaved draft found</span>
+      <div className="draft-banner-actions">
+        <button
+          type="button"
+          className="btn btn-sm btn-primary"
+          onClick={() => onRestore(draft)}
+        >
+          Restore
+        </button>
+        <button
+          type="button"
+          className="btn btn-sm btn-outline"
+          onClick={onDiscard}
+        >
+          Discard
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/frontend/src/hooks/useDraftAutosave.js
+++ b/app/frontend/src/hooks/useDraftAutosave.js
@@ -1,0 +1,34 @@
+import { useState, useEffect, useRef } from 'react';
+
+export default function useDraftAutosave(key, state, { enabled }) {
+  const [savedDraft, setSavedDraft] = useState(() => {
+    try {
+      const raw = localStorage.getItem(key);
+      return raw ? JSON.parse(raw) : null;
+    } catch {
+      return null;
+    }
+  });
+
+  const timerRef = useRef(null);
+
+  useEffect(() => {
+    if (!enabled) return;
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => {
+      try {
+        localStorage.setItem(key, JSON.stringify(state));
+      } catch {
+        // localStorage quota exceeded — silently skip
+      }
+    }, 1500);
+    return () => clearTimeout(timerRef.current);
+  }, [key, state, enabled]);
+
+  function clearDraft() {
+    localStorage.removeItem(key);
+    setSavedDraft(null);
+  }
+
+  return { savedDraft, clearDraft };
+}

--- a/app/frontend/src/pages/RecipeCreatePage.jsx
+++ b/app/frontend/src/pages/RecipeCreatePage.jsx
@@ -2,6 +2,8 @@ import { useState, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import IngredientRow from '../components/IngredientRow';
 import Toast from '../components/Toast';
+import DraftRestoreBanner from '../components/DraftRestoreBanner';
+import useDraftAutosave from '../hooks/useDraftAutosave';
 import {
   createRecipe,
   updateRecipe,
@@ -12,6 +14,8 @@ import {
 } from '../services/recipeService';
 import { fetchRegions } from '../services/searchService';
 import './RecipeCreatePage.css';
+
+const DRAFT_KEY = 'draft:recipe:new';
 
 function makeRow() {
   return {
@@ -42,6 +46,9 @@ export default function RecipeCreatePage() {
   const [errors, setErrors] = useState({});
   const [toast, setToast] = useState({ message: '', type: 'success' });
 
+  const draftState = { title, description, region, qaEnabled, rows };
+  const { savedDraft, clearDraft } = useDraftAutosave(DRAFT_KEY, draftState, { enabled: true });
+
   useEffect(() => {
     fetchIngredients().then(setIngredients).catch(() => {});
     fetchUnits().then(setUnits).catch(() => {});
@@ -51,6 +58,15 @@ export default function RecipeCreatePage() {
   function showToast(message, type) {
     setToast({ message, type });
     setTimeout(() => setToast({ message: '', type: 'success' }), 3000);
+  }
+
+  function handleRestore(draft) {
+    if (draft.title !== undefined) setTitle(draft.title);
+    if (draft.description !== undefined) setDescription(draft.description);
+    if (draft.region !== undefined) setRegion(draft.region);
+    if (draft.qaEnabled !== undefined) setQaEnabled(draft.qaEnabled);
+    if (Array.isArray(draft.rows) && draft.rows.length > 0) setRows(draft.rows);
+    clearDraft();
   }
 
   const handleRowChange = useCallback((rowId, field, value) => {
@@ -119,6 +135,7 @@ export default function RecipeCreatePage() {
         await updateRecipe(created.id, mediaData);
       }
 
+      clearDraft();
       showToast('Recipe published!', 'success');
       setTimeout(() => navigate(`/recipes/${created.id}`), 1500);
     } catch {
@@ -129,6 +146,11 @@ export default function RecipeCreatePage() {
   return (
     <main className="page-card recipe-form">
       <h1 className="recipe-form-heading">Create Recipe</h1>
+      <DraftRestoreBanner
+        draft={savedDraft}
+        onRestore={handleRestore}
+        onDiscard={clearDraft}
+      />
       <form onSubmit={handleSubmit}>
         <div className="form-group">
           <label htmlFor="title">Title</label>

--- a/app/frontend/src/pages/RecipeEditPage.jsx
+++ b/app/frontend/src/pages/RecipeEditPage.jsx
@@ -3,6 +3,8 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { AuthContext } from '../context/AuthContext';
 import IngredientRow from '../components/IngredientRow';
 import Toast from '../components/Toast';
+import DraftRestoreBanner from '../components/DraftRestoreBanner';
+import useDraftAutosave from '../hooks/useDraftAutosave';
 import {
   fetchRecipe,
   updateRecipe,
@@ -57,6 +59,10 @@ export default function RecipeEditPage() {
   const [errors, setErrors] = useState({});
   const [toast, setToast] = useState({ message: '', type: 'success' });
 
+  const draftKey = `draft:recipe:${id}`;
+  const draftState = { title, description, region, qaEnabled, rows };
+  const { savedDraft, clearDraft } = useDraftAutosave(draftKey, draftState, { enabled: !loading });
+
   useEffect(() => {
     let cancelled = false;
     fetchRegions().then((regs) => { if (!cancelled) setRegions(regs); }).catch(() => {});
@@ -88,6 +94,15 @@ export default function RecipeEditPage() {
   function showToast(message, type) {
     setToast({ message, type });
     setTimeout(() => setToast({ message: '', type: 'success' }), 3000);
+  }
+
+  function handleRestore(draft) {
+    if (draft.title !== undefined) setTitle(draft.title);
+    if (draft.description !== undefined) setDescription(draft.description);
+    if (draft.region !== undefined) setRegion(draft.region);
+    if (draft.qaEnabled !== undefined) setQaEnabled(draft.qaEnabled);
+    if (Array.isArray(draft.rows) && draft.rows.length > 0) setRows(draft.rows);
+    clearDraft();
   }
 
   const handleRowChange = useCallback((rowId, field, value) => {
@@ -156,6 +171,7 @@ export default function RecipeEditPage() {
         await updateRecipe(id, mediaData);
       }
 
+      clearDraft();
       showToast('Recipe updated!', 'success');
       setTimeout(() => navigate(`/recipes/${id}`), 1500);
     } catch {
@@ -172,6 +188,11 @@ export default function RecipeEditPage() {
   return (
     <main className="page-card recipe-form">
       <h1 className="recipe-form-heading">Edit Recipe</h1>
+      <DraftRestoreBanner
+        draft={savedDraft}
+        onRestore={handleRestore}
+        onDiscard={clearDraft}
+      />
       <form onSubmit={handleSubmit}>
         <div className="form-group">
           <label htmlFor="title">Title</label>

--- a/app/frontend/src/pages/StoryCreatePage.jsx
+++ b/app/frontend/src/pages/StoryCreatePage.jsx
@@ -3,7 +3,11 @@ import { useNavigate } from 'react-router-dom';
 import { createStory } from '../services/storyService';
 import { fetchRecipes } from '../services/recipeService';
 import Toast from '../components/Toast';
+import DraftRestoreBanner from '../components/DraftRestoreBanner';
+import useDraftAutosave from '../hooks/useDraftAutosave';
 import './StoryCreatePage.css';
+
+const DRAFT_KEY = 'draft:story:new';
 
 export default function StoryCreatePage() {
   const navigate = useNavigate();
@@ -18,6 +22,9 @@ export default function StoryCreatePage() {
   const [errors, setErrors] = useState({});
   const [toast, setToast] = useState({ message: '', type: 'success' });
 
+  const draftState = { title, body, language, linkedRecipe };
+  const { savedDraft, clearDraft } = useDraftAutosave(DRAFT_KEY, draftState, { enabled: true });
+
   useEffect(() => {
     fetchRecipes().then(setAllRecipes).catch(() => {});
   }, []);
@@ -25,6 +32,14 @@ export default function StoryCreatePage() {
   function showToast(message, type) {
     setToast({ message, type });
     setTimeout(() => setToast({ message: '', type: 'success' }), 3000);
+  }
+
+  function handleRestore(draft) {
+    if (draft.title !== undefined) setTitle(draft.title);
+    if (draft.body !== undefined) setBody(draft.body);
+    if (draft.language !== undefined) setLanguage(draft.language);
+    if (draft.linkedRecipe !== undefined) setLinkedRecipe(draft.linkedRecipe);
+    clearDraft();
   }
 
   function validate() {
@@ -49,6 +64,7 @@ export default function StoryCreatePage() {
 
     try {
       const created = await createStory(formData);
+      clearDraft();
       showToast('Story published!', 'success');
       navigate(`/stories/${created.id}`);
     } catch {
@@ -65,6 +81,11 @@ export default function StoryCreatePage() {
   return (
     <main className="page-card story-form">
       <h1 className="story-form-heading">Create Story</h1>
+      <DraftRestoreBanner
+        draft={savedDraft}
+        onRestore={handleRestore}
+        onDiscard={clearDraft}
+      />
       <form onSubmit={handleSubmit}>
         <div className="form-group">
           <label htmlFor="story-title">Title</label>

--- a/app/frontend/src/pages/StoryEditPage.jsx
+++ b/app/frontend/src/pages/StoryEditPage.jsx
@@ -4,6 +4,8 @@ import { AuthContext } from '../context/AuthContext';
 import { fetchStory, updateStory } from '../services/storyService';
 import { fetchRecipes } from '../services/recipeService';
 import Toast from '../components/Toast';
+import DraftRestoreBanner from '../components/DraftRestoreBanner';
+import useDraftAutosave from '../hooks/useDraftAutosave';
 import './StoryEditPage.css';
 
 export default function StoryEditPage() {
@@ -26,6 +28,10 @@ export default function StoryEditPage() {
 
   const toastTimerRef = useRef(null);
   const navTimerRef = useRef(null);
+
+  const draftKey = `draft:story:${id}`;
+  const draftState = { title, body, language, linkedRecipe };
+  const { savedDraft, clearDraft } = useDraftAutosave(draftKey, draftState, { enabled: !loading });
 
   useEffect(() => {
     let cancelled = false;
@@ -50,6 +56,14 @@ export default function StoryEditPage() {
     toastTimerRef.current = setTimeout(() => setToast({ message: '', type: 'success' }), 3000);
   }
 
+  function handleRestore(draft) {
+    if (draft.title !== undefined) setTitle(draft.title);
+    if (draft.body !== undefined) setBody(draft.body);
+    if (draft.language !== undefined) setLanguage(draft.language);
+    if (draft.linkedRecipe !== undefined) setLinkedRecipe(draft.linkedRecipe);
+    clearDraft();
+  }
+
   function validate() {
     const e = {};
     if (!title.trim()) e.title = 'Title is required.';
@@ -71,6 +85,7 @@ export default function StoryEditPage() {
 
     try {
       await updateStory(id, formData);
+      clearDraft();
       showToast('Story updated!', 'success');
       if (navTimerRef.current) clearTimeout(navTimerRef.current);
       navTimerRef.current = setTimeout(() => navigate(`/stories/${id}`), 1500);
@@ -102,6 +117,11 @@ export default function StoryEditPage() {
   return (
     <main className="page-card story-form">
       <h1 className="story-form-heading">Edit Story</h1>
+      <DraftRestoreBanner
+        draft={savedDraft}
+        onRestore={handleRestore}
+        onDiscard={clearDraft}
+      />
       <form onSubmit={handleSubmit}>
         <div className="form-group">
           <label htmlFor="story-title">Title</label>

--- a/app/frontend/src/services/recipeService.js
+++ b/app/frontend/src/services/recipeService.js
@@ -27,16 +27,27 @@ export async function updateRecipe(id, formData) {
   return response.data;
 }
 
+let _ingredientsPromise = null;
+let _unitsPromise = null;
+
 export async function fetchIngredients() {
   if (USE_MOCK) return getMockIngredients();
-  const response = await apiClient.get('/api/ingredients/');
-  return response.data;
+  if (!_ingredientsPromise) {
+    _ingredientsPromise = apiClient.get('/api/ingredients/')
+      .then(r => r.data)
+      .catch(err => { _ingredientsPromise = null; return Promise.reject(err); });
+  }
+  return _ingredientsPromise;
 }
 
 export async function fetchUnits() {
   if (USE_MOCK) return getMockUnits();
-  const response = await apiClient.get('/api/units/');
-  return response.data;
+  if (!_unitsPromise) {
+    _unitsPromise = apiClient.get('/api/units/')
+      .then(r => r.data)
+      .catch(err => { _unitsPromise = null; return Promise.reject(err); });
+  }
+  return _unitsPromise;
 }
 
 export async function submitIngredient(name) {

--- a/ops/ROLLBACK.md
+++ b/ops/ROLLBACK.md
@@ -1,0 +1,61 @@
+# Web Rollback Runbook
+
+The deploy pipeline (`.github/workflows/deploy-web.yml`) runs automatically on every push to `main`.
+This document covers how to roll back to a previous known-good state.
+
+---
+
+## Option A — Revert commit (recommended, CI re-runs)
+
+Push a revert commit to `main`. The CI pipeline re-deploys automatically.
+
+```bash
+# On your local machine
+git fetch origin
+git checkout main && git pull
+git revert <bad-commit-sha> --no-edit
+git push origin main
+```
+
+The workflow will build and deploy the reverted state. Monitor `.github/workflows/deploy-web.yml`
+in the Actions tab.
+
+---
+
+## Option B — SSH rollback (emergency, bypasses CI)
+
+Use this when the CI pipeline itself is broken or unavailable.
+
+```bash
+# SSH into the Vultr box
+ssh root@<server-ip>
+cd /root/bounswe2026group12
+
+# Reset to a known-good commit
+git fetch origin
+git reset --hard <good-commit-sha>
+
+# Rebuild only the web container (fastest path)
+docker compose -f docker-compose.yml -f docker-compose.prod.yml build web
+
+# Bring the web container back up without restarting backend or db
+docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --no-deps web
+
+# Smoke test
+curl -fsS https://genipe.app/ && echo "OK"
+```
+
+If the smoke test fails, check logs:
+```bash
+docker compose -f docker-compose.yml -f docker-compose.prod.yml logs --tail=50 web
+```
+
+---
+
+## Finding a good commit SHA
+
+```bash
+git log --oneline origin/main | head -20
+```
+
+Pick the last commit before the bad deploy. The SHA is the 7-character prefix on the left.


### PR DESCRIPTION
## Summary
- #356: Cache ingredient and unit API responses at module level so dropdowns fill in < 1 s after the first load
- #364: Add localStorage auto-save with 1.5 s debounce and draft restore banner to RecipeCreate, RecipeEdit, StoryCreate, StoryEdit
- #367: Add ops/ROLLBACK.md documenting revert-commit and SSH rollback paths for the web service

## Test plan
- [ ] \`npm test\` passes in \`app/frontend\`
- [ ] Open Recipe Create — fill title — close tab — reopen — banner appears — Restore fills the title back
- [ ] Open Recipe Edit — edit title — navigate away — return — banner appears
- [ ] Same for Story Create and Story Edit
- [ ] On Recipe Create, open ingredient dropdown twice in one session — only one network request visible in DevTools
- [ ] Smoke test \`https://genipe.app/\` after merge