### PR TITLE
fix(frontend): collapse auth links into user menu dropdown

### DIFF
--- a/app/frontend/src/__tests__/Navbar.test.jsx
+++ b/app/frontend/src/__tests__/Navbar.test.jsx
@@ -45,6 +45,7 @@ describe('Navbar', () => {
     renderNavbar({ username: 'alice', id: 1 });
     expect(screen.getByText('@alice')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /notifications/i })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /@alice/i }));
     expect(screen.getByRole('link', { name: /new recipe/i })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /new story/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /log out/i })).toBeInTheDocument();
@@ -53,6 +54,7 @@ describe('Navbar', () => {
   it('calls logout when Log Out clicked', () => {
     const mockLogout = jest.fn();
     renderNavbar({ username: 'alice', id: 1 }, mockLogout);
+    fireEvent.click(screen.getByRole('button', { name: /@alice/i }));
     fireEvent.click(screen.getByRole('button', { name: /log out/i }));
     expect(mockLogout).toHaveBeenCalledTimes(1);
   });

--- a/app/frontend/src/components/Navbar.css
+++ b/app/frontend/src/components/Navbar.css
@@ -13,6 +13,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  position: relative;
 }
 
 .navbar-brand {
@@ -60,6 +61,127 @@
   color: var(--color-text-muted);
 }
 
+.navbar-user-menu {
+  position: relative;
+}
+
+.navbar-user-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: none;
+  border: 1.5px solid var(--color-border);
+  border-radius: 999px;
+  padding: 0.3rem 0.75rem 0.3rem 0.3rem;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.navbar-user-btn:hover {
+  background: var(--color-surface-dark);
+  border-color: var(--color-primary);
+}
+
+.navbar-user-btn:hover .navbar-username {
+  color: var(--color-surface);
+}
+
+.navbar-user-btn:hover .navbar-chevron {
+  border-color: var(--color-surface);
+}
+
+.navbar-avatar {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: var(--color-primary);
+  color: #fff;
+  font-size: 0.8125rem;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.navbar-chevron {
+  width: 8px;
+  height: 8px;
+  border-right: 2px solid var(--color-text-muted);
+  border-bottom: 2px solid var(--color-text-muted);
+  transform: rotate(45deg) translateY(-2px);
+  transition: transform 0.2s ease, border-color 0.15s ease;
+  flex-shrink: 0;
+}
+
+.navbar-chevron.open {
+  transform: rotate(-135deg) translateY(-2px);
+}
+
+.navbar-dropdown {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 8px);
+  background: var(--color-surface);
+  border: 1.5px solid var(--color-border);
+  border-radius: 10px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+  min-width: 100%;
+  width: 100%;
+  z-index: 100;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  padding: 0.25rem 0;
+}
+
+.navbar-dropdown-item {
+  display: block;
+  width: 100%;
+  padding: 0.5rem 1.1rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--color-text);
+  text-decoration: none;
+  background: none;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.12s ease;
+  line-height: 1.4;
+}
+
+.navbar-dropdown-item:hover {
+  background: rgba(196, 82, 30, 0.07);
+  color: var(--color-primary-text);
+  text-decoration: none;
+}
+
+.navbar-dropdown-logout {
+  color: var(--color-text-muted);
+}
+
+.navbar-dropdown-logout:hover {
+  color: #c0392b;
+  background: rgba(192, 57, 43, 0.07);
+}
+
+.navbar-dropdown-divider {
+  border-top: 1px solid var(--color-border);
+  margin: 0.25rem 0;
+}
+
+.navbar-inner .notification-tray {
+  position: static;
+}
+
+.navbar-inner .notification-panel {
+  position: absolute;
+  right: 1.5rem;
+  top: calc(100% - 0.875rem + 8px);
+  margin-top: 0;
+}
+
 .navbar-btn {
   font-size: 0.875rem;
   padding: 0.45rem 1.1rem;
@@ -95,6 +217,53 @@
   display: flex;
   gap: 1rem;
   margin: 0 auto;
+}
+
+.navbar-browse-link-wrap {
+  position: relative;
+}
+
+.navbar-hover-card {
+  position: absolute;
+  top: calc(100% + 10px);
+  left: 50%;
+  transform: translateX(-50%) translateY(4px);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s ease, transform 0.15s ease;
+  width: 210px;
+  background: var(--color-surface);
+  border: 1.5px solid var(--color-border);
+  border-radius: 10px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.1);
+  padding: 0.85rem 1rem;
+  z-index: 60;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.navbar-browse-link-wrap:hover .navbar-hover-card {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}
+
+.navbar-hover-icon {
+  font-size: 1.4rem;
+  line-height: 1;
+}
+
+.navbar-hover-title {
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: var(--color-text);
+}
+
+.navbar-hover-desc {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+  line-height: 1.4;
 }
 
 @media (max-width: 640px) {

--- a/app/frontend/src/components/Navbar.jsx
+++ b/app/frontend/src/components/Navbar.jsx
@@ -1,4 +1,4 @@
-import { useContext } from 'react';
+import { useContext, useState, useEffect, useRef } from 'react';
 import { Link, NavLink } from 'react-router-dom';
 import { AuthContext } from '../context/AuthContext';
 import NotificationTray from './NotificationTray';
@@ -6,32 +6,107 @@ import './Navbar.css';
 
 export default function Navbar() {
   const { user, logout } = useContext(AuthContext);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef(null);
+
+  useEffect(() => {
+    function handleClickOutside(e) {
+      if (menuRef.current && !menuRef.current.contains(e.target)) {
+        setMenuOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
 
   return (
     <nav className="navbar" aria-label="Site navigation">
       <div className="navbar-inner">
         <Link to="/" className="navbar-brand">Genipe</Link>
         <div className="navbar-browse-links">
-          <NavLink to="/recipes" className="navbar-link">Recipes</NavLink>
-          <NavLink to="/stories" className="navbar-link">Stories</NavLink>
-          <NavLink to="/map" className="navbar-link">Map</NavLink>
-          <NavLink to="/explore" className="navbar-link">Explore</NavLink>
+          <div className="navbar-browse-link-wrap">
+            <NavLink to="/recipes" className="navbar-link">Recipes</NavLink>
+            <div className="navbar-hover-card">
+              <span className="navbar-hover-icon">🍽️</span>
+              <strong className="navbar-hover-title">Recipes</strong>
+              <p className="navbar-hover-desc">Discover dishes from cultures around the world</p>
+            </div>
+          </div>
+          <div className="navbar-browse-link-wrap">
+            <NavLink to="/stories" className="navbar-link">Stories</NavLink>
+            <div className="navbar-hover-card">
+              <span className="navbar-hover-icon">📖</span>
+              <strong className="navbar-hover-title">Stories</strong>
+              <p className="navbar-hover-desc">Food memories and heritage passed down through generations</p>
+            </div>
+          </div>
+          <div className="navbar-browse-link-wrap">
+            <NavLink to="/map" className="navbar-link">Map</NavLink>
+            <div className="navbar-hover-card">
+              <span className="navbar-hover-icon">🗺️</span>
+              <strong className="navbar-hover-title">Map</strong>
+              <p className="navbar-hover-desc">Explore regional cuisines and traditions on an interactive map</p>
+            </div>
+          </div>
+          <div className="navbar-browse-link-wrap">
+            <NavLink to="/explore" className="navbar-link">Explore</NavLink>
+            <div className="navbar-hover-card">
+              <span className="navbar-hover-icon">🔍</span>
+              <strong className="navbar-hover-title">Explore</strong>
+              <p className="navbar-hover-desc">Find cultural food events and experiences near you</p>
+            </div>
+          </div>
         </div>
         <div className="navbar-links">
           {user ? (
             <>
-              <span className="navbar-username">@{user.username}</span>
               <NotificationTray />
-              <NavLink to="/inbox" className="navbar-link">Inbox</NavLink>
-              <Link to="/recipes/new" className="btn btn-outline navbar-btn">
-                New Recipe
-              </Link>
-              <Link to="/stories/new" className="btn btn-outline navbar-btn">
-                New Story
-              </Link>
-              <button className="btn btn-primary navbar-btn" onClick={logout}>
-                Log Out
-              </button>
+              <div className="navbar-user-menu" ref={menuRef}>
+                <button
+                  className="navbar-user-btn"
+                  onClick={() => setMenuOpen(o => !o)}
+                  aria-expanded={menuOpen}
+                  aria-haspopup="true"
+                >
+                  <span className="navbar-avatar">
+                    {user.username[0].toUpperCase()}
+                  </span>
+                  <span className="navbar-username">@{user.username}</span>
+                  <span className={`navbar-chevron${menuOpen ? ' open' : ''}`} aria-hidden="true" />
+                </button>
+                {menuOpen && (
+                  <div className="navbar-dropdown" role="menu">
+                    <Link
+                      to="/recipes/new"
+                      className="navbar-dropdown-item"
+                      onClick={() => setMenuOpen(false)}
+                    >
+                      New Recipe
+                    </Link>
+                    <Link
+                      to="/stories/new"
+                      className="navbar-dropdown-item"
+                      onClick={() => setMenuOpen(false)}
+                    >
+                      New Story
+                    </Link>
+                    <Link
+                      to="/inbox"
+                      className="navbar-dropdown-item"
+                      onClick={() => setMenuOpen(false)}
+                    >
+                      Inbox
+                    </Link>
+                    <div className="navbar-dropdown-divider" />
+                    <button
+                      className="navbar-dropdown-item navbar-dropdown-logout"
+                      onClick={() => { setMenuOpen(false); logout(); }}
+                    >
+                      Log Out
+                    </button>
+                  </div>
+                )}
+              </div>
             </>
           ) : (
             <>


### PR DESCRIPTION
## Summary

Navbar: The authenticated header was too crowded with @username, notification bell, Inbox, New Recipe, New Story, and Log Out all visible at once. Collapsed all auth-related actions into a single user menu dropdown (avatar + @username), keeping the notification bell standalone beside it.

Browse links: Added rich hover cards to Recipes, Stories, Map, and Explore nav links — each card shows an icon, bold title, and a short description of the page.

## Test plan

- [ ] Log in — navbar shows only avatar + @username button and notification bell on the right
- [ ] Click the user menu — dropdown opens with New Recipe, New Story, Inbox, Log Out
- [ ] Click outside the dropdown — it closes
- [ ] Hover over Recipes, Stories, Map, Explore — hover card appears with icon + description
- [ ] Log out via the dropdown — works correctly
- [ ] Verify notification bell still opens its panel independently