### PR TITLE
feat(frontend): homepage culture discovery redesign

### DIFF
--- a/app/frontend/src/__tests__/DailyCulturalSection.test.jsx
+++ b/app/frontend/src/__tests__/DailyCulturalSection.test.jsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import DailyCulturalSection from '../components/DailyCulturalSection';
+
+const wrap = (ui) => render(<MemoryRouter>{ui}</MemoryRouter>);
+
+const ITEMS = [
+  { id: '1', kind: 'tradition', title: 'Coffee Reading', body: 'Grounds are read.', region: 'Marmara' },
+  { id: '2', kind: 'dish',      title: 'Mansaf',         body: 'Slow-cooked lamb.', region: 'Levantine' },
+  { id: '3', kind: 'fact',      title: 'Six Tastes',     body: 'Ayurvedic.',        region: 'Indian' },
+  { id: '4', kind: 'holiday',   title: 'Asure Day',      body: 'Shared bowl.',      region: 'Anatolian' },
+  { id: '5', kind: 'unknown',   title: 'Mystery',        body: 'No kind match.',    region: null },
+];
+
+test('renders tradition card with candle emoji and amber class', () => {
+  wrap(<DailyCulturalSection items={[ITEMS[0]]} />);
+  expect(screen.getByText('🕯️')).toBeInTheDocument();
+  expect(document.querySelector('.card-tradition')).toBeInTheDocument();
+});
+
+test('renders dish card with fork emoji and terracotta class', () => {
+  wrap(<DailyCulturalSection items={[ITEMS[1]]} />);
+  expect(screen.getByText('🍽️')).toBeInTheDocument();
+  expect(document.querySelector('.card-dish')).toBeInTheDocument();
+});
+
+test('renders fact card with leaf emoji and blue class', () => {
+  wrap(<DailyCulturalSection items={[ITEMS[2]]} />);
+  expect(screen.getByText('🌿')).toBeInTheDocument();
+  expect(document.querySelector('.card-fact')).toBeInTheDocument();
+});
+
+test('renders holiday card with party emoji and green class', () => {
+  wrap(<DailyCulturalSection items={[ITEMS[3]]} />);
+  expect(screen.getByText('🎉')).toBeInTheDocument();
+  expect(document.querySelector('.card-holiday')).toBeInTheDocument();
+});
+
+test('unknown kind falls back to globe emoji and default class', () => {
+  wrap(<DailyCulturalSection items={[ITEMS[4]]} />);
+  expect(screen.getByText('🌍')).toBeInTheDocument();
+  expect(document.querySelector('.card-default')).toBeInTheDocument();
+});
+
+test('Read more link points to search with item title', () => {
+  wrap(<DailyCulturalSection items={[ITEMS[0]]} />);
+  const link = screen.getByText('Read more →');
+  expect(link).toHaveAttribute('href', expect.stringContaining('Coffee+Reading'));
+});
+
+test('renders nothing when items is empty', () => {
+  const { container } = wrap(<DailyCulturalSection items={[]} />);
+  expect(container.firstChild).toBeNull();
+});

--- a/app/frontend/src/__tests__/FloatingCulturalPrompt.test.jsx
+++ b/app/frontend/src/__tests__/FloatingCulturalPrompt.test.jsx
@@ -117,3 +117,13 @@ test('modal close button closes modal', async () => {
   fireEvent.click(screen.getByLabelText('Close'));
   expect(document.querySelector('.story-modal')).not.toBeInTheDocument();
 });
+
+test('prompt does not appear when sessionStorage flag is already set', () => {
+  sessionStorage.setItem('cultural_prompt_shown', '1');
+  wrap(<FloatingCulturalPrompt regions={REGIONS} />);
+  act(() => {
+    Object.defineProperty(window, 'scrollY', { value: 350, configurable: true });
+    fireEvent.scroll(window);
+  });
+  expect(document.querySelector('.floating-prompt')).not.toBeInTheDocument();
+});

--- a/app/frontend/src/__tests__/FloatingCulturalPrompt.test.jsx
+++ b/app/frontend/src/__tests__/FloatingCulturalPrompt.test.jsx
@@ -1,0 +1,56 @@
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import FloatingCulturalPrompt from '../components/FloatingCulturalPrompt';
+
+const REGIONS = [
+  { id: 1, name: 'Aegean' },
+  { id: 3, name: 'Black Sea' },
+];
+
+beforeEach(() => sessionStorage.clear());
+
+const wrap = (ui) => render(<MemoryRouter>{ui}</MemoryRouter>);
+
+test('prompt is not visible before scroll', () => {
+  wrap(<FloatingCulturalPrompt regions={REGIONS} />);
+  expect(document.querySelector('.floating-prompt')).not.toBeInTheDocument();
+});
+
+test('prompt appears after scrollY > 300', () => {
+  wrap(<FloatingCulturalPrompt regions={REGIONS} />);
+  act(() => {
+    Object.defineProperty(window, 'scrollY', { value: 350, configurable: true });
+    fireEvent.scroll(window);
+  });
+  expect(document.querySelector('.floating-prompt')).toBeInTheDocument();
+});
+
+test('dismiss button hides prompt and sets sessionStorage', () => {
+  wrap(<FloatingCulturalPrompt regions={REGIONS} />);
+  act(() => {
+    Object.defineProperty(window, 'scrollY', { value: 350, configurable: true });
+    fireEvent.scroll(window);
+  });
+  fireEvent.click(screen.getByLabelText('Dismiss'));
+  expect(document.querySelector('.floating-prompt')).not.toBeInTheDocument();
+  expect(sessionStorage.getItem('cultural_prompt_shown')).toBe('1');
+});
+
+test('region chips are rendered in the balloon', () => {
+  wrap(<FloatingCulturalPrompt regions={REGIONS} />);
+  act(() => {
+    Object.defineProperty(window, 'scrollY', { value: 350, configurable: true });
+    fireEvent.scroll(window);
+  });
+  expect(screen.getByText('Aegean')).toBeInTheDocument();
+  expect(screen.getByText('Black Sea')).toBeInTheDocument();
+});
+
+test('does not render when regions list is empty', () => {
+  wrap(<FloatingCulturalPrompt regions={[]} />);
+  act(() => {
+    Object.defineProperty(window, 'scrollY', { value: 350, configurable: true });
+    fireEvent.scroll(window);
+  });
+  expect(document.querySelector('.floating-prompt')).not.toBeInTheDocument();
+});

