### PR TITLE
feat(mobile): visible pills and inline personalization badge on Home story cards (#557, #556)

### DIFF
--- a/app/mobile/src/components/home/StoryFeatureCard.tsx
+++ b/app/mobile/src/components/home/StoryFeatureCard.tsx
@@ -8,6 +8,8 @@ type Props = {
   image?: string | null;
   authorUsername?: string | null;
   recipeTitle?: string | null;
+  /** Optional footer node (e.g. RankReasonBadge) rendered inside the card body. */
+  footer?: React.ReactNode;
   onPress: () => void;
   onPressAuthor?: () => void;
   onPressRecipe?: () => void;
@@ -19,6 +21,7 @@ export function StoryFeatureCard({
   image,
   authorUsername,
   recipeTitle,
+  footer,
   onPress,
   onPressAuthor,
   onPressRecipe,
@@ -75,6 +78,7 @@ export function StoryFeatureCard({
             </Pressable>
           ) : null}
         </View>
+        {footer ? <View style={styles.footer}>{footer}</View> : null}
       </View>
     </Pressable>
   );
@@ -108,9 +112,9 @@ const styles = StyleSheet.create({
   excerpt: { fontSize: 14, color: tokens.colors.textMuted, lineHeight: 20 },
   metaRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 8, marginTop: 4 },
   pill: {
-    backgroundColor: tokens.colors.primarySubtle,
+    backgroundColor: tokens.colors.bg,
     borderWidth: 1.5,
-    borderColor: tokens.colors.primaryBorder,
+    borderColor: tokens.colors.surfaceDark,
     borderRadius: tokens.radius.pill,
     paddingVertical: 4,
     paddingHorizontal: 10,
@@ -123,5 +127,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: 10,
     maxWidth: '70%',
   },
-  recipePillText: { fontSize: 12, color: tokens.colors.text, fontWeight: '800' },
+  recipePillText: { fontSize: 12, color: tokens.colors.textOnDark, fontWeight: '800' },
+  footer: { marginTop: 6 },
 });

--- a/app/mobile/src/screens/HomeScreen.tsx
+++ b/app/mobile/src/screens/HomeScreen.tsx
@@ -155,31 +155,30 @@ export default function HomeScreen({ navigation }: Props) {
                       ? String(linkedRecipeRaw.title)
                       : null;
                 return (
-                  <View key={String(item.id)} style={styles.storyWrap}>
-                    <StoryFeatureCard
-                      title={item.title}
-                      body={item.body}
-                      image={item.image}
-                      authorUsername={authorUsername ?? null}
-                      recipeTitle={linkedRecipeId ? linkedRecipeTitle : null}
-                      onPress={() => navigation.navigate('StoryDetail', { id: String(item.id) })}
-                      onPressAuthor={
-                        authorId != null && authorUsername
-                          ? () =>
-                              navigation.navigate('UserProfile', {
-                                userId: authorId,
-                                username: authorUsername,
-                              })
-                          : undefined
-                      }
-                      onPressRecipe={
-                        linkedRecipeId
-                          ? () => navigation.navigate('RecipeDetail', { id: linkedRecipeId })
-                          : undefined
-                      }
-                    />
-                    <RankReasonBadge reason={item.rank_reason} style={styles.storyBadge} />
-                  </View>
+                  <StoryFeatureCard
+                    key={String(item.id)}
+                    title={item.title}
+                    body={item.body}
+                    image={item.image}
+                    authorUsername={authorUsername ?? null}
+                    recipeTitle={linkedRecipeId ? linkedRecipeTitle : null}
+                    footer={<RankReasonBadge reason={item.rank_reason} />}
+                    onPress={() => navigation.navigate('StoryDetail', { id: String(item.id) })}
+                    onPressAuthor={
+                      authorId != null && authorUsername
+                        ? () =>
+                            navigation.navigate('UserProfile', {
+                              userId: authorId,
+                              username: authorUsername,
+                            })
+                        : undefined
+                    }
+                    onPressRecipe={
+                      linkedRecipeId
+                        ? () => navigation.navigate('RecipeDetail', { id: linkedRecipeId })
+                        : undefined
+                    }
+                  />
                 );
               })}
             </View>
@@ -411,7 +410,5 @@ const styles = StyleSheet.create({
   },
   tagText: { fontSize: 12, fontWeight: '800', color: tokens.colors.text },
   link: { fontSize: 15, color: tokens.colors.text, fontWeight: '800' },
-  storyWrap: { gap: 6 },
-  storyBadge: { marginLeft: 4 },
   recipeBadge: { marginLeft: 12, marginBottom: 12 },
 });


### PR DESCRIPTION
## Summary
Closes #557 and closes #556. The Home story card had two related issues from the palette swap: the "By X" and "Recipe: X" pills used `primarySubtle` / `surfaceDark` with low-contrast text, and the personalization badge ("From your region", "Matches your interests") was rendered as a sibling of the card so it floated outside the rounded border. Both fixed in `StoryFeatureCard`.

## Files
- `components/home/StoryFeatureCard.tsx` — author pill: cream fill + `surfaceDark` border + dark text; recipe pill: keeps the dark fill but text now `textOnDark` so it reads. New `footer` prop renders any badge inside the card body.
- `screens/HomeScreen.tsx` — passes `<RankReasonBadge />` via the new `footer` prop instead of mounting it as a sibling. Drops the obsolete `storyWrap` / `storyBadge` styles.

## Test
- `npx tsc --noEmit` clean
- Local docker stack with a logged-in user that has profile terms: each story card on Home now shows the "By X" pill, "Recipe: X" pill, and the personalization badge **all inside** the card border. Tapping the pills navigates to the user profile and the linked recipe respectively.

Closes #557
Closes #556