### PR TITLE
fix(backend): allow anonymous POST /api/convert/ (#503)

### DIFF
--- a/app/backend/apps/common/middleware.py
+++ b/app/backend/apps/common/middleware.py
@@ -19,10 +19,14 @@ class JWTAuthenticationMiddleware(MiddlewareMixin):
     where a view might accidentally omit permission_classes.
     """
     
+    # Paths that are public for unsafe methods (POST/PUT/PATCH/DELETE).
+    # The middleware otherwise blocks anonymous unsafe requests to /api/* before
+    # DRF gets a chance to resolve view-level permission_classes (#503).
     EXEMPT_POST_PATHS = [
         '/api/auth/register/',
         '/api/auth/login/',
         '/api/auth/refresh/',
+        '/api/convert/',
     ]
 
     def process_request(self, request):

--- a/app/backend/apps/recipes/tests_convert_api.py
+++ b/app/backend/apps/recipes/tests_convert_api.py
@@ -1,6 +1,8 @@
 """Tests for POST /api/convert/."""
+import json
 from decimal import Decimal
 
+from django.test import Client
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
@@ -124,3 +126,26 @@ class ConvertApiTests(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(Decimal(response.data['amount']), Decimal('0.5'))
+
+    def test_convert_allows_anonymous(self):
+        # Regression for #503. APIClient sets request._force_auth_user even
+        # when no force_authenticate() is called, which makes the custom
+        # JWTAuthenticationMiddleware short-circuit and skip its 401 enforcement
+        # branch. Use the plain django.test.Client so the middleware runs the
+        # same path it does in production for a logged-out browser.
+        plain_client = Client()
+        response = plain_client.post(
+            self.url,
+            data=json.dumps({
+                'amount': '100',
+                'from_unit': 'g',
+                'to_unit': 'oz',
+            }),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertEqual(body['from_unit'], 'g')
+        self.assertEqual(body['to_unit'], 'oz')
+        self.assertEqual(Decimal(body['amount']), Decimal('3.5274'))

--- a/app/backend/apps/recipes/views.py
+++ b/app/backend/apps/recipes/views.py
@@ -373,8 +373,16 @@ class CommentViewSet(mixins.DestroyModelMixin, viewsets.GenericViewSet):
 
 
 class ConvertView(APIView):
-    """POST /api/convert/ — public unit conversion endpoint (#376)."""
+    """POST /api/convert/ public unit conversion endpoint (#376, #503).
 
+    Anonymous and authenticated users both hit the same code path. The view is
+    explicitly auth-free: an empty authentication_classes list tells DRF not to
+    even attempt JWT/session resolution, and AllowAny documents the intent at
+    the permission layer. The custom JWTAuthenticationMiddleware also exempts
+    this path from its blanket unsafe-method block (see apps.common.middleware).
+    """
+
+    authentication_classes = []
     permission_classes = [permissions.AllowAny]
 
     def post(self, request):


### PR DESCRIPTION
## Summary
- Root cause: the custom `JWTAuthenticationMiddleware` (apps/common/middleware.py) blocks every unsafe method under `/api/` for anonymous requests before DRF gets a chance to resolve view-level `permission_classes`, so `ConvertView`'s `permission_classes = [AllowAny]` was never consulted.
- Added `/api/convert/` to `EXEMPT_POST_PATHS` so anonymous unit conversions go through.
- Set `authentication_classes = []` on `ConvertView` and updated its docstring so the public contract is explicit at the DRF layer too. View-only changes do not fix the bug on their own (middleware short-circuits first), but they document intent.
- Added a regression test that uses `django.test.Client` directly. The existing `APITestCase` suite was passing against the broken middleware because DRF's `ForceAuthClientHandler` always sets `request._force_auth_user` (even to `None`), which makes the middleware return early at the `hasattr(...)` check and skip its 401 branch. Plain `Client` reproduces the production path.

## Test plan
- [x] `python manage.py test apps.recipes` (205 tests, all green)
- [x] `python manage.py test apps.common` (21 tests, all green)
- [x] Reverted the middleware exemption locally and confirmed the new `test_convert_allows_anonymous` fails with 401, then re-applied the fix and confirmed it goes back to 200.
- [ ] Manual smoke against the dev server: `curl -X POST /api/convert/` without an Authorization header should return 200 with the converted amount.

## Notes
- View-local + middleware-local fix only. `REST_FRAMEWORK` defaults are untouched, so every other endpoint keeps its existing auth posture.
- Out of scope per the issue: `IngredientViewSet.substitutes` is auth-required by design and stays as is.

Closes #503.