### PR TITLE
feat(mobile): swap client-side unit conversion to backend /convert API (#408)

### DIFF
--- a/app/mobile/src/navigation/PublicStackNavigator.tsx
+++ b/app/mobile/src/navigation/PublicStackNavigator.tsx
@@ -100,6 +100,8 @@ export function PublicStackNavigator() {
         name="MapDiscovery"
         component={MapDiscoveryScreen}
         options={{ title: 'Discover by region' }}
+      />
+      <Stack.Screen
         name="Explore"
         component={ExploreScreen}
         options={{ title: 'Explore' }}

--- a/app/mobile/src/screens/HomeScreen.tsx
+++ b/app/mobile/src/screens/HomeScreen.tsx
@@ -104,6 +104,9 @@ export default function HomeScreen({ navigation }: Props) {
             <Text style={styles.mapSubtitle}>Tap a pin on the map to focus a region</Text>
           </View>
           <Text style={styles.mapArrow}>→</Text>
+        </Pressable>
+
+        <Pressable
           onPress={() => navigation.navigate('Explore')}
           style={({ pressed }) => [styles.exploreEntry, pressed && styles.exploreEntryPressed]}
           accessibilityRole="button"
@@ -291,7 +294,6 @@ const styles = StyleSheet.create({
   },
   searchWrap: { marginBottom: 14 },
   mapEntry: {
-  exploreEntry: {
     flexDirection: 'row',
     alignItems: 'center',
     gap: 12,
@@ -299,6 +301,18 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     borderRadius: tokens.radius.xl,
     backgroundColor: tokens.colors.bg,
+    borderWidth: 2,
+    borderColor: tokens.colors.surfaceDark,
+    marginBottom: 14,
+    ...shadows.md,
+  },
+  exploreEntry: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    paddingVertical: 14,
+    paddingHorizontal: 16,
+    borderRadius: tokens.radius.xl,
     backgroundColor: tokens.colors.accentGreen,
     borderWidth: 2,
     borderColor: tokens.colors.surfaceDark,

--- a/app/mobile/src/screens/RecipeDetailScreen.tsx
+++ b/app/mobile/src/screens/RecipeDetailScreen.tsx
@@ -12,9 +12,10 @@ import { RecipeCommentsSection } from '../components/recipe/RecipeCommentsSectio
 import type { RootStackParamList } from '../navigation/types';
 import { fetchRecipeById } from '../services/recipeService';
 import { fetchStoriesForRecipe, type StoryListItem } from '../services/storyService';
+import { fetchConversion } from '../services/unitConversionService';
 import type { RecipeDetail } from '../types/recipe';
 import { isRecipeAuthor } from '../utils/recipeAuthor';
-import { convertIngredient } from '../utils/unitConversion';
+import { targetUnitFor, type ConvertedAmount } from '../utils/unitConversion';
 import { shadows, tokens } from '../theme';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'RecipeDetail'>;
@@ -29,6 +30,8 @@ export default function RecipeDetailScreen({ route, navigation }: Props) {
   const [showConverted, setShowConverted] = useState(false);
   const [linkedStories, setLinkedStories] = useState<StoryListItem[]>([]);
   const [substituteTarget, setSubstituteTarget] = useState<{ id: number; name: string } | null>(null);
+  const [convertedByLine, setConvertedByLine] = useState<Record<string, ConvertedAmount>>({});
+  const [convertingLoading, setConvertingLoading] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -65,6 +68,45 @@ export default function RecipeDetailScreen({ route, navigation }: Props) {
       cancelled = true;
     };
   }, [id, reloadToken]);
+
+  useEffect(() => {
+    if (!showConverted || !recipe) return;
+    const ingredients = recipe.ingredients ?? [];
+    const targets = ingredients
+      .map((ri, idx) => {
+        const lineKey = ri.lineId != null ? `line-${ri.lineId}` : `idx-${idx}-${ri.ingredient.id}`;
+        const toUnit = targetUnitFor(ri.unit.name);
+        if (!toUnit) return null;
+        return { lineKey, amount: ri.amount, fromUnit: ri.unit.name, toUnit, ingredientId: ri.ingredient.id };
+      })
+      .filter((t): t is NonNullable<typeof t> => t !== null);
+
+    const missing = targets.filter((t) => convertedByLine[t.lineKey] === undefined);
+    if (missing.length === 0) return;
+
+    let cancelled = false;
+    setConvertingLoading(true);
+    Promise.allSettled(
+      missing.map((t) => fetchConversion(t.amount, t.fromUnit, t.toUnit, t.ingredientId)),
+    )
+      .then((results) => {
+        if (cancelled) return;
+        const next: Record<string, ConvertedAmount> = {};
+        results.forEach((r, i) => {
+          if (r.status === 'fulfilled') next[missing[i].lineKey] = r.value;
+        });
+        if (Object.keys(next).length > 0) {
+          setConvertedByLine((prev) => ({ ...prev, ...next }));
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setConvertingLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [showConverted, recipe, convertedByLine]);
 
   if (loading) {
     return (
@@ -192,7 +234,7 @@ export default function RecipeDetailScreen({ route, navigation }: Props) {
                   accessibilityLabel="Show converted units"
                 >
                   <Text style={[styles.unitToggleText, showConverted && styles.unitToggleTextActive]}>
-                    Converted
+                    {convertingLoading ? 'Converting…' : 'Converted'}
                   </Text>
                 </Pressable>
               </View>
@@ -203,9 +245,9 @@ export default function RecipeDetailScreen({ route, navigation }: Props) {
           ) : (
             <View style={styles.list}>
               {ingredients.map((ri, index) => {
-                const converted = showConverted
-                  ? convertIngredient(ri.amount, ri.unit.name)
-                  : null;
+                const lineKey =
+                  ri.lineId != null ? `line-${ri.lineId}` : `idx-${index}-${ri.ingredient.id}`;
+                const converted = showConverted ? convertedByLine[lineKey] : undefined;
                 const displayAmount = converted ? converted.amount : String(ri.amount);
                 const displayUnit = converted ? converted.unit : ri.unit.name;
                 return (

--- a/app/mobile/src/services/unitConversionService.ts
+++ b/app/mobile/src/services/unitConversionService.ts
@@ -1,0 +1,51 @@
+import { apiPostJson } from './httpClient';
+
+export type ConvertedAmount = { amount: string; unit: string };
+
+type RawResponse = {
+  amount: string;
+  from_unit: string;
+  to_unit: string;
+  ingredient_id: number | null;
+};
+
+/**
+ * Module-level cache keyed by `amount|fromUnit|toUnit|ingredientId`. Survives
+ * the lifetime of the JS engine so toggling the unit panel back and forth
+ * doesn't re-hit the API.
+ */
+const cache = new Map<string, ConvertedAmount>();
+
+function cacheKey(
+  amount: string | number,
+  fromUnit: string,
+  toUnit: string,
+  ingredientId: number | undefined,
+): string {
+  return `${String(amount)}|${fromUnit}|${toUnit}|${ingredientId ?? ''}`;
+}
+
+export async function fetchConversion(
+  amount: string | number,
+  fromUnit: string,
+  toUnit: string,
+  ingredientId?: number,
+): Promise<ConvertedAmount> {
+  const key = cacheKey(amount, fromUnit, toUnit, ingredientId);
+  const cached = cache.get(key);
+  if (cached) return cached;
+
+  const body: Record<string, unknown> = {
+    amount: String(amount),
+    from_unit: fromUnit,
+    to_unit: toUnit,
+  };
+  if (ingredientId !== undefined && ingredientId !== null) {
+    body.ingredient_id = ingredientId;
+  }
+
+  const res = await apiPostJson<RawResponse>('/api/convert/', body);
+  const result: ConvertedAmount = { amount: res.amount, unit: res.to_unit };
+  cache.set(key, result);
+  return result;
+}

--- a/app/mobile/src/utils/unitConversion.ts
+++ b/app/mobile/src/utils/unitConversion.ts
@@ -1,31 +1,20 @@
-type ConversionPair = { to: string; factor: number };
-
-const CONVERSIONS: Record<string, ConversionPair> = {
-  grams: { to: 'oz', factor: 0.035274 },
-  kg: { to: 'lb', factor: 2.20462 },
-  ml: { to: 'fl oz', factor: 0.033814 },
-  liters: { to: 'qt', factor: 1.05669 },
-  cups: { to: 'ml', factor: 236.588 },
-  tablespoons: { to: 'ml', factor: 14.787 },
-  teaspoons: { to: 'ml', factor: 4.929 },
+/**
+ * Mapping from a source unit name to the target unit the recipe-detail
+ * "Converted" toggle displays. The actual math goes through the backend
+ * `/api/convert/` API (`services/unitConversionService.ts`).
+ */
+const TARGET_UNITS: Record<string, string> = {
+  grams: 'oz',
+  kg: 'lb',
+  ml: 'fl oz',
+  liters: 'qt',
+  cups: 'ml',
+  tablespoons: 'ml',
+  teaspoons: 'ml',
 };
 
 export type ConvertedAmount = { amount: string; unit: string };
 
-export function convertIngredient(
-  amount: string | number,
-  unitName: string,
-): ConvertedAmount | null {
-  const pair = CONVERSIONS[unitName];
-  if (!pair) return null;
-  const numeric = typeof amount === 'number' ? amount : parseFloat(amount);
-  if (Number.isNaN(numeric)) return null;
-  const converted = numeric * pair.factor;
-  return { amount: formatAmount(converted), unit: pair.to };
-}
-
-function formatAmount(n: number): string {
-  if (n >= 100) return n.toFixed(0);
-  if (n >= 10) return n.toFixed(1);
-  return n.toFixed(2);
+export function targetUnitFor(unitName: string): string | null {
+  return TARGET_UNITS[unitName] ?? null;
 }


### PR DESCRIPTION
## Summary
Closes #408. Replaces the local hardcoded factor table in `unitConversion.ts` with calls to `POST /api/convert/`. The recipe detail "Converted" toggle now shows server-computed values, with an in-memory cache so toggling back and forth doesn't re-hit the API.

## Files
- `services/unitConversionService.ts` — `fetchConversion(amount, fromUnit, toUnit, ingredientId?)` with module-level cache keyed by the input tuple
- `utils/unitConversion.ts` — kept the source-to-target unit mapping (`targetUnitFor`); removed the math
- `screens/RecipeDetailScreen.tsx` — `useEffect` batches a request per ingredient when the user flips to "Converted"; shows "Converting…" while in flight; falls back to the original amount on network failure
- `screens/HomeScreen.tsx` + `navigation/PublicStackNavigator.tsx` — small fixes for merge resolution leftovers picked up while on this branch

## Test
- `npx tsc --noEmit` clean
- Local docker stack: logged in as `ayse@example.com`, opened Greek Dolmadakia. Toggling "Converted" replaces 200 grams Rice with `7.0548 oz` and 80 ml Olive Oil with `2.6667 fl oz`. Toggling again is instant (cache hit). Pieces / bunch / pinch ingredients keep their original display because no target unit is mapped — that's the intended scope.

## Notes
- Anonymous users see the original values without conversion because `POST /api/convert/` returns 401 anon despite the view declaring `AllowAny`. Tracked in #503 (backend). Mobile is unblocked since logged-in users always send a JWT.
- Pieces/bunch/pinch and other counted units have no target unit by design — they pass through.

Closes #408