--- a/app/frontend/src/__tests__/FloatingCulturalPrompt.test.jsx
+++ b/app/frontend/src/__tests__/FloatingCulturalPrompt.test.jsx
@@ -1,13 +1,21 @@
-import { render, screen, fireEvent, act } from '@testing-library/react';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import FloatingCulturalPrompt from '../components/FloatingCulturalPrompt';
+import * as mapService from '../services/mapService';
+
+jest.mock('../services/mapService');
 
 const REGIONS = [
   { id: 1, name: 'Aegean' },
   { id: 3, name: 'Black Sea' },
 ];
 
-beforeEach(() => sessionStorage.clear());
+beforeEach(() => {
+  sessionStorage.clear();
+  mapService.fetchMapRegionContent.mockResolvedValue([
+    { id: 10, content_type: 'story', title: 'Tea Ritual', body: 'Long long body text here', author_username: 'ali' },
+  ]);
+});
 
 const wrap = (ui) => render(<MemoryRouter>{ui}</MemoryRouter>);
 
@@ -53,4 +61,59 @@ test('does not render when regions list is empty', () => {
     fireEvent.scroll(window);
   });
   expect(document.querySelector('.floating-prompt')).not.toBeInTheDocument();
+});
+
+test('clicking a region chip opens the modal', async () => {
+  wrap(<FloatingCulturalPrompt regions={REGIONS} />);
+  act(() => {
+    Object.defineProperty(window, 'scrollY', { value: 350, configurable: true });
+    fireEvent.scroll(window);
+  });
+  fireEvent.click(screen.getByText('Aegean'));
+  expect(document.querySelector('.story-modal')).toBeInTheDocument();
+});
+
+test('modal shows region name as header', async () => {
+  wrap(<FloatingCulturalPrompt regions={REGIONS} />);
+  act(() => {
+    Object.defineProperty(window, 'scrollY', { value: 350, configurable: true });
+    fireEvent.scroll(window);
+  });
+  fireEvent.click(screen.getByText('Aegean'));
+  expect(screen.getByRole('heading', { level: 2, name: 'Aegean' })).toBeInTheDocument();
+});
+
+test('modal shows story card with Read story link', async () => {
+  wrap(<FloatingCulturalPrompt regions={REGIONS} />);
+  act(() => {
+    Object.defineProperty(window, 'scrollY', { value: 350, configurable: true });
+    fireEvent.scroll(window);
+  });
+  fireEvent.click(screen.getByText('Aegean'));
+  await waitFor(() => expect(screen.getByText('Tea Ritual')).toBeInTheDocument());
+  expect(screen.getByText('Read story →')).toBeInTheDocument();
+});
+
+test('clicking backdrop closes modal', async () => {
+  wrap(<FloatingCulturalPrompt regions={REGIONS} />);
+  act(() => {
+    Object.defineProperty(window, 'scrollY', { value: 350, configurable: true });
+    fireEvent.scroll(window);
+  });
+  fireEvent.click(screen.getByText('Aegean'));
+  expect(document.querySelector('.story-modal')).toBeInTheDocument();
+  fireEvent.click(document.querySelector('.story-modal-backdrop'));
+  expect(document.querySelector('.story-modal')).not.toBeInTheDocument();
+});
+
+test('modal close button closes modal', async () => {
+  wrap(<FloatingCulturalPrompt regions={REGIONS} />);
+  act(() => {
+    Object.defineProperty(window, 'scrollY', { value: 350, configurable: true });
+    fireEvent.scroll(window);
+  });
+  fireEvent.click(screen.getByText('Aegean'));
+  expect(document.querySelector('.story-modal')).toBeInTheDocument();
+  fireEvent.click(screen.getByLabelText('Close'));
+  expect(document.querySelector('.story-modal')).not.toBeInTheDocument();
 });

--- a/app/frontend/src/__tests__/HomePage.test.jsx
+++ b/app/frontend/src/__tests__/HomePage.test.jsx
@@ -45,39 +45,39 @@ describe('HomePage', () => {
     expect(screen.getByRole('button', { name: /search/i })).toBeInTheDocument();
   });
 
