### PR TITLE
fix(mobile): show region as a clickable pill on Recipe and Story detail (#545, #561)

### DIFF
--- a/app/mobile/src/screens/RecipeDetailScreen.tsx
+++ b/app/mobile/src/screens/RecipeDetailScreen.tsx
@@ -148,7 +148,19 @@ export default function RecipeDetailScreen({ route, navigation }: Props) {
           <Text style={styles.title} accessibilityRole="header">
             {recipe.title}
           </Text>
-          {recipe.region ? <Text style={styles.meta}>{recipe.region}</Text> : null}
+          {recipe.region ? (
+            <Pressable
+              onPress={() =>
+                navigation.navigate('Search', { region: recipe.region as string })
+              }
+              style={({ pressed }) => [styles.regionPill, pressed && { opacity: 0.85 }]}
+              accessibilityRole="link"
+              accessibilityLabel={`Browse ${recipe.region} recipes`}
+              hitSlop={6}
+            >
+              <Text style={styles.regionPillText}>{recipe.region}</Text>
+            </Pressable>
+          ) : null}
           {authorObj ? (
             <Pressable
               onPress={() =>
@@ -341,6 +353,17 @@ const styles = StyleSheet.create({
     fontFamily: tokens.typography.display.fontFamily,
   },
   meta: { fontSize: 14, color: tokens.colors.textMuted, marginTop: 6 },
+  regionPill: {
+    alignSelf: 'flex-start',
+    marginTop: 8,
+    paddingVertical: 5,
+    paddingHorizontal: 12,
+    borderRadius: tokens.radius.pill,
+    backgroundColor: tokens.colors.bg,
+    borderWidth: 1.5,
+    borderColor: tokens.colors.surfaceDark,
+  },
+  regionPillText: { fontSize: 12, color: tokens.colors.text, fontWeight: '800', letterSpacing: 0.2 },
   author: { fontSize: 14, color: tokens.colors.textMuted, marginTop: 4 },
   authorPill: {
     alignSelf: 'flex-start',

--- a/app/mobile/src/screens/StoryDetailScreen.tsx
+++ b/app/mobile/src/screens/StoryDetailScreen.tsx
@@ -86,6 +86,19 @@ export default function StoryDetailScreen({ route, navigation }: Props) {
           <Text style={styles.title} accessibilityRole="header">
             {story.title}
           </Text>
+          {story.region ? (
+            <Pressable
+              onPress={() =>
+                navigation.navigate('Search', { region: story.region as string })
+              }
+              style={({ pressed }) => [styles.regionPill, pressed && { opacity: 0.85 }]}
+              accessibilityRole="link"
+              accessibilityLabel={`Browse ${story.region} content`}
+              hitSlop={6}
+            >
+              <Text style={styles.regionPillText}>{story.region}</Text>
+            </Pressable>
+          ) : null}
           {authorObj ? (
             <Pressable
               onPress={() =>
@@ -168,6 +181,17 @@ const styles = StyleSheet.create({
   thumb: { width: '100%', height: '100%' },
   title: { fontSize: 24, fontWeight: '800', color: tokens.colors.text, fontFamily: tokens.typography.display.fontFamily },
   meta: { fontSize: 14, color: tokens.colors.textMuted, marginTop: 8 },
+  regionPill: {
+    alignSelf: 'flex-start',
+    marginTop: 8,
+    paddingVertical: 5,
+    paddingHorizontal: 12,
+    borderRadius: tokens.radius.pill,
+    backgroundColor: tokens.colors.bg,
+    borderWidth: 1.5,
+    borderColor: tokens.colors.surfaceDark,
+  },
+  regionPillText: { fontSize: 12, color: tokens.colors.text, fontWeight: '800', letterSpacing: 0.2 },
   authorPill: {
     alignSelf: 'flex-start',
     marginTop: 8,

--- a/app/mobile/src/services/recipeService.ts
+++ b/app/mobile/src/services/recipeService.ts
@@ -81,11 +81,25 @@ function normalizeRecipeDetail(data: RecipeDetail & Record<string, unknown>): Re
         }
       : undefined;
 
+  // Backend sends `region` as the FK pk (integer) and the human label as
+  // `region_name`. Normalise to the friendly name so callers can render it
+  // directly without showing the raw id.
+  const reg = data.region;
+  const regionLabel =
+    typeof reg === 'string'
+      ? reg
+      : reg && typeof reg === 'object' && 'name' in reg && typeof (reg as { name: unknown }).name === 'string'
+        ? (reg as { name: string }).name
+        : typeof data.region_name === 'string'
+          ? data.region_name
+          : undefined;
+
   return {
     ...data,
     ingredients: normalizeRecipeIngredients(data.ingredients),
     image: typeof data.image === 'string' ? data.image : null,
     author,
+    region: regionLabel,
   };
 }
 

--- a/app/mobile/src/services/storyService.ts
+++ b/app/mobile/src/services/storyService.ts
@@ -112,12 +112,25 @@ function normalizeStoryDetail(data: StoryDetail & Record<string, unknown>): Stor
     };
   }
 
+  // Backend exposes `region` as the FK pk and the friendly label in
+  // `region_name`. Surface the name so the detail screen renders it directly.
+  const reg = (data as { region?: unknown }).region;
+  const regionLabel =
+    typeof reg === 'string'
+      ? reg
+      : reg && typeof reg === 'object' && 'name' in reg && typeof (reg as { name: unknown }).name === 'string'
+        ? (reg as { name: string }).name
+        : typeof (data as { region_name?: unknown }).region_name === 'string'
+          ? (data as unknown as { region_name: string }).region_name
+          : undefined;
+
   return {
     ...data,
     author,
     linked_recipe,
     image: typeof data.image === 'string' ? data.image : null,
     is_published: typeof data.is_published === 'boolean' ? data.is_published : undefined,
+    region: regionLabel,
   };
 }
 

--- a/app/mobile/src/types/story.ts
+++ b/app/mobile/src/types/story.ts
@@ -9,6 +9,8 @@ export type StoryDetail = {
   is_published?: boolean;
   /** Optional image URL/uri (mock uses remote url). */
   image?: string | null;
+  /** Friendly region name surfaced by `normalizeStoryDetail` (backend exposes `region_name`). */
+  region?: string;
   rank_score?: number;
   rank_reason?: string | null;
 };


### PR DESCRIPTION
## Summary
Closes #545 and closes #561. The recipe and story detail screens used to render `recipe.region` / `story.region` directly, but the backend exposes those fields as the FK pk (an integer like `3`) and surfaces the human label in `region_name`. That's where the stray "3" was coming from on Trabzon Butter Kuymak. This PR normalizes the field to the friendly name and turns it into a tappable pill that opens Search filtered by that region — same affordance the map's CTA uses.

## Files
- `services/recipeService.ts` — `normalizeRecipeDetail` resolves `region` from `region_name` (or a nested `{name}` object)
- `services/storyService.ts` — `normalizeStoryDetail` does the same for stories; surfaces `region` on the normalized payload
- `types/story.ts` — `StoryDetail` now declares the optional `region: string`
- `screens/RecipeDetailScreen.tsx` — region rendered as a pill (cream fill, surfaceDark border); tap navigates to `Search` with `?region=<name>`
- `screens/StoryDetailScreen.tsx` — same pill mirroring the recipe behaviour

## Test
- `npx tsc --noEmit` clean
- Local docker stack: opened Trabzon Butter Kuymak — title now shows "Black Sea" pill instead of the stray "3". Tapping it opens Search filtered by Black Sea. Stories with a region get the same pill. Recipes/stories without a region don't render an empty pill.

Closes #545
Closes #561