### PR TITLE
fix(mobile): make Reply action visible on Q&A panel (#541)

### DIFF
--- a/app/mobile/src/components/recipe/RecipeCommentsSection.tsx
+++ b/app/mobile/src/components/recipe/RecipeCommentsSection.tsx
@@ -455,7 +455,12 @@ const styles = StyleSheet.create({
   helpfulTextActive: { color: '#FAF7EF' },
   helpfulCount: { fontSize: 13, fontWeight: '700', color: tokens.colors.surfaceDark },
   actions: { flexDirection: 'row', gap: 16, marginTop: 4 },
-  actionText: { fontSize: 13, fontWeight: '800', color: tokens.colors.primary },
+  actionText: {
+    fontSize: 13,
+    fontWeight: '800',
+    color: tokens.colors.text,
+    textDecorationLine: 'underline',
+  },
   destructive: { color: '#991b1b' },
   repliesWrap: { marginTop: 10, marginLeft: 16, gap: 10 },
 });


### PR DESCRIPTION
## Summary
Closes #541. The Reply action on the recipe Q&A panel was invisible — the text used `tokens.colors.primary` (orange) on a `surface` (orange) card after the palette swap. Same regression family as #493 / #538.

## Files
- `components/recipe/RecipeCommentsSection.tsx` — `actionText` now uses `tokens.colors.text` with an underline so it reads as a link on any palette.

## Test
- `npx tsc --noEmit` clean
- Local docker stack: opened a recipe with comments, the "Reply" action is now readable (dark text, underlined). Delete on own comments still shows in dark red. No regression on Post button or Q&A type toggle.

Closes #541