-  it('populates region dropdown from API', async () => {
+  it('populates region chips from API', async () => {
     renderPage();
     await waitFor(() => {
-      expect(screen.getByRole('option', { name: 'Aegean' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Aegean' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Mediterranean' })).toBeInTheDocument();
     });
   });
 
-  it('renders ingredient and meal type filter inputs', () => {
+  it('renders meal type chip buttons', () => {
     renderPage();
-    expect(screen.getByLabelText(/ingredient/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/meal type/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Breakfast' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Soup' })).toBeInTheDocument();
   });
 
-  it('navigates to /search with all params on submit', async () => {
+  it('navigates to /search with region and meal_type on submit', async () => {
     renderPage();
-    await waitFor(() => screen.getByRole('option', { name: 'Aegean' }));
+    await waitFor(() => screen.getByRole('button', { name: 'Aegean' }));
 
     fireEvent.change(screen.getByRole('searchbox'), { target: { value: 'baklava' } });
-    fireEvent.change(screen.getByLabelText(/region/i), { target: { value: 'Aegean' } });
-    fireEvent.change(screen.getByLabelText(/ingredient/i), { target: { value: 'yogurt' } });
-    fireEvent.change(screen.getByLabelText(/meal type/i), { target: { value: 'soup' } });
-    fireEvent.click(screen.getByRole('button', { name: /search/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'Aegean' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Soup' }));
+    fireEvent.click(screen.getByRole('button', { name: /^search$/i }));
 
     expect(mockNavigate).toHaveBeenCalledWith(
-      '/search?q=baklava&region=Aegean&ingredient=yogurt&meal_type=soup'
+      '/search?q=baklava&region=Aegean&meal_type=Soup'
     );
   });
 
   it('navigates with empty params when no input is given', () => {
     renderPage();
-    fireEvent.click(screen.getByRole('button', { name: /search/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^search$/i }));
     expect(mockNavigate).toHaveBeenCalledWith(
-      '/search?q=&region=&ingredient=&meal_type='
+      '/search?q=&region=&meal_type='
     );
   });
 

--- a/app/frontend/src/__tests__/culturalContentService.test.js
+++ b/app/frontend/src/__tests__/culturalContentService.test.js
@@ -22,7 +22,7 @@ describe('fetchDailyCulturalContent', () => {
     });
     const result = await fetchDailyCulturalContent();
     expect(result).toEqual([
-      { id: 1, title: 'Card', body: 'Body', imageUrl: '/img.jpg', tags: ['Aegean'] },
+      { id: 1, kind: null, title: 'Card', body: 'Body', region: null, imageUrl: '/img.jpg', tags: ['Aegean'] },
     ]);
   });
 });

--- a/app/frontend/src/components/DailyCulturalSection.css
+++ b/app/frontend/src/components/DailyCulturalSection.css
@@ -3,14 +3,23 @@
   text-align: left;
 }
 
+.daily-cultural-header {
+  margin-bottom: 1rem;
+}
+
 .daily-cultural-header h2 {
   margin: 0;
   font-size: 1.4rem;
 }
 
 .daily-cultural-header p {
-  margin: 0.35rem 0 1rem 0;
+  margin: 0.35rem 0 0;
   color: var(--color-text-muted);
+}
+
+@keyframes card-fade-in {
+  from { opacity: 0; transform: translateY(12px); }
+  to   { opacity: 1; transform: translateY(0); }
 }
 
 .daily-cultural-grid {
@@ -22,35 +31,87 @@
 .daily-cultural-card {
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
-  background: var(--color-surface);
-  padding: 0.85rem;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  animation: card-fade-in 0.4s cubic-bezier(0.22, 1, 0.36, 1) both;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.daily-cultural-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.10);
+}
+
+.card-fact      { background: #EEF6FB; }
+.card-tradition { background: #FEF5D9; }
+.card-holiday   { background: #EBF5EB; }
+.card-dish      { background: #FBE9E1; }
+.card-default   { background: var(--color-surface); }
+
+.card-top-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.card-emoji {
+  font-size: 1.75rem;
+  line-height: 1;
+}
+
+.card-badge {
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-text-muted);
+  background: rgba(0, 0, 0, 0.06);
+  border-radius: var(--radius-pill);
+  padding: 0.2rem 0.55rem;
 }
 
 .daily-cultural-card h3 {
   margin: 0;
-  font-size: 1rem;
+  font-size: 0.9375rem;
+  color: var(--color-text);
+  line-height: 1.35;
 }
 
-.daily-cultural-card p {
-  margin: 0.55rem 0 0 0;
-  font-size: 0.9rem;
+.card-body {
+  margin: 0;
+  font-size: 0.875rem;
   color: var(--color-text-muted);
+  line-height: 1.55;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
-.daily-cultural-tags {
-  margin-top: 0.65rem;
+.card-footer {
+  margin-top: auto;
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.4rem;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
 }
 
-.daily-cultural-tags span {
-  border: 1px solid var(--color-primary-border);
-  color: var(--color-primary-text);
-  background: var(--color-primary-tint);
-  border-radius: 999px;
-  padding: 0.15rem 0.55rem;
+.card-region {
   font-size: 0.75rem;
+  color: var(--color-primary);
   font-weight: 600;
 }
 
+.card-read-more {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--color-primary);
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.card-read-more:hover {
+  text-decoration: underline;
+}

--- a/app/frontend/src/components/DailyCulturalSection.jsx
+++ b/app/frontend/src/components/DailyCulturalSection.jsx
@@ -1,4 +1,13 @@
+import { Link } from 'react-router-dom';
 import './DailyCulturalSection.css';
+
+const KIND_CONFIG = {
+  fact:      { emoji: '🌿', colorClass: 'card-fact',      label: 'Fact' },
+  tradition: { emoji: '🕯️', colorClass: 'card-tradition', label: 'Tradition' },
+  holiday:   { emoji: '🎉', colorClass: 'card-holiday',   label: 'Holiday' },
+  dish:      { emoji: '🍽️', colorClass: 'card-dish',      label: 'Dish' },
+};
+const FALLBACK = { emoji: '🌍', colorClass: 'card-default', label: 'Culture' };
 
 export default function DailyCulturalSection({ items, personalized }) {
   if (!items || items.length === 0) return null;
@@ -15,19 +24,33 @@ export default function DailyCulturalSection({ items, personalized }) {
       </div>
 
       <div className="daily-cultural-grid">
-        {items.map((item) => (
-          <article key={item.id} className="daily-cultural-card">
-            <h3>{item.title}</h3>
-            {item.body && <p>{item.body}</p>}
-            {item.tags.length > 0 && (
-              <div className="daily-cultural-tags">
-                {item.tags.map((tag) => <span key={tag}>{tag}</span>)}
+        {items.map((item, index) => {
+          const config = KIND_CONFIG[item.kind] ?? FALLBACK;
+          return (
+            <article
+              key={item.id}
+              className={`daily-cultural-card ${config.colorClass}`}
+              style={{ animationDelay: `${index * 80}ms` }}
+            >
+              <div className="card-top-row">
+                <span className="card-emoji" aria-hidden="true">{config.emoji}</span>
+                <span className="card-badge">{config.label}</span>
               </div>
-            )}
-          </article>
-        ))}
+              <h3>{item.title}</h3>
+              {item.body && <p className="card-body">{item.body}</p>}
+              <div className="card-footer">
+                {item.region && <span className="card-region">{item.region}</span>}
+                <Link
+                  to={`/search?q=${encodeURIComponent(item.title).replace(/%20/g, '+')}`}
+                  className="card-read-more"
+                >
+                  Read more →
+                </Link>
+              </div>
+            </article>
+          );
+        })}
       </div>
     </section>
   );
 }
-

--- a/app/frontend/src/components/FloatingCulturalPrompt.css
+++ b/app/frontend/src/components/FloatingCulturalPrompt.css
@@ -13,7 +13,7 @@
   border-radius: var(--radius-xl);
   padding: 1.25rem 1.5rem;
   max-width: 320px;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+  box-shadow: var(--shadow-md);
   animation: prompt-slide-up 0.4s cubic-bezier(0.22, 1, 0.36, 1) both;
 }
 
@@ -59,7 +59,7 @@
 
 .floating-prompt-chip:hover {
   background: var(--color-primary);
-  color: #fff;
+  color: var(--color-surface);
 }
 
 /* ── Modal ─────────────────────────── */
@@ -82,7 +82,7 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.18);
+  box-shadow: var(--shadow-lg);
 }
 
 .story-modal-header {
@@ -172,4 +172,20 @@
   font-size: 0.8125rem;
   font-weight: 600;
   color: var(--color-primary);
+}
+
+/* Fix 5: subtitle below region name */
+.story-modal-subtitle {
+  margin: 0.25rem 0 0;
+  font-size: 0.9rem;
+  color: var(--color-text-muted);
+}
+
+/* Fix 9: focus-visible styles for interactive elements */
+.floating-prompt-chip:focus-visible,
+.floating-prompt-close:focus-visible,
+.story-modal-close:focus-visible,
+.story-modal-card:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
 }

--- a/app/frontend/src/components/FloatingCulturalPrompt.css
+++ b/app/frontend/src/components/FloatingCulturalPrompt.css
@@ -1,0 +1,164 @@
+@keyframes prompt-slide-up {
+  from { opacity: 0; transform: translateY(20px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.floating-prompt {
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  z-index: 100;
+  background: var(--color-surface);
+  border: 2px solid var(--color-border);
+  border-radius: var(--radius-xl);
+  padding: 1.25rem 1.5rem;
+  max-width: 320px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+  animation: prompt-slide-up 0.4s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.floating-prompt-close {
+  position: absolute;
+  top: 0.6rem;
+  right: 0.75rem;
+  background: none;
+  border: none;
+  font-size: 1.25rem;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  line-height: 1;
+  padding: 0;
+}
+
+.floating-prompt-close:hover { color: var(--color-text); }
+
+.floating-prompt-question {
+  font-weight: 700;
+  font-size: 1rem;
+  color: var(--color-text);
+  margin: 0 1.5rem 0.9rem 0;
+}
+
+.floating-prompt-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.floating-prompt-chip {
+  background: var(--color-primary-subtle);
+  border: 1.5px solid var(--color-primary-border);
+  border-radius: var(--radius-pill);
+  padding: 0.3rem 0.75rem;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--color-primary);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+
+.floating-prompt-chip:hover {
+  background: var(--color-primary);
+  color: #fff;
+}
+
+/* ── Modal ─────────────────────────── */
+.story-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  z-index: 200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+}
+
+.story-modal {
+  background: var(--color-surface);
+  border-radius: var(--radius-xl);
+  width: 100%;
+  max-width: 560px;
+  max-height: calc(100vh - 3rem);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.18);
+}
+
+.story-modal-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1.5rem 1.5rem 1rem;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.story-modal-header h2 {
+  margin: 0;
+  font-size: 1.125rem;
+  color: var(--color-text);
+  line-height: 1.4;
+}
+
+.story-modal-close {
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  flex-shrink: 0;
+  line-height: 1;
+  padding: 0;
+}
+
+.story-modal-close:hover { color: var(--color-text); }
+
+.story-modal-body {
+  overflow-y: auto;
+  padding: 1rem 1.5rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.story-modal-status {
+  color: var(--color-text-muted);
+  text-align: center;
+  padding: 2rem 0;
+}
+
+.story-modal-card {
+  display: block;
+  padding: 1rem;
+  border: 1.5px solid var(--color-border);
+  border-radius: var(--radius-md);
+  text-decoration: none;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.story-modal-card:hover {
+  border-color: var(--color-primary);
+  background: var(--color-primary-subtle);
+  text-decoration: none;
+}
+
+.story-modal-card h3 {
+  margin: 0 0 0.4rem;
+  font-size: 0.9375rem;
+  color: var(--color-text);
+}
+
+.story-modal-excerpt {
+  margin: 0 0 0.5rem;
+  font-size: 0.875rem;
+  color: var(--color-text-muted);
+  line-height: 1.5;
+}
+
+.story-modal-author {
+  font-size: 0.8125rem;
+  color: var(--color-primary);
+  font-weight: 600;
+}

--- a/app/frontend/src/components/FloatingCulturalPrompt.css
+++ b/app/frontend/src/components/FloatingCulturalPrompt.css
@@ -77,8 +77,7 @@
 .story-modal {
   background: var(--color-surface);
   border-radius: var(--radius-xl);
-  width: 100%;
-  max-width: 560px;
+  width: min(90vw, 560px);
   max-height: calc(100vh - 3rem);
   display: flex;
   flex-direction: column;
@@ -155,10 +154,22 @@
   font-size: 0.875rem;
   color: var(--color-text-muted);
   line-height: 1.5;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
 .story-modal-author {
   font-size: 0.8125rem;
   color: var(--color-primary);
   font-weight: 600;
+}
+
+.story-modal-read-more {
+  display: block;
+  margin-top: 0.5rem;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--color-primary);
 }

--- a/app/frontend/src/components/FloatingCulturalPrompt.jsx
+++ b/app/frontend/src/components/FloatingCulturalPrompt.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { Link } from 'react-router-dom';
 import { fetchMapRegionContent } from '../services/mapService';
 import './FloatingCulturalPrompt.css';
@@ -25,7 +25,19 @@ export default function FloatingCulturalPrompt({ regions }) {
   const [selectedRegion, setSelectedRegion] = useState(null);
   const [stories, setStories] = useState([]);
   const [storiesLoading, setStoriesLoading] = useState(false);
+  const [storiesError, setStoriesError] = useState(false);
   const [modalOpen, setModalOpen] = useState(false);
+
+  // Fix 2: ref for modal close button (focus on open)
+  const modalCloseRef = useRef(null);
+  // Fix 4: ref for modal container (focus trap)
+  const modalRef = useRef(null);
+  // Fix 7: prevent setState after unmount
+  const isMountedRef = useRef(true);
+
+  useEffect(() => {
+    return () => { isMountedRef.current = false; };
+  }, []);
 
   useEffect(() => {
     if (sessionStorage.getItem('cultural_prompt_shown')) return;
@@ -40,13 +52,67 @@ export default function FloatingCulturalPrompt({ regions }) {
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);
 
+  // Fix 2: move focus to close button when modal opens
+  useEffect(() => {
+    if (modalOpen && modalCloseRef.current) {
+      modalCloseRef.current.focus();
+    }
+  }, [modalOpen]);
+
+  // Fix 3: close modal on Escape key
+  useEffect(() => {
+    if (!modalOpen) return;
+    function handleKey(e) {
+      if (e.key === 'Escape') closeModal();
+    }
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [modalOpen]);
+
+  // Fix 4: focus trap inside modal
+  useEffect(() => {
+    if (!modalOpen || !modalRef.current) return;
+
+    const modal = modalRef.current;
+    const focusable = modal.querySelectorAll(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    );
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+
+    function handleTab(e) {
+      if (e.key !== 'Tab') return;
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    }
+
+    modal.addEventListener('keydown', handleTab);
+    return () => modal.removeEventListener('keydown', handleTab);
+  }, [modalOpen, stories, storiesLoading]);
+
+  // Fix 6 & 7: error handling + isMounted guard
   function handleRegionSelect(region) {
     setSelectedRegion(region);
     setModalOpen(true);
     setStoriesLoading(true);
+    setStoriesError(false);
     fetchMapRegionContent(region.id)
-      .then((items) => setStories(items.filter((i) => i.content_type === 'story')))
-      .finally(() => setStoriesLoading(false));
+      .then((items) => {
+        if (isMountedRef.current) {
+          setStories(items.filter((i) => i.content_type === 'story'));
+        }
+      })
+      .catch(() => { if (isMountedRef.current) setStoriesError(true); })
+      .finally(() => { if (isMountedRef.current) setStoriesLoading(false); });
   }
 
   function handleDismiss() {
@@ -80,22 +146,35 @@ export default function FloatingCulturalPrompt({ regions }) {
 
       {modalOpen && (
         <div className="story-modal-backdrop" onClick={closeModal}>
+          {/* Fix 1: aria-labelledby; Fix 4: ref */}
           <div
+            ref={modalRef}
             className="story-modal"
             role="dialog"
             aria-modal="true"
+            aria-labelledby="story-modal-title"
             onClick={(e) => e.stopPropagation()}
           >
             <div className="story-modal-header">
-              <h2>{selectedRegion?.name}</h2>
-              <button className="story-modal-close" onClick={closeModal} aria-label="Close">×</button>
+              {/* Fix 1: id on h2 */}
+              <h2 id="story-modal-title">{selectedRegion?.name}</h2>
+              {/* Fix 2: ref on close button */}
+              <button ref={modalCloseRef} className="story-modal-close" onClick={closeModal} aria-label="Close">×</button>
             </div>
+            {/* Fix 5: response subtitle */}
+            {selectedRegion && (
+              <p className="story-modal-subtitle">{prompt.response(selectedRegion.name)}</p>
+            )}
             <div className="story-modal-body">
               {storiesLoading && <p className="story-modal-status">Loading…</p>}
-              {!storiesLoading && stories.length === 0 && (
+              {/* Fix 6: error state */}
+              {!storiesLoading && storiesError && (
+                <p className="story-modal-status">Hikayeler yüklenemedi. Lütfen tekrar deneyin.</p>
+              )}
+              {!storiesLoading && !storiesError && stories.length === 0 && (
                 <p className="story-modal-status">No stories for this region yet.</p>
               )}
-              {!storiesLoading && stories.map((story) => (
+              {!storiesLoading && !storiesError && stories.map((story) => (
                 <Link
                   key={story.id}
                   to={`/stories/${story.id}`}

--- a/app/frontend/src/components/FloatingCulturalPrompt.jsx
+++ b/app/frontend/src/components/FloatingCulturalPrompt.jsx
@@ -6,7 +6,7 @@ import './FloatingCulturalPrompt.css';
 const PROMPTS = [
   {
     question: 'Nerelisin?',
-    response: (name) => `Hadi ${name}'e ufak bir yolculuğa çıkalım 🏡`,
+    response: () => 'Hadi evine ufak bir yolculuğa çıkalım 🏡',
   },
   {
     question: 'Sıradaki seyahatin nereye?',
@@ -87,7 +87,7 @@ export default function FloatingCulturalPrompt({ regions }) {
             onClick={(e) => e.stopPropagation()}
           >
             <div className="story-modal-header">
-              <h2>{selectedRegion && prompt.response(selectedRegion.name)}</h2>
+              <h2>{selectedRegion?.name}</h2>
               <button className="story-modal-close" onClick={closeModal} aria-label="Close">×</button>
             </div>
             <div className="story-modal-body">
@@ -103,8 +103,9 @@ export default function FloatingCulturalPrompt({ regions }) {
                   onClick={closeModal}
                 >
                   <h3>{story.title}</h3>
-                  <p className="story-modal-excerpt">{story.body?.slice(0, 120)}…</p>
+                  <p className="story-modal-excerpt">{story.body}</p>
                   <span className="story-modal-author">@{story.author_username}</span>
+                  <span className="story-modal-read-more">Read story →</span>
                 </Link>
               ))}
             </div>

--- a/app/frontend/src/components/FloatingCulturalPrompt.jsx
+++ b/app/frontend/src/components/FloatingCulturalPrompt.jsx
@@ -1,0 +1,116 @@
+import { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import { fetchMapRegionContent } from '../services/mapService';
+import './FloatingCulturalPrompt.css';
+
+const PROMPTS = [
+  {
+    question: 'Nerelisin?',
+    response: (name) => `Hadi ${name}'e ufak bir yolculuğa çıkalım 🏡`,
+  },
+  {
+    question: 'Sıradaki seyahatin nereye?',
+    response: (name) => `${name} mutfağını keşfedelim 🗺️`,
+  },
+  {
+    question: 'Bu hafta neyi tatmak isterdin?',
+    response: (name) => `${name}'den hikayeler seni bekliyor ✨`,
+  },
+];
+
+export default function FloatingCulturalPrompt({ regions }) {
+  const [visible, setVisible] = useState(false);
+  const [dismissed, setDismissed] = useState(false);
+  const [prompt] = useState(() => PROMPTS[Math.floor(Math.random() * PROMPTS.length)]);
+  const [selectedRegion, setSelectedRegion] = useState(null);
+  const [stories, setStories] = useState([]);
+  const [storiesLoading, setStoriesLoading] = useState(false);
+  const [modalOpen, setModalOpen] = useState(false);
+
+  useEffect(() => {
+    if (sessionStorage.getItem('cultural_prompt_shown')) return;
+
+    function handleScroll() {
+      if (window.scrollY > 300) {
+        setVisible(true);
+        window.removeEventListener('scroll', handleScroll);
+      }
+    }
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
+
+  function handleRegionSelect(region) {
+    setSelectedRegion(region);
+    setModalOpen(true);
+    setStoriesLoading(true);
+    fetchMapRegionContent(region.id)
+      .then((items) => setStories(items.filter((i) => i.content_type === 'story')))
+      .finally(() => setStoriesLoading(false));
+  }
+
+  function handleDismiss() {
+    setDismissed(true);
+    sessionStorage.setItem('cultural_prompt_shown', '1');
+  }
+
+  function closeModal() {
+    setModalOpen(false);
+  }
+
+  if (!visible || dismissed || regions.length === 0) return null;
+
+  return (
+    <>
+      <div className="floating-prompt" role="complementary" aria-label="Cultural discovery prompt">
+        <button className="floating-prompt-close" onClick={handleDismiss} aria-label="Dismiss">×</button>
+        <p className="floating-prompt-question">{prompt.question}</p>
+        <div className="floating-prompt-chips">
+          {regions.map((r) => (
+            <button
+              key={r.id}
+              className="floating-prompt-chip"
+              onClick={() => handleRegionSelect(r)}
+            >
+              {r.name}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {modalOpen && (
+        <div className="story-modal-backdrop" onClick={closeModal}>
+          <div
+            className="story-modal"
+            role="dialog"
+            aria-modal="true"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="story-modal-header">
+              <h2>{selectedRegion && prompt.response(selectedRegion.name)}</h2>
+              <button className="story-modal-close" onClick={closeModal} aria-label="Close">×</button>
+            </div>
+            <div className="story-modal-body">
+              {storiesLoading && <p className="story-modal-status">Loading…</p>}
+              {!storiesLoading && stories.length === 0 && (
+                <p className="story-modal-status">No stories for this region yet.</p>
+              )}
+              {!storiesLoading && stories.map((story) => (
+                <Link
+                  key={story.id}
+                  to={`/stories/${story.id}`}
+                  className="story-modal-card"
+                  onClick={closeModal}
+                >
+                  <h3>{story.title}</h3>
+                  <p className="story-modal-excerpt">{story.body?.slice(0, 120)}…</p>
+                  <span className="story-modal-author">@{story.author_username}</span>
+                </Link>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/app/frontend/src/components/FloatingCulturalPrompt.jsx
+++ b/app/frontend/src/components/FloatingCulturalPrompt.jsx
@@ -5,16 +5,16 @@ import './FloatingCulturalPrompt.css';
 
 const PROMPTS = [
   {
-    question: 'Nerelisin?',
-    response: () => 'Hadi evine ufak bir yolculuğa çıkalım 🏡',
+    question: 'Where are you from? 🏡',
+    response: () => 'Let\'s take a little trip home',
   },
   {
-    question: 'Sıradaki seyahatin nereye?',
-    response: (name) => `${name} mutfağını keşfedelim 🗺️`,
+    question: 'Where is your next destination? 🗺️',
+    response: (name) => `Explore the cuisine of ${name}`,
   },
   {
-    question: 'Bu hafta neyi tatmak isterdin?',
-    response: (name) => `${name}'den hikayeler seni bekliyor ✨`,
+    question: 'What would you like to taste this week? ✨',
+    response: (name) => `Stories from ${name} are waiting for you`,
   },
 ];
 
@@ -157,7 +157,7 @@ export default function FloatingCulturalPrompt({ regions }) {
             <div className="story-modal-body">
               {storiesLoading && <p className="story-modal-status">Loading…</p>}
               {!storiesLoading && storiesError && (
-                <p className="story-modal-status">Hikayeler yüklenemedi. Lütfen tekrar deneyin.</p>
+                <p className="story-modal-status">Failed to load stories. Please try again.</p>
               )}
               {!storiesLoading && !storiesError && stories.length === 0 && (
                 <p className="story-modal-status">No stories for this region yet.</p>

--- a/app/frontend/src/components/FloatingCulturalPrompt.jsx
+++ b/app/frontend/src/components/FloatingCulturalPrompt.jsx
@@ -28,11 +28,8 @@ export default function FloatingCulturalPrompt({ regions }) {
   const [storiesError, setStoriesError] = useState(false);
   const [modalOpen, setModalOpen] = useState(false);
 
-  // Fix 2: ref for modal close button (focus on open)
   const modalCloseRef = useRef(null);
-  // Fix 4: ref for modal container (focus trap)
   const modalRef = useRef(null);
-  // Fix 7: prevent setState after unmount
   const isMountedRef = useRef(true);
 
   useEffect(() => {
@@ -52,14 +49,12 @@ export default function FloatingCulturalPrompt({ regions }) {
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);
 
-  // Fix 2: move focus to close button when modal opens
   useEffect(() => {
     if (modalOpen && modalCloseRef.current) {
       modalCloseRef.current.focus();
     }
   }, [modalOpen]);
 
-  // Fix 3: close modal on Escape key
   useEffect(() => {
     if (!modalOpen) return;
     function handleKey(e) {
@@ -69,7 +64,6 @@ export default function FloatingCulturalPrompt({ regions }) {
     return () => window.removeEventListener('keydown', handleKey);
   }, [modalOpen]);
 
-  // Fix 4: focus trap inside modal
   useEffect(() => {
     if (!modalOpen || !modalRef.current) return;
 
@@ -99,7 +93,6 @@ export default function FloatingCulturalPrompt({ regions }) {
     return () => modal.removeEventListener('keydown', handleTab);
   }, [modalOpen, stories, storiesLoading]);
 
-  // Fix 6 & 7: error handling + isMounted guard
   function handleRegionSelect(region) {
     setSelectedRegion(region);
     setModalOpen(true);
@@ -146,7 +139,6 @@ export default function FloatingCulturalPrompt({ regions }) {
 
       {modalOpen && (
         <div className="story-modal-backdrop" onClick={closeModal}>
-          {/* Fix 1: aria-labelledby; Fix 4: ref */}
           <div
             ref={modalRef}
             className="story-modal"
@@ -156,18 +148,14 @@ export default function FloatingCulturalPrompt({ regions }) {
             onClick={(e) => e.stopPropagation()}
           >
             <div className="story-modal-header">
-              {/* Fix 1: id on h2 */}
               <h2 id="story-modal-title">{selectedRegion?.name}</h2>
-              {/* Fix 2: ref on close button */}
               <button ref={modalCloseRef} className="story-modal-close" onClick={closeModal} aria-label="Close">×</button>
             </div>
-            {/* Fix 5: response subtitle */}
             {selectedRegion && (
               <p className="story-modal-subtitle">{prompt.response(selectedRegion.name)}</p>
             )}
             <div className="story-modal-body">
               {storiesLoading && <p className="story-modal-status">Loading…</p>}
-              {/* Fix 6: error state */}
               {!storiesLoading && storiesError && (
                 <p className="story-modal-status">Hikayeler yüklenemedi. Lütfen tekrar deneyin.</p>
               )}

--- a/app/frontend/src/pages/HomePage.css
+++ b/app/frontend/src/pages/HomePage.css
@@ -80,24 +80,6 @@
   flex-shrink: 0;
 }
 
-.home-filters {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 1rem;
-  justify-content: center;
-}
-
-.home-filter-group {
-  margin-bottom: 0;
-  text-align: left;
-}
-
-@media (max-width: 540px) {
-  .home-filters {
-    grid-template-columns: 1fr;
-  }
-}
-
 .sr-only {
   position: absolute;
   width: 1px;
@@ -108,4 +90,75 @@
   clip: rect(0, 0, 0, 0);
   white-space: nowrap;
   border: 0;
+}
+
+.home-chip-filters {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  text-align: left;
+  max-width: 680px;
+  margin: 0 auto;
+}
+
+.home-chip-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.home-chip-label {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-text-muted);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.chip-soon {
+  font-size: 0.65rem;
+  font-weight: 600;
+  background: var(--color-border);
+  color: var(--color-text-muted);
+  border-radius: var(--radius-pill);
+  padding: 0.1rem 0.45rem;
+  text-transform: none;
+  letter-spacing: 0;
+}
+
+.home-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.home-chip {
+  background: var(--color-surface);
+  border: 1.5px solid var(--color-border);
+  border-radius: var(--radius-pill);
+  padding: 0.3rem 0.85rem;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s, background 0.15s;
+}
+
+.home-chip:hover:not(:disabled) {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+}
+
+.home-chip.active {
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+  color: #fff;
+}
+
+.home-chip:disabled {
+  opacity: 0.45;
+  cursor: default;
 }

--- a/app/frontend/src/pages/HomePage.css
+++ b/app/frontend/src/pages/HomePage.css
@@ -97,8 +97,6 @@
   flex-direction: column;
   gap: 0.85rem;
   text-align: left;
-  max-width: 680px;
-  margin: 0 auto;
 }
 
 .home-chip-group {

--- a/app/frontend/src/pages/HomePage.jsx
+++ b/app/frontend/src/pages/HomePage.jsx
@@ -7,14 +7,17 @@ import DailyCulturalSection from '../components/DailyCulturalSection';
 import useKeyboardShortcuts from '../hooks/useKeyboardShortcuts';
 import './HomePage.css';
 
+const MEAL_TYPES = ['Breakfast', 'Soup', 'Main Course', 'Dessert', 'Snack', 'Drink'];
+const STORY_TYPES = ['Traditional', 'Historical', 'Family', 'Festive', 'Personal'];
+
 export default function HomePage() {
   const auth = useContext(AuthContext) || {};
   const user = auth.user;
   const navigate = useNavigate();
   const [q, setQ] = useState('');
-  const [region, setRegion] = useState('');
-  const [ingredient, setIngredient] = useState('');
-  const [mealType, setMealType] = useState('');
+  const [selectedRegion, setSelectedRegion] = useState('');
+  const [selectedMealType, setSelectedMealType] = useState('');
+  const [selectedStoryType, setSelectedStoryType] = useState('');
   const [regions, setRegions] = useState([]);
   const [dailyCards, setDailyCards] = useState([]);
   const searchInputRef = useRef(null);
@@ -59,7 +62,7 @@ export default function HomePage() {
   function handleSubmit(e) {
     e.preventDefault();
     navigate(
-      `/search?q=${encodeURIComponent(q)}&region=${encodeURIComponent(region)}&ingredient=${encodeURIComponent(ingredient)}&meal_type=${encodeURIComponent(mealType)}`
+      `/search?q=${encodeURIComponent(q)}&region=${encodeURIComponent(selectedRegion)}&meal_type=${encodeURIComponent(selectedMealType)}`
     );
   }
 
@@ -106,41 +109,56 @@ export default function HomePage() {
           <button type="submit" className="btn btn-primary home-search-btn">Search</button>
         </div>
 
-        <div className="home-filters">
-          <div className="form-group home-filter-group">
-            <label htmlFor="ingredient-input">Ingredient</label>
-            <input
-              id="ingredient-input"
-              type="text"
-              value={ingredient}
-              onChange={(e) => setIngredient(e.target.value)}
-              placeholder="e.g. yogurt"
-            />
-          </div>
-
-          <div className="form-group home-filter-group">
-            <label htmlFor="meal-type-input">Meal Type</label>
-            <input
-              id="meal-type-input"
-              type="text"
-              value={mealType}
-              onChange={(e) => setMealType(e.target.value)}
-              placeholder="e.g. soup"
-            />
-          </div>
-
-          <div className="form-group home-filter-group">
-            <label htmlFor="region-select">Region</label>
-            <select
-              id="region-select"
-              value={region}
-              onChange={(e) => setRegion(e.target.value)}
-            >
-              <option value="">All regions</option>
+        <div className="home-chip-filters">
+          <div className="home-chip-group">
+            <span className="home-chip-label">Region</span>
+            <div className="home-chips">
               {regions.map((r) => (
-                <option key={r.id} value={r.name}>{r.name}</option>
+                <button
+                  key={r.id}
+                  type="button"
+                  className={`home-chip${selectedRegion === r.name ? ' active' : ''}`}
+                  onClick={() => setSelectedRegion(selectedRegion === r.name ? '' : r.name)}
+                >
+                  {r.name}
+                </button>
               ))}
-            </select>
+            </div>
+          </div>
+
+          <div className="home-chip-group">
+            <span className="home-chip-label">Meal Type</span>
+            <div className="home-chips">
+              {MEAL_TYPES.map((m) => (
+                <button
+                  key={m}
+                  type="button"
+                  className={`home-chip${selectedMealType === m ? ' active' : ''}`}
+                  onClick={() => setSelectedMealType(selectedMealType === m ? '' : m)}
+                >
+                  {m}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="home-chip-group">
+            <span className="home-chip-label">
+              Story Type <span className="chip-soon">coming soon</span>
+            </span>
+            <div className="home-chips">
+              {STORY_TYPES.map((s) => (
+                <button
+                  key={s}
+                  type="button"
+                  className={`home-chip${selectedStoryType === s ? ' active' : ''}`}
+                  onClick={() => setSelectedStoryType(selectedStoryType === s ? '' : s)}
+                  disabled
+                >
+                  {s}
+                </button>
+              ))}
+            </div>
           </div>
         </div>
       </form>

--- a/app/frontend/src/pages/HomePage.jsx
+++ b/app/frontend/src/pages/HomePage.jsx
@@ -4,6 +4,7 @@ import { AuthContext } from '../context/AuthContext';
 import { fetchRegions } from '../services/searchService';
 import { fetchDailyCulturalContent } from '../services/culturalContentService';
 import DailyCulturalSection from '../components/DailyCulturalSection';
+import FloatingCulturalPrompt from '../components/FloatingCulturalPrompt';
 import useKeyboardShortcuts from '../hooks/useKeyboardShortcuts';
 import './HomePage.css';
 
@@ -164,6 +165,7 @@ export default function HomePage() {
       </form>
 
       <DailyCulturalSection items={dailyCards} personalized={isPersonalized} />
+      <FloatingCulturalPrompt regions={regions} />
     </main>
   );
 }

--- a/app/frontend/src/services/culturalContentService.js
+++ b/app/frontend/src/services/culturalContentService.js
@@ -5,16 +5,20 @@ const USE_MOCK = process.env.REACT_APP_USE_MOCK === 'true';
 const MOCK_DAILY = [
   {
     id: 1,
+    kind: 'tradition',
     title: 'The Story of Wedding Pilaf',
     body: 'A short cultural note from Anatolian celebrations.',
     image_url: null,
+    region: 'Anatolia',
     cultural_tags: ['Wedding', 'Anatolian'],
   },
   {
     id: 2,
+    kind: 'dish',
     title: 'Ramadan Table Traditions',
     body: 'How iftar tables differ by region.',
     image_url: null,
+    region: 'Aegean',
     cultural_tags: ['Ramadan', 'Aegean'],
   },
 ];
@@ -22,8 +26,10 @@ const MOCK_DAILY = [
 function normalize(item) {
   return {
     id: item.id,
+    kind: item.kind || null,
     title: item.title,
     body: item.body || '',
+    region: item.region || null,
     imageUrl: item.image_url || null,
     tags: Array.isArray(item.cultural_tags) ? item.cultural_tags : [],
   };

--- a/app/frontend/src/services/mapService.js
+++ b/app/frontend/src/services/mapService.js
@@ -5,6 +5,11 @@ const USE_MOCK = process.env.REACT_APP_USE_MOCK === 'true';
 
 export async function fetchMapRegions() {
   if (USE_MOCK) return MOCK_MAP_REGIONS;
-  const response = await apiClient.get('/api/regions/map/');
+  const response = await apiClient.get('/api/map/regions/');
   return response.data;
+}
+
+export async function fetchMapRegionContent(regionId) {
+  const response = await apiClient.get(`/api/map/regions/${regionId}/content/`);
+  return response.data.results ?? response.data;
 }


### PR DESCRIPTION
PR Description:

  Closes #553

  ## Summary

  - Replaced search dropdowns with tappable filter chip panels (Region, Meal Type, Story Type)
  - Redesigned cultural highlights cards with kind-based emoji, colour accents, and hover animation
  - Added floating cultural prompt balloon that opens a regional story modal on scroll

  ## Changes

  | File | What changed |
  |---|---|
  | `DailyCulturalSection.jsx / .css` | Kind→emoji/colour mapping, staggered fade-in, hover lift, "Read more →" link |
  | `FloatingCulturalPrompt.jsx / .css` | New component — scroll-triggered balloon + accessible story modal |
  | `HomePage.jsx / .css` | Chip panels replace dropdowns; FloatingCulturalPrompt wired in |
  | `culturalContentService.js` | Bug fix: `normalize()` was stripping `kind` and `region` fields |

  ## Test Plan
  - [ ] Homepage loads and shows Region / Meal Type chip rows
  - [ ] Clicking a chip fills it; clicking again deselects; Search navigates to `/search` with correct params
  - [ ] Cultural Highlights cards show correct emoji and background colour per kind
  - [ ] Cards lift on hover
  - [ ] Scroll down ~300 px — floating prompt appears bottom-right
  - [ ] Pick a region in the prompt — story modal opens with region name header
  - [ ] Modal closes via ×, Escape, or backdrop click
  - [ ] Dismiss (×) on balloon — does not reappear in the same session
  - [ ] 245 tests passing