### PR TITLE
feat(mobile): shopping list affordance on recipe detail (#576)

### DIFF
--- a/app/mobile/package-lock.json
+++ b/app/mobile/package-lock.json
@@ -17,6 +17,7 @@
         "expo": "~54.0.0",
         "expo-asset": "~12.0.12",
         "expo-av": "~16.0.8",
+        "expo-clipboard": "~8.0.8",
         "expo-font": "~14.0.11",
         "expo-image-picker": "~17.0.10",
         "expo-status-bar": "~3.0.9",
@@ -4095,6 +4096,17 @@
         "react-native-web": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-clipboard": {
+      "version": "8.0.8",
+      "resolved": "https://registry.npmjs.org/expo-clipboard/-/expo-clipboard-8.0.8.tgz",
+      "integrity": "sha512-VKoBkHIpZZDJTB0jRO4/PZskHdMNOEz3P/41tmM6fDuODMpqhvyWK053X0ebspkxiawJX9lX33JXHBCvVsTTOA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-constants": {

--- a/app/mobile/package.json
+++ b/app/mobile/package.json
@@ -18,6 +18,7 @@
     "expo": "~54.0.0",
     "expo-asset": "~12.0.12",
     "expo-av": "~16.0.8",
+    "expo-clipboard": "~8.0.8",
     "expo-font": "~14.0.11",
     "expo-image-picker": "~17.0.10",
     "expo-status-bar": "~3.0.9",

--- a/app/mobile/src/screens/RecipeDetailScreen.tsx
+++ b/app/mobile/src/screens/RecipeDetailScreen.tsx
@@ -1,9 +1,11 @@
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import * as Clipboard from 'expo-clipboard';
 import { ResizeMode, Video } from 'expo-av';
 import { useEffect, useState } from 'react';
 import { Image, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useAuth } from '../context/AuthContext';
+import { useToast } from '../context/ToastContext';
 import { ErrorView } from '../components/ui/ErrorView';
 import { LoadingView } from '../components/ui/LoadingView';
 import { IngredientSubstitutesSheet } from '../components/recipe/IngredientSubstitutesSheet';
@@ -34,6 +36,8 @@ export default function RecipeDetailScreen({ route, navigation }: Props) {
   const [convertedByLine, setConvertedByLine] = useState<Record<string, ConvertedAmount>>({});
   const [convertingLoading, setConvertingLoading] = useState(false);
   const [checkedIds, setCheckedIds] = useState<Set<number>>(new Set());
+  const [showShoppingList, setShowShoppingList] = useState(false);
+  const { showToast } = useToast();
 
   useEffect(() => {
     let cancelled = false;
@@ -174,6 +178,26 @@ export default function RecipeDetailScreen({ route, navigation }: Props) {
   }
 
   const ingredients = recipe.ingredients ?? [];
+
+  const shoppingItems = ingredients
+    .filter((ri) => !checkedIds.has(ri.ingredient.id))
+    .map((ri) => ({
+      key: `shop-${ri.lineId ?? ri.ingredient.id}`,
+      name: ri.ingredient.name,
+      amount: String(ri.amount),
+      unit: ri.unit.name,
+    }));
+
+  async function copyShoppingList() {
+    if (shoppingItems.length === 0) return;
+    const text = shoppingItems.map((i) => `${i.name} — ${i.amount} ${i.unit}`).join('\n');
+    try {
+      await Clipboard.setStringAsync(text);
+      showToast('Shopping list copied to clipboard', 'success');
+    } catch {
+      showToast('Could not copy to clipboard', 'error');
+    }
+  }
 
   const authorObj =
     recipe.author && typeof recipe.author === 'object' && recipe.author.username && recipe.author.id != null
@@ -374,6 +398,59 @@ export default function RecipeDetailScreen({ route, navigation }: Props) {
               })}
             </View>
           )}
+
+          {isAuthenticated && ingredients.length > 0 ? (
+            <View style={styles.shoppingSection}>
+              <Pressable
+                onPress={() => setShowShoppingList((v) => !v)}
+                style={({ pressed }) => [styles.shoppingToggle, pressed && styles.pressed]}
+                accessibilityRole="button"
+                accessibilityLabel={
+                  showShoppingList ? 'Hide shopping list' : `Show shopping list with ${shoppingItems.length} items`
+                }
+              >
+                <Text style={styles.shoppingToggleText}>
+                  {showShoppingList
+                    ? 'Hide shopping list'
+                    : `Shopping list (${shoppingItems.length})`}
+                </Text>
+              </Pressable>
+
+              {showShoppingList ? (
+                <View style={styles.shoppingPanel}>
+                  <View style={styles.shoppingPanelHeader}>
+                    <Text style={styles.shoppingPanelTitle}>Shopping List</Text>
+                    {shoppingItems.length > 0 ? (
+                      <Pressable
+                        onPress={() => void copyShoppingList()}
+                        style={({ pressed }) => [styles.shoppingCopyBtn, pressed && styles.pressed]}
+                        accessibilityRole="button"
+                        accessibilityLabel="Copy shopping list to clipboard"
+                      >
+                        <Text style={styles.shoppingCopyBtnText}>Copy</Text>
+                      </Pressable>
+                    ) : null}
+                  </View>
+                  {shoppingItems.length === 0 ? (
+                    <Text style={styles.shoppingEmpty}>All ingredients are checked off!</Text>
+                  ) : (
+                    <View style={styles.shoppingList}>
+                      {shoppingItems.map((item) => (
+                        <View key={item.key} style={styles.shoppingItem}>
+                          <Text style={styles.shoppingItemName} numberOfLines={2}>
+                            {item.name}
+                          </Text>
+                          <Text style={styles.shoppingItemQty}>
+                            {item.amount} {item.unit}
+                          </Text>
+                        </View>
+                      ))}
+                    </View>
+                  )}
+                </View>
+              ) : null}
+            </View>
+          ) : null}
 
           <RecipeCommentsSection recipeId={id} qaEnabled={recipe.qa_enabled !== false} />
 
@@ -595,6 +672,60 @@ const styles = StyleSheet.create({
   },
   subBtnText: { fontSize: 12, fontWeight: '800', color: tokens.colors.textOnDark },
   pressed: { opacity: 0.85 },
+  shoppingSection: { marginTop: 18 },
+  shoppingToggle: {
+    alignSelf: 'flex-start',
+    paddingVertical: 8,
+    paddingHorizontal: 14,
+    borderRadius: tokens.radius.pill,
+    backgroundColor: tokens.colors.bg,
+    borderWidth: 1.5,
+    borderColor: tokens.colors.surfaceDark,
+  },
+  shoppingToggleText: { fontSize: 13, fontWeight: '800', color: tokens.colors.text, letterSpacing: 0.2 },
+  shoppingPanel: {
+    marginTop: 12,
+    padding: 14,
+    borderRadius: tokens.radius.lg,
+    backgroundColor: tokens.colors.bg,
+    borderWidth: 1,
+    borderColor: tokens.colors.surfaceDark,
+    gap: 10,
+  },
+  shoppingPanelHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 12,
+  },
+  shoppingPanelTitle: {
+    fontSize: 16,
+    fontWeight: '800',
+    color: tokens.colors.text,
+    fontFamily: tokens.typography.display.fontFamily,
+  },
+  shoppingCopyBtn: {
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    borderRadius: tokens.radius.pill,
+    backgroundColor: tokens.colors.accentGreen,
+    borderWidth: 1,
+    borderColor: tokens.colors.surfaceDark,
+  },
+  shoppingCopyBtnText: { fontSize: 12, fontWeight: '800', color: tokens.colors.textOnDark, letterSpacing: 0.3 },
+  shoppingEmpty: { fontSize: 14, color: tokens.colors.textMuted, fontStyle: 'italic' },
+  shoppingList: { gap: 8 },
+  shoppingItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 12,
+    paddingVertical: 6,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: tokens.colors.surfaceDark,
+  },
+  shoppingItemName: { flex: 1, fontSize: 14, color: tokens.colors.text, fontWeight: '700' },
+  shoppingItemQty: { fontSize: 13, color: tokens.colors.text, fontWeight: '600' },
   storiesSection: { marginTop: 28, paddingTop: 16, borderTopWidth: 1, borderTopColor: tokens.colors.primaryTint, gap: 12 },
   storyList: { gap: 10 },
 });


