### PR TITLE
feat(backend): public user profile endpoint at /api/users/<username>/ (#582)

### DIFF
--- a/app/backend/apps/users/serializers.py
+++ b/app/backend/apps/users/serializers.py
@@ -40,6 +40,37 @@ class UserProfileSerializer(serializers.ModelSerializer):
         ]
 
 
+class PublicUserSerializer(serializers.ModelSerializer):
+    """Public-facing user profile (#582).
+
+    Excludes sensitive fields (email, is_contactable, password) so the same
+    payload is safe to return to anonymous visitors. `recipe_count` and
+    `story_count` reflect published content only.
+    """
+    recipe_count = serializers.SerializerMethodField()
+    story_count = serializers.SerializerMethodField()
+
+    class Meta:
+        model = User
+        fields = [
+            'username',
+            'bio',
+            'region',
+            'cultural_interests',
+            'religious_preferences',
+            'event_interests',
+            'created_at',
+            'recipe_count',
+            'story_count',
+        ]
+
+    def get_recipe_count(self, obj):
+        return obj.recipes.filter(is_published=True).count()
+
+    def get_story_count(self, obj):
+        return obj.stories.filter(is_published=True).count()
+
+
 class StringTagListField(serializers.ListField):
     """List of string tags; rejects non-string items instead of coercing."""
 

--- a/app/backend/apps/users/tests.py
+++ b/app/backend/apps/users/tests.py
@@ -488,3 +488,108 @@ class TokenRefreshTest(APITestCase):
         response = self.client.post('/api/auth/token/refresh/', {"refresh": bad_token})
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
         self.assertEqual(response.data['code'], 'token_not_valid')
+
+
+class PublicUserProfileTest(APITestCase):
+    """Tests for GET /api/users/<username>/ (Issue #582)."""
+
+    PUBLIC_FIELDS = [
+        'username', 'bio', 'region', 'cultural_interests',
+        'religious_preferences', 'event_interests', 'created_at',
+        'recipe_count', 'story_count',
+    ]
+    SENSITIVE_FIELDS = ['email', 'is_contactable', 'password']
+
+    def setUp(self):
+        self.alice = User.objects.create_user(
+            email='alice@example.com',
+            username='alice',
+            password='StrongPass123!',
+            bio='Loves slow cooking.',
+            region='Aegean',
+            cultural_interests=['Mediterranean cuisine'],
+            religious_preferences=['Halal'],
+            event_interests=['Wedding'],
+        )
+        self.bob = User.objects.create_user(
+            email='bob@example.com',
+            username='bob',
+            password='StrongPass123!',
+        )
+
+    def test_public_profile_returns_200_for_existing_user(self):
+        response = self.client.get('/api/users/alice/')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        for field in self.PUBLIC_FIELDS:
+            self.assertIn(field, response.data)
+        self.assertEqual(response.data['username'], 'alice')
+        self.assertEqual(response.data['bio'], 'Loves slow cooking.')
+        self.assertEqual(response.data['region'], 'Aegean')
+        self.assertEqual(response.data['cultural_interests'], ['Mediterranean cuisine'])
+        self.assertEqual(response.data['religious_preferences'], ['Halal'])
+        self.assertEqual(response.data['event_interests'], ['Wedding'])
+
+    def test_public_profile_excludes_sensitive_fields(self):
+        response = self.client.get('/api/users/alice/')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        for field in self.SENSITIVE_FIELDS:
+            self.assertNotIn(field, response.data)
+
+    def test_public_profile_404_for_unknown_username(self):
+        response = self.client.get('/api/users/ghost/')
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_public_profile_recipe_and_story_counts(self):
+        from apps.recipes.models import Recipe
+        from apps.stories.models import Story
+
+        Recipe.objects.create(
+            title='Alice Recipe 1', description='d', author=self.alice, is_published=True,
+        )
+        Recipe.objects.create(
+            title='Alice Recipe 2', description='d', author=self.alice, is_published=True,
+        )
+        Recipe.objects.create(
+            title='Alice Draft', description='d', author=self.alice, is_published=False,
+        )
+        Recipe.objects.create(
+            title='Bob Recipe', description='d', author=self.bob, is_published=True,
+        )
+        Story.objects.create(
+            title='Alice Story', body='b', author=self.alice, is_published=True,
+        )
+        Story.objects.create(
+            title='Alice Draft Story', body='b', author=self.alice, is_published=False,
+        )
+
+        response = self.client.get('/api/users/alice/')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['recipe_count'], 2)
+        self.assertEqual(response.data['story_count'], 1)
+
+        response = self.client.get('/api/users/bob/')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['recipe_count'], 1)
+        self.assertEqual(response.data['story_count'], 0)
+
+    def test_users_me_still_works(self):
+        login = self.client.post(
+            '/api/auth/login/',
+            {"email": "alice@example.com", "password": "StrongPass123!"},
+        )
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {login.data["access"]}')
+        response = self.client.get('/api/users/me/')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['email'], 'alice@example.com')
+        self.assertEqual(response.data['username'], 'alice')
+
+    def test_authenticated_visitor_to_other_profile_does_not_see_email(self):
+        login = self.client.post(
+            '/api/auth/login/',
+            {"email": "alice@example.com", "password": "StrongPass123!"},
+        )
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {login.data["access"]}')
+        response = self.client.get('/api/users/bob/')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        for field in self.SENSITIVE_FIELDS:
+            self.assertNotIn(field, response.data)

