### PR TITLE
feat(mobile): allow creating a recipe without photo or video (#550)

### DIFF
--- a/app/mobile/src/components/recipe/RecipeVideoSection.tsx
+++ b/app/mobile/src/components/recipe/RecipeVideoSection.tsx
@@ -33,7 +33,7 @@ export function RecipeVideoSection({
 
   return (
     <View style={styles.section}>
-      <Text style={styles.sectionTitle}>Video</Text>
+      <Text style={styles.sectionTitle}>{requireSelection ? 'Video' : 'Video (optional)'}</Text>
 
       {hasRemoteOnly ? (
         <Text style={styles.videoHint}>

--- a/app/mobile/src/screens/RecipeCreateScreen.tsx
+++ b/app/mobile/src/screens/RecipeCreateScreen.tsx
@@ -45,14 +45,12 @@ export default function RecipeCreateScreen(_props: Props) {
     const next: {
       title?: string;
       description?: string;
-      video?: string;
       rows?: Record<string, { amount?: string; ingredient?: string; unit?: string }>;
       rowsTop?: string;
     } = {};
 
     if (!title.trim()) next.title = 'Title is required.';
     if (!description.trim()) next.description = 'Description is required.';
-    if (!localVideo) next.video = 'Please select a video.';
 
     if (!rows.length) {
       next.rowsTop = 'Add at least one ingredient.';
@@ -71,12 +69,11 @@ export default function RecipeCreateScreen(_props: Props) {
     }
 
     return next;
-  }, [title, description, rows, localVideo]);
+  }, [title, description, rows]);
 
   const isValid =
     !errors.title &&
     !errors.description &&
-    !errors.video &&
     !errors.rowsTop &&
     (!errors.rows || Object.keys(errors.rows).length === 0);
 
@@ -207,8 +204,8 @@ export default function RecipeCreateScreen(_props: Props) {
             Recipe upload
           </Text>
           <Text style={styles.lead}>
-            Add a title and description, ingredients, and a video. Ingredient and unit pickers load
-            from the same API as the web app.
+            Add a title and description, and at least one ingredient. A photo or video is optional —
+            you can share text-only recipes too.
           </Text>
 
           <View style={styles.section}>
@@ -293,9 +290,8 @@ export default function RecipeCreateScreen(_props: Props) {
             onPickPress={() => void pickVideo()}
             localVideo={localVideo}
             onClearLocal={() => setLocalVideo(null)}
-            requireSelection
+            requireSelection={false}
             attemptedSubmit={attemptedSubmit}
-            errorMessage={errors.video}
           />
 
           <Pressable


### PR DESCRIPTION
## Summary
Closes #550 (mobile side). Recipe creation used to block submit unless a video was picked, even though the image was already optional. Some users want to share quick text-only recipes — ideas, family stories — so both media fields are now fully optional. The backend already accepts a recipe without `image` / `video` (the JSON create call doesn't carry media; the multipart PATCH only fires when at least one is selected).

## Files
- `screens/RecipeCreateScreen.tsx` — drop the `video required` validation, drop the `errors.video` field, update the helper text to call out that photo and video are optional, pass `requireSelection={false}` to the video section.
- `components/recipe/RecipeVideoSection.tsx` — render the section title as "Video (optional)" when not required, so the optional state is obvious before the user tries to submit.

## Test
- `npx tsc --noEmit` clean
- Local docker stack: opened Create Recipe, filled title + description + one ingredient, skipped both image and video pickers, hit Submit → "Recipe published!" toast, recipe shows up in the feed with the placeholder thumbnail and "No video for this recipe." text on detail.
- Regression: also created a recipe with both image and video — uploads still go through via the multipart PATCH as before.

## Out of scope
Web side of #550 (someone else's lane). The issue stays open until the web change lands.

Closes #550 (mobile)