### PR TITLE
fix(mobile): stop silently losing data on recipe and story edit (#615)

### DIFF
--- a/app/mobile/src/components/recipe/buildRecipeUpdateFormData.ts
+++ b/app/mobile/src/components/recipe/buildRecipeUpdateFormData.ts
@@ -8,20 +8,21 @@ import type { LocalVideoSelection } from './RecipeVideoSection';
 export function buildRecipePatchJsonBody(input: {
   title: string;
   description: string;
-  region: string;
   qaEnabled: boolean;
   rows: AuthoringIngredientRow[];
 }): Record<string, unknown> {
   const validRows = input.rows.filter(
     (r) => r.ingredient.id != null && r.amount.trim() !== '' && r.unit.id != null,
   );
-  const regionTrim = input.region.trim();
-  const regionNum = regionTrim ? Number(regionTrim) : NaN;
 
+  // Region intentionally omitted from the patch body. The detail API exposes
+  // the region as a friendly NAME, not the FK pk we'd need to PATCH back.
+  // Including it here used to silently null the region on every edit because
+  // `Number("Aegean")` is `NaN`. Until a proper region picker lands, leaving
+  // the field out of the payload keeps the existing region untouched.
   return {
     title: input.title.trim(),
     description: input.description.trim(),
-    region: regionTrim && Number.isFinite(regionNum) ? regionNum : null,
     qa_enabled: input.qaEnabled,
     is_published: true,
     ingredients_write: validRows.map((r) => ({

--- a/app/mobile/src/screens/RecipeEditScreen.tsx
+++ b/app/mobile/src/screens/RecipeEditScreen.tsx
@@ -182,7 +182,6 @@ export default function RecipeEditScreen({ route, navigation }: Props) {
     const jsonBody = buildRecipePatchJsonBody({
       title,
       description,
-      region,
       qaEnabled,
       rows,
     });
@@ -322,12 +321,15 @@ export default function RecipeEditScreen({ route, navigation }: Props) {
           <Text style={styles.sectionTitle}>Region</Text>
           <TextInput
             value={region}
-            onChangeText={setRegion}
             placeholder="Region"
             placeholderTextColor="#94a3b8"
-            style={styles.input}
-            accessibilityLabel="Recipe region"
+            style={[styles.input, { opacity: 0.7 }]}
+            editable={false}
+            accessibilityLabel="Recipe region (read-only)"
           />
+          <Text style={styles.videoHint}>
+            Region cannot be changed from this screen yet. The original region is preserved.
+          </Text>
         </View>
 
         <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 18 }}>

--- a/app/mobile/src/screens/StoryEditScreen.tsx
+++ b/app/mobile/src/screens/StoryEditScreen.tsx
@@ -40,6 +40,9 @@ export default function StoryEditScreen({ route, navigation }: Props) {
   const [linkedRecipe, setLinkedRecipe] = useState<RecipeLink | null>(null);
   const [published, setPublished] = useState(true);
   const [imageUri, setImageUri] = useState<string | null>(null);
+  /** Remote URL of the image when the story was loaded; used to detect whether
+   * the user picked a new local file or is still showing the server image. */
+  const [initialImageUrl, setInitialImageUrl] = useState<string | null>(null);
 
   const [attemptedSubmit, setAttemptedSubmit] = useState(false);
   const [submitting, setSubmitting] = useState(false);
@@ -59,6 +62,7 @@ export default function StoryEditScreen({ route, navigation }: Props) {
     }
     setPublished(story.is_published !== false);
     setImageUri(story.image ?? null);
+    setInitialImageUrl(story.image ?? null);
   }, []);
 
   async function pickImage() {
@@ -132,7 +136,11 @@ export default function StoryEditScreen({ route, navigation }: Props) {
           linked_recipe: linkedRecipe ? Number(linkedRecipe.id) : null,
           is_published: published,
         });
-        if (imageUri) {
+        // Only upload when the user picked a NEW local file. The remote URL
+        // loaded from the server stays as `imageUri` until they pick something,
+        // and re-uploading that URL as if it were a local file used to corrupt
+        // the image / fail on Android.
+        if (imageUri && imageUri !== initialImageUrl) {
           await updateStoryImageById(String(id), { uri: imageUri });
         }
         showToast('Story updated!', 'success');


### PR DESCRIPTION
## Summary
Closes #615. Two edit screens were silently corrupting or dropping data on save because state shape didn't match the payload contract. Both bugs were invisible to the user — no error, no toast, the save "succeeded" but data was lost.

## Bugs fixed

### 1. RecipeEdit silently nulled the region on every save
The recipe detail API exposes region as a friendly NAME string ("Aegean", "Black Sea"). The edit screen populated a TextInput with that string and on save did `Number(value)` → `NaN` → sent `region: null` to the backend. Every recipe edit nuked the region tag, even if the user only fixed a typo in the title.

**Fix**: drop the `region` field from the patch payload entirely. The TextInput is now read-only with a helper note ("Region cannot be changed from this screen yet. The original region is preserved."). Until a proper region picker lands, omitting the field from the body is the safest behaviour — the backend keeps the existing region.

### 2. StoryEdit re-uploaded the existing remote image as a local file on every save
When loaded for editing, `imageUri` was set to the remote URL. On save, that URL was wrapped in FormData like a local file — wasteful download-and-reupload on iOS, outright failure on some Android paths.

**Fix**: track `initialImageUrl` separately and only call `updateStoryImageById` when `imageUri !== initialImageUrl` (i.e., the user actually picked a new local file).

## Files
- `components/recipe/buildRecipeUpdateFormData.ts` — drop `region` parameter and field; comment explaining why.
- `screens/RecipeEditScreen.tsx` — region TextInput → `editable={false}` with helper text; drop `region` from the builder call.
- `screens/StoryEditScreen.tsx` — add `initialImageUrl` state, only upload image when it differs from the loaded value.

## Test
- `npx tsc --noEmit` clean
- Local docker stack:
  - Recipe edit on a `ayse@example.com` recipe with region "Black Sea": changed only the title → after save, region survived on the detail screen. Repeated 3 times — region stable.
  - Story edit on a story with an existing image: changed only the title → save fired exactly one PATCH (no second image upload). Then picked a new local image → save fired the JSON PATCH plus the image PATCH as expected.
- No regression on Create flows (untouched).

## Out of scope (follow-ups)
- A proper region picker on the recipe edit form so users can change region intentionally.
- Stories don't even have a region field on the create/edit form yet — separate issue coming.

Closes #615