### PR TITLE
feat(mobile): show original message body in the reply banner on Q&A panel (#548)

### DIFF
--- a/app/mobile/src/components/recipe/RecipeCommentsSection.tsx
+++ b/app/mobile/src/components/recipe/RecipeCommentsSection.tsx
@@ -169,17 +169,24 @@ export function RecipeCommentsSection({ recipeId, qaEnabled }: Props) {
           ) : null}
           {replyTarget ? (
             <View style={styles.replyBanner}>
-              <Text style={styles.replyBannerText} numberOfLines={1}>
-                Replying to {replyTarget.author_username}
-              </Text>
-              <Pressable
-                onPress={() => setReplyTo(null)}
-                hitSlop={6}
-                accessibilityRole="button"
-                accessibilityLabel="Cancel reply"
-              >
-                <Text style={styles.replyBannerCancel}>Cancel</Text>
-              </Pressable>
+              <View style={styles.replyBannerHeader}>
+                <Text style={styles.replyBannerText} numberOfLines={1}>
+                  Replying to {replyTarget.author_username}
+                </Text>
+                <Pressable
+                  onPress={() => setReplyTo(null)}
+                  hitSlop={6}
+                  accessibilityRole="button"
+                  accessibilityLabel="Cancel reply"
+                >
+                  <Text style={styles.replyBannerCancel}>Cancel</Text>
+                </Pressable>
+              </View>
+              {replyTarget.body ? (
+                <Text style={styles.replyBannerBody} numberOfLines={2}>
+                  {replyTarget.body}
+                </Text>
+              ) : null}
             </View>
           ) : null}
           <TextInput
@@ -374,17 +381,28 @@ const styles = StyleSheet.create({
   typeText: { fontSize: 13, fontWeight: '700', color: tokens.colors.text },
   typeTextActive: { color: tokens.colors.textOnDark },
   replyBanner: {
+    padding: 10,
+    borderRadius: tokens.radius.md,
+    backgroundColor: tokens.colors.bg,
+    borderLeftWidth: 4,
+    borderLeftColor: tokens.colors.surfaceDark,
+    borderTopWidth: 1,
+    borderRightWidth: 1,
+    borderBottomWidth: 1,
+    borderTopColor: tokens.colors.surfaceDark,
+    borderRightColor: tokens.colors.surfaceDark,
+    borderBottomColor: tokens.colors.surfaceDark,
+    gap: 6,
+  },
+  replyBannerHeader: {
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
-    padding: 8,
-    borderRadius: tokens.radius.md,
-    backgroundColor: tokens.colors.primarySubtle,
-    borderWidth: 1,
-    borderColor: tokens.colors.primaryBorder,
+    gap: 8,
   },
-  replyBannerText: { flex: 1, fontSize: 13, fontWeight: '700', color: tokens.colors.primary },
-  replyBannerCancel: { fontSize: 13, fontWeight: '800', color: tokens.colors.primary, marginLeft: 8 },
+  replyBannerText: { flex: 1, fontSize: 13, fontWeight: '800', color: tokens.colors.text },
+  replyBannerCancel: { fontSize: 13, fontWeight: '800', color: tokens.colors.text, marginLeft: 8, textDecorationLine: 'underline' },
+  replyBannerBody: { fontSize: 13, color: tokens.colors.textMuted, fontStyle: 'italic', lineHeight: 18 },
   input: {
     minHeight: 70,
     borderWidth: 1.5,


### PR DESCRIPTION
## Summary
Closes #548. Tapping Reply on a comment used to show only "Replying to {username}" — the user had to scroll up to remember the message they were responding to. The banner now also includes a 2-line italic snippet of the parent comment's body, with a left accent bar to read as a quote.

## Files
- `components/recipe/RecipeCommentsSection.tsx` — reply banner restructured into a header row (username + Cancel) and a body line below; styles refreshed to palette-safe cream + `surfaceDark` border (the old `primarySubtle` / `primary` combination was hard to read after the palette swap).

## Test
- `npx tsc --noEmit` clean
- Local docker stack: opened a recipe with comments, tapped Reply on one — the banner shows the username, an underlined Cancel, and a 2-line snippet of the original body. Cancel still clears the reply state cleanly. No regression on the regular Post flow.

Closes #548