### PR DESCRIPTION
## Summary
Closes #576. Web shipped a per-recipe shopping list in M5 (#373, PR #437) — a button on the recipe page that lists the ingredients you haven't checked off yet, with a one-tap copy to clipboard. Mobile had the underlying check-off state via #372 + #529 but no shopping-list affordance, so users on the phone couldn't quickly grab the "still need to buy" subset of a recipe. This PR ports the same affordance to mobile, behaviour-for-behaviour with web.

## Files
- `screens/RecipeDetailScreen.tsx` — derive `shoppingItems` from `ingredients` filtered by `checkedIds`, add a "Shopping list (N)" pill below the ingredients list, render a collapsible panel with a Copy action and the unchecked lines (or the "All ingredients are checked off!" empty state). Hidden when not authenticated or when the recipe has no ingredients.
- `package.json` / `package-lock.json` — add `expo-clipboard ~8.0.8` for the Copy action (web uses `navigator.clipboard.writeText`; the mobile equivalent is `Clipboard.setStringAsync`).

## Behaviour parity with web (PR #437)
- Same filter rule: `ingredients.filter(ri => !checkedIds.has(ri.ingredient.id))`
- Same copy format: `name — amount unit`, one per line
- Same empty state copy: "All ingredients are checked off!"
- Same auth gate: button only shows when the user is logged in

## Test
- `npx tsc --noEmit` clean
- Local docker stack (had to rebuild the backend container — the running image was stale and 404'd `/api/recipes/<id>/checked-ingredients/`; after `docker compose up -d --build backend` the endpoint serves correctly): logged in as `ayse@example.com`, opened a recipe, the "Shopping list (N)" button appeared with N matching ingredient count. Tapped it → panel opened with all lines. Tapped Copy → toast "Shopping list copied to clipboard"; pasted the list into another app and the lines matched the recipe. Checked an ingredient off → reopened the panel, the line was gone and N decreased. Checked everything off → panel showed the empty-state copy.
- Regression: inline check-off flow on the ingredient list still works exactly as before; substitutes sheet, unit toggle, and edit pill all unaffected.

## Out of scope
- The web `is-sub` (substitution) badge isn't carried over — mobile's substitution flow is a modal sheet that doesn't persist a "this row is a sub" state, so there's nothing to badge here. Filed mentally for a follow-up if substitution persistence ever lands on mobile.

Closes #576