### PR TITLE
feat(mobile): pill-style "By X" with profile navigation on linked story cards (#546)

### DIFF
--- a/app/mobile/src/components/recipe/LinkedStoryPreviewCard.tsx
+++ b/app/mobile/src/components/recipe/LinkedStoryPreviewCard.tsx
@@ -8,9 +8,17 @@ type Props = {
   image?: string | null;
   authorUsername?: string | null;
   onPress: () => void;
+  onPressAuthor?: () => void;
 };
 
-export function LinkedStoryPreviewCard({ title, excerpt, image, authorUsername, onPress }: Props) {
+export function LinkedStoryPreviewCard({
+  title,
+  excerpt,
+  image,
+  authorUsername,
+  onPress,
+  onPressAuthor,
+}: Props) {
   return (
     <Pressable
       onPress={onPress}
@@ -37,9 +45,25 @@ export function LinkedStoryPreviewCard({ title, excerpt, image, authorUsername, 
           </Text>
         ) : null}
         {authorUsername ? (
-          <Text style={styles.author} numberOfLines={1}>
-            By {authorUsername}
-          </Text>
+          onPressAuthor ? (
+            <Pressable
+              onPress={onPressAuthor}
+              style={({ pressed }) => [styles.authorPill, pressed && styles.authorPillPressed]}
+              accessibilityRole="link"
+              accessibilityLabel={`Open profile of ${authorUsername}`}
+              hitSlop={6}
+            >
+              <Text style={styles.authorPillText} numberOfLines={1}>
+                By {authorUsername}
+              </Text>
+            </Pressable>
+          ) : (
+            <View style={styles.authorPill}>
+              <Text style={styles.authorPillText} numberOfLines={1}>
+                By {authorUsername}
+              </Text>
+            </View>
+          )
         ) : null}
       </View>
     </Pressable>
@@ -72,5 +96,16 @@ const styles = StyleSheet.create({
     fontFamily: tokens.typography.display.fontFamily,
   },
   excerpt: { fontSize: 13, color: tokens.colors.textMuted, lineHeight: 18 },
-  author: { fontSize: 12, color: tokens.colors.text, fontWeight: '800' },
+  authorPill: {
+    alignSelf: 'flex-start',
+    marginTop: 2,
+    paddingVertical: 4,
+    paddingHorizontal: 10,
+    borderRadius: tokens.radius.pill,
+    backgroundColor: tokens.colors.bg,
+    borderWidth: 1.5,
+    borderColor: tokens.colors.surfaceDark,
+  },
+  authorPillPressed: { opacity: 0.85 },
+  authorPillText: { fontSize: 12, color: tokens.colors.text, fontWeight: '800' },
 });

--- a/app/mobile/src/screens/RecipeDetailScreen.tsx
+++ b/app/mobile/src/screens/RecipeDetailScreen.tsx
@@ -299,6 +299,15 @@ export default function RecipeDetailScreen({ route, navigation }: Props) {
                     image={s.image}
                     authorUsername={s.authorUsername}
                     onPress={() => navigation.navigate('StoryDetail', { id: s.id })}
+                    onPressAuthor={
+                      s.authorId && s.authorUsername
+                        ? () =>
+                            navigation.navigate('UserProfile', {
+                              userId: s.authorId as string,
+                              username: s.authorUsername ?? undefined,
+                            })
+                        : undefined
+                    }
                   />
                 ))}
               </View>

--- a/app/mobile/src/services/storyService.ts
+++ b/app/mobile/src/services/storyService.ts
@@ -13,6 +13,7 @@ export type StoryListItem = {
   title: string;
   body: string;
   image: string | null;
+  authorId: string | null;
   authorUsername: string | null;
   linkedRecipeId: string | null;
   rank_score?: number;
@@ -27,17 +28,25 @@ function pickListItem(raw: any): StoryListItem {
       : typeof linkedRaw === 'object' && 'id' in linkedRaw
         ? String(linkedRaw.id)
         : String(linkedRaw);
+  const authorRaw = raw?.author;
+  const authorId =
+    authorRaw == null
+      ? null
+      : typeof authorRaw === 'object' && 'id' in authorRaw
+        ? String((authorRaw as { id: unknown }).id)
+        : String(authorRaw);
   const authorUsername =
     typeof raw?.author_username === 'string'
       ? raw.author_username
-      : typeof raw?.author === 'object' && raw?.author?.username
-        ? String(raw.author.username)
+      : typeof authorRaw === 'object' && authorRaw?.username
+        ? String(authorRaw.username)
         : null;
   return {
     id: String(raw?.id ?? ''),
     title: typeof raw?.title === 'string' ? raw.title : '',
     body: typeof raw?.body === 'string' ? raw.body : '',
     image: typeof raw?.image === 'string' ? raw.image : null,
+    authorId,
     authorUsername,
     linkedRecipeId,
     rank_score: typeof raw?.rank_score === 'number' ? raw.rank_score : undefined,


### PR DESCRIPTION
## Summary
Closes #546. The "By X" line on each card in the Stories-about-this-recipe section was plain text. Promoted it to a pill button matching the author affordance on the recipe and story detail screens (#544), and wired it to the user profile.

## Files
- `services/storyService.ts` — `StoryListItem` carries `authorId` so callers can navigate
- `components/recipe/LinkedStoryPreviewCard.tsx` — new `onPressAuthor` prop, "By X" rendered as a pill (cream fill, surfaceDark border); falls back to a non-tappable pill when the prop isn't provided
- `screens/RecipeDetailScreen.tsx` — passes `onPressAuthor` that navigates to `UserProfile` when the author has an id

## Test
- `npx tsc --noEmit` clean
- Local docker stack: opened a recipe with linked stories — each card shows the "By X" pill; tapping it opens the user profile, tapping the rest of the card still opens the story.

Closes #546