### PR TITLE
fix(frontend): explore page, search filter accordions, map content loading

### DIFF
--- a/app/frontend/src/pages/MapPage.css
+++ b/app/frontend/src/pages/MapPage.css
@@ -72,6 +72,14 @@
   color: var(--color-text);
 }
 
+.map-panel-counts {
+  display: flex;
+  gap: 1rem;
+  font-size: 0.875rem;
+  color: var(--color-text-muted);
+  font-weight: 600;
+}
+
 .map-panel-desc {
   font-size: 0.9375rem;
   color: var(--color-text-muted);

--- a/app/frontend/src/pages/MapPage.jsx
+++ b/app/frontend/src/pages/MapPage.jsx
@@ -2,22 +2,35 @@ import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { MapContainer, TileLayer, CircleMarker, Tooltip } from 'react-leaflet';
 import 'leaflet/dist/leaflet.css';
-import { fetchMapRegions } from '../services/mapService';
+import { fetchMapRegions, fetchMapRegionContent } from '../services/mapService';
 import './MapPage.css';
 
 export default function MapPage() {
   const [regions, setRegions] = useState([]);
   const [selected, setSelected] = useState(null);
+  const [content, setContent] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [contentLoading, setContentLoading] = useState(false);
 
   useEffect(() => {
     fetchMapRegions()
       .then((data) => {
         setRegions(data);
-        if (data.length > 0) setSelected(data[0]);
+        if (data.length > 0) selectRegion(data[0]);
       })
       .finally(() => setLoading(false));
   }, []);
+
+  function selectRegion(region) {
+    setSelected(region);
+    setContentLoading(true);
+    fetchMapRegionContent(region.id)
+      .then(setContent)
+      .finally(() => setContentLoading(false));
+  }
+
+  const recipes = content.filter((c) => c.content_type === 'recipe');
+  const stories = content.filter((c) => c.content_type === 'story');
 
   return (
     <div className="map-page">
@@ -38,13 +51,13 @@ export default function MapPage() {
               scrollWheelZoom={false}
             >
               <TileLayer
-                url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-                attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+                url="https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png"
+                attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>'
               />
               {regions.map((region) => (
                 <CircleMarker
                   key={region.id}
-                  center={[region.lat, region.lng]}
+                  center={[region.latitude, region.longitude]}
                   radius={selected?.id === region.id ? 16 : 11}
                   pathOptions={{
                     color: selected?.id === region.id ? '#A3401A' : '#C4521E',
@@ -52,7 +65,7 @@ export default function MapPage() {
                     fillOpacity: selected?.id === region.id ? 0.9 : 0.7,
                     weight: 2,
                   }}
-                  eventHandlers={{ click: () => setSelected(region) }}
+                  eventHandlers={{ click: () => selectRegion(region) }}
                 >
                   <Tooltip direction="top" offset={[0, -8]} opacity={0.95}>
                     {region.name}
@@ -68,13 +81,18 @@ export default function MapPage() {
           {selected ? (
             <>
               <h2 className="map-panel-title">{selected.name}</h2>
-              <p className="map-panel-desc">{selected.description}</p>
+              <div className="map-panel-counts">
+                <span>{selected.content_count.recipes} recipes</span>
+                <span>{selected.content_count.stories} stories</span>
+              </div>
 
-              {selected.featured_recipes?.length > 0 && (
+              {contentLoading && <p className="map-panel-empty">Loading…</p>}
+
+              {!contentLoading && recipes.length > 0 && (
                 <section className="map-panel-section">
                   <h3>Recipes</h3>
                   <ul className="map-content-list">
-                    {selected.featured_recipes.map((r) => (
+                    {recipes.map((r) => (
                       <li key={r.id}>
                         <Link to={`/recipes/${r.id}`} className="map-content-item">
                           <span className="map-content-title">{r.title}</span>
@@ -86,11 +104,11 @@ export default function MapPage() {
                 </section>
               )}
 
-              {selected.featured_stories?.length > 0 && (
+              {!contentLoading && stories.length > 0 && (
                 <section className="map-panel-section">
                   <h3>Stories</h3>
                   <ul className="map-content-list">
-                    {selected.featured_stories.map((s) => (
+                    {stories.map((s) => (
                       <li key={s.id}>
                         <Link to={`/stories/${s.id}`} className="map-content-item">
                           <span className="map-content-title">{s.title}</span>
@@ -100,6 +118,10 @@ export default function MapPage() {
                     ))}
                   </ul>
                 </section>
+              )}
+
+              {!contentLoading && recipes.length === 0 && stories.length === 0 && (
+                <p className="map-panel-empty">No content yet for this region.</p>
               )}
 
               <Link
@@ -120,7 +142,7 @@ export default function MapPage() {
           <button
             key={region.id}
             className={`map-region-chip${selected?.id === region.id ? ' active' : ''}`}
-            onClick={() => setSelected(region)}
+            onClick={() => selectRegion(region)}
           >
             {region.name}
           </button>

--- a/app/frontend/src/pages/SearchPage.css
+++ b/app/frontend/src/pages/SearchPage.css
@@ -108,25 +108,87 @@
   margin-top: 1.25rem;
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 1rem;
+  gap: 0.5rem;
+  align-items: start;
 }
 
-.rich-filter-group {
+.filter-accordion {
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
-  padding: 0.8rem;
   background: var(--color-surface);
+  overflow: hidden;
 }
 
-.rich-filter-group h3 {
-  margin: 0 0 0.6rem 0;
-  font-size: 0.95rem;
+.filter-accordion-header {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.7rem 1rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-family: var(--font-body);
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--color-text);
+  text-align: left;
+  transition: background-color 0.15s ease;
+}
+
+.filter-accordion-header:hover {
+  background: var(--color-surface-input);
+}
+
+.filter-accordion-title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.filter-accordion-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-primary);
+  color: #fff;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  min-width: 1.2rem;
+  height: 1.2rem;
+  padding: 0 0.3rem;
+}
+
+.filter-accordion-chevron {
+  font-size: 0.65rem;
+  color: var(--color-text-muted);
+  display: inline-block;
+  transition: transform 0.22s ease;
+}
+
+.filter-accordion-open .filter-accordion-chevron {
+  transform: rotate(180deg);
+}
+
+.filter-accordion-body {
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.25s ease;
+}
+
+.filter-accordion-open .filter-accordion-body {
+  max-height: 600px;
+}
+
+.filter-accordion-inner {
+  padding: 0.2rem 1rem 0.9rem;
 }
 
 .rich-chip-list {
   display: flex;
   flex-direction: column;
-  gap: 0.45rem;
+  gap: 0.4rem;
 }
 
 .rich-chip-wrap {
@@ -140,8 +202,13 @@
   background: var(--color-surface-input);
   color: var(--color-text);
   font-size: 0.78rem;
-  padding: 0.22rem 0.6rem;
+  padding: 0.22rem 0.65rem;
   cursor: pointer;
+  transition: border-color 0.15s ease, background-color 0.15s ease;
+}
+
+.rich-chip:hover {
+  border-color: var(--color-primary);
 }
 
 .rich-chip-include {

--- a/app/frontend/src/pages/SearchPage.jsx
+++ b/app/frontend/src/pages/SearchPage.jsx
@@ -6,6 +6,35 @@ import { fetchDietaryTags, fetchEventTags, fetchIngredients } from '../services/
 import SearchResultCard from '../components/SearchResultCard';
 import './SearchPage.css';
 
+function FilterAccordion({ title, activeCount, children }) {
+  const [open, setOpen] = useState(false);
+  useEffect(() => {
+    if (activeCount > 0) setOpen(true);
+  }, [activeCount]);
+
+  return (
+    <div className={`filter-accordion${open ? ' filter-accordion-open' : ''}`}>
+      <button
+        type="button"
+        className="filter-accordion-header"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+      >
+        <span className="filter-accordion-title">
+          {title}
+          {activeCount > 0 && (
+            <span className="filter-accordion-badge">{activeCount}</span>
+          )}
+        </span>
+        <span className="filter-accordion-chevron" aria-hidden="true">▼</span>
+      </button>
+      <div className="filter-accordion-body">
+        <div className="filter-accordion-inner">{children}</div>
+      </div>
+    </div>
+  );
+}
+
 function parseCsv(value) {
   if (!value) return [];
   return value.split(',').map((v) => v.trim()).filter(Boolean);
@@ -217,8 +246,7 @@ export default function SearchPage() {
         </div>
 
         <div className="rich-filter-panels">
-          <div className="rich-filter-group">
-            <h3>Dietary Tags</h3>
+          <FilterAccordion title="Dietary Tags" activeCount={localDietInclude.length + localDietExclude.length}>
             <div className="rich-chip-list">
               {dietaryTags.map((tag) => (
                 <div className="rich-chip-wrap" key={tag.id}>
@@ -239,10 +267,9 @@ export default function SearchPage() {
                 </div>
               ))}
             </div>
-          </div>
+          </FilterAccordion>
 
-          <div className="rich-filter-group">
-            <h3>Event Tags</h3>
+          <FilterAccordion title="Event Tags" activeCount={localEventInclude.length + localEventExclude.length}>
             <div className="rich-chip-list">
               {eventTags.map((tag) => (
                 <div className="rich-chip-wrap" key={tag.id}>
@@ -263,10 +290,9 @@ export default function SearchPage() {
                 </div>
               ))}
             </div>
-          </div>
+          </FilterAccordion>
 
-          <div className="rich-filter-group">
-            <h3>Ingredients</h3>
+          <FilterAccordion title="Ingredients" activeCount={localIngredientInclude.length + localIngredientExclude.length}>
             <div className="rich-chip-list">
               {ingredientTags.map((tag) => (
                 <div className="rich-chip-wrap" key={tag.id}>
@@ -287,7 +313,7 @@ export default function SearchPage() {
                 </div>
               ))}
             </div>
-          </div>
+          </FilterAccordion>
         </div>
       </form>
 

--- a/app/frontend/src/services/exploreService.js
+++ b/app/frontend/src/services/exploreService.js
@@ -5,8 +5,17 @@ const USE_MOCK = process.env.REACT_APP_USE_MOCK === 'true';
 
 export async function fetchExploreEvents() {
   if (USE_MOCK) return MOCK_EXPLORE_EVENTS;
-  const response = await apiClient.get('/api/explore/events/');
-  return response.data;
+  const response = await apiClient.get('/api/recommendations/', {
+    params: { surface: 'explore', limit: 20 },
+  });
+  const results = response.data.results || [];
+  const recipes = results.filter((r) => r.type === 'recipe');
+  const stories = results.filter((r) => r.type === 'story');
+  const events = [];
+  if (recipes.length) events.push({ id: 'recipes', name: 'Recipes', emoji: '🍽️', featured: recipes });
+  if (stories.length) events.push({ id: 'stories', name: 'Stories', emoji: '📖', featured: stories });
+  if (!events.length) events.push({ id: 'explore', name: 'Discover', emoji: '✨', featured: results });
+  return events;
 }
 
 export async function fetchEventDetail(id) {
@@ -15,6 +24,13 @@ export async function fetchEventDetail(id) {
     if (!event) return Promise.reject(new Error('Not found'));
     return event;
   }
-  const response = await apiClient.get(`/api/explore/events/${id}/`);
-  return response.data;
+  const response = await apiClient.get('/api/recommendations/', {
+    params: { surface: 'explore', limit: 50 },
+  });
+  const results = response.data.results || [];
+  const recipes = results.filter((r) => r.type === 'recipe');
+  const stories = results.filter((r) => r.type === 'story');
+  if (id === 'recipes') return { id: 'recipes', name: 'Recipes', emoji: '🍽️', featured: recipes };
+  if (id === 'stories') return { id: 'stories', name: 'Stories', emoji: '📖', featured: stories };
+  return { id: 'explore', name: 'Discover', emoji: '✨', featured: results };
 }

--- a/app/frontend/src/services/recipeService.js
+++ b/app/frontend/src/services/recipeService.js
@@ -65,7 +65,7 @@ export async function submitUnit(name) {
 export async function fetchRecipes() {
   if (USE_MOCK) return MOCK_RECIPES_LIST;
   const response = await apiClient.get('/api/recipes/');
-  return response.data;
+  return response.data.results ?? response.data;
 }
 
 export async function fetchDietaryTags() {

--- a/app/frontend/src/services/storyService.js
+++ b/app/frontend/src/services/storyService.js
@@ -11,7 +11,7 @@ export async function fetchStory(id) {
 
 export async function fetchStories() {
   const response = await apiClient.get('/api/stories/');
-  return response.data;
+  return response.data.results ?? response.data;
 }
 
 export async function createStory(data) {


### PR DESCRIPTION
## Summary

  - **Explore page**: The page was broken because `exploreService` called a
    non-existent `/api/explore/events/` endpoint. Fixed to use the existing
    `/api/recommendations/?surface=explore` endpoint and adapt the flat response
    into the event-rail shape the UI expects.

  - **Search filters**: Replaced the three always-visible filter boxes (Dietary
    Tags, Event Tags, Ingredients) with collapsible accordion panels. Panels are
    closed by default and show an active-selection count badge when filters are
    selected.

  - **Map page**: Fixed `lat`/`lng` → `latitude`/`longitude` field name mismatch,
    wired up `fetchMapRegionContent` to load recipes and stories per region,
    added recipe/story counts in the panel header, and switched to the CARTO
    light tile layer for a cleaner look.
  
  - **recipeService / storyService**: Handle paginated API responses by reading
    `response.data.results` with a fallback to `response.data`.

  ## Test plan 

  - [ ] Navigate to `/explore` while logged in — recipes and stories load in two rails
  - [ ] Search for a term, open/close each accordion panel, select filters and verify badge counts update
  - [ ] Open the Map page, click different regions and verify recipe/story lists load correctly
  - [ ] Confirm recipe list and story list pages still render without regressions