--- a/app/backend/apps/users/urls.py
+++ b/app/backend/apps/users/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
-from .views import RegisterView, LoginView, LogoutView, MeView, TokenRefreshView
+from .views import RegisterView, LoginView, LogoutView, MeView, PublicUserView, TokenRefreshView
 
 urlpatterns = [
     path('auth/register/', RegisterView.as_view(), name='register'),
@@ -7,5 +7,7 @@ urlpatterns = [
     path('auth/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
     path('auth/logout/', LogoutView.as_view(), name='logout'),
     path('auth/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
+    # `users/me/` must stay before `users/<username>/` so the literal route wins.
     path('users/me/', MeView.as_view(), name='me'),
+    path('users/<str:username>/', PublicUserView.as_view(), name='public-user-profile'),
 ]

--- a/app/backend/apps/users/views.py
+++ b/app/backend/apps/users/views.py
@@ -1,6 +1,6 @@
 from django.contrib.auth import authenticate, get_user_model
 from django.db import transaction
-from rest_framework import status, permissions
+from rest_framework import generics, status, permissions
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework_simplejwt.tokens import RefreshToken
@@ -9,6 +9,7 @@ from rest_framework_simplejwt.token_blacklist.models import OutstandingToken, Bl
 from .serializers import (
     RegisterSerializer,
     LoginSerializer,
+    PublicUserSerializer,
     UserProfileSerializer,
     UserPreferencesUpdateSerializer,
 )
@@ -117,3 +118,16 @@ class MeView(APIView):
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
         serializer.save()
         return Response(UserProfileSerializer(request.user).data)
+
+
+class PublicUserView(generics.RetrieveAPIView):
+    """Public profile lookup by username (#582).
+
+    Anonymous access allowed; returns 404 for unknown usernames. The response
+    shape is uniform across visitors and the profile owner; editable fields
+    remain on `users/me/`.
+    """
+    permission_classes = [permissions.AllowAny]
+    serializer_class = PublicUserSerializer
+    queryset = get_user_model().objects.all()
+    lookup_field = 'username'


### PR DESCRIPTION
## Summary
- Add `GET /api/users/<username>/` returning public profile fields and computed `recipe_count` / `story_count`.
- New `PublicUserSerializer` excludes `email`, `is_contactable`, `password`.
- Endpoint resolves by username, 404 for missing user, anonymous access allowed.

## Test plan
- [x] `python manage.py test apps.users` green (61 tests)
- [x] `python manage.py test` green (498 tests)
- [x] Manual: anonymous GET `/api/users/<existing>/` returns 200, sensitive fields absent
- [x] Manual: GET `/api/users/<unknown>/` returns 404
- [x] Manual: GET `/api/users/me/` still works (route ordering verified, `users/me/` registered before `users/<username>/`)

## Notes
- Response shape is uniform for visitors and the profile owner; editable fields remain on `users/me/`. Own-profile extras can be added later if needed without breaking visitor consumers.
- `recipe_count` and `story_count` count published items only so drafts stay hidden from public viewers.
- Foundation for the Cultural Passport feature (#583 will mount passport data under this username route).

Closes #582.