### PR TITLE
fix(mobile): prevent duplicate recipe submissions and navigate after success (#616)

### DIFF
--- a/app/mobile/src/screens/RecipeCreateScreen.tsx
+++ b/app/mobile/src/screens/RecipeCreateScreen.tsx
@@ -19,7 +19,7 @@ import { tokens } from '../theme';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'RecipeCreate'>;
 
-export default function RecipeCreateScreen(_props: Props) {
+export default function RecipeCreateScreen({ navigation }: Props) {
   const { showToast } = useToast();
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
@@ -40,6 +40,7 @@ export default function RecipeCreateScreen(_props: Props) {
   });
 
   const [attemptedSubmit, setAttemptedSubmit] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
 
   const errors = useMemo(() => {
     const next: {
@@ -139,8 +140,9 @@ export default function RecipeCreateScreen(_props: Props) {
 
   function submit() {
     setAttemptedSubmit(true);
-    if (!isValid) return;
+    if (!isValid || submitting) return;
 
+    setSubmitting(true);
     const payload = {
       description: description.trim(),
       qa_enabled: qaEnabled,
@@ -187,8 +189,11 @@ export default function RecipeCreateScreen(_props: Props) {
           await apiPatchFormData(`/api/recipes/${created.id}/`, fd);
         }
         showToast('Recipe published!', 'success');
+        navigation.navigate('RecipeDetail', { id: String(created.id) });
       } catch {
         showToast('Failed to publish recipe. Please try again.', 'error');
+      } finally {
+        setSubmitting(false);
       }
     })();
   }
@@ -309,11 +314,16 @@ export default function RecipeCreateScreen(_props: Props) {
 
           <Pressable
             onPress={submit}
-            style={({ pressed }) => [styles.primaryButton, pressed && styles.buttonPressed]}
+            disabled={submitting}
+            style={({ pressed }) => [
+              styles.primaryButton,
+              pressed && styles.buttonPressed,
+              submitting && { opacity: 0.7 },
+            ]}
             accessibilityRole="button"
             accessibilityLabel="Submit recipe"
           >
-            <Text style={styles.primaryButtonText}>Submit</Text>
+            <Text style={styles.primaryButtonText}>{submitting ? 'Publishing…' : 'Submit'}</Text>
           </Pressable>
 
           <View style={styles.summary}>

--- a/app/mobile/src/screens/RecipeEditScreen.tsx
+++ b/app/mobile/src/screens/RecipeEditScreen.tsx
@@ -58,6 +58,7 @@ export default function RecipeEditScreen({ route, navigation }: Props) {
   const [remoteVideoUrl, setRemoteVideoUrl] = useState<string | null>(null);
 
   const [attemptedSubmit, setAttemptedSubmit] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
 
   const applyRecipe = useCallback((recipe: RecipeDetail) => {
     setTitle(recipe.title ?? '');
@@ -177,8 +178,9 @@ export default function RecipeEditScreen({ route, navigation }: Props) {
 
   function submit() {
     setAttemptedSubmit(true);
-    if (!isValid) return;
+    if (!isValid || submitting) return;
 
+    setSubmitting(true);
     const jsonBody = buildRecipePatchJsonBody({
       title,
       description,
@@ -207,6 +209,8 @@ export default function RecipeEditScreen({ route, navigation }: Props) {
         setTimeout(() => navigation.navigate('RecipeDetail', { id }), 1500);
       } catch {
         showToast('Failed to save changes. Please try again.', 'error');
+      } finally {
+        setSubmitting(false);
       }
     })();
   }
@@ -386,11 +390,16 @@ export default function RecipeEditScreen({ route, navigation }: Props) {
 
         <Pressable
           onPress={submit}
-          style={({ pressed }) => [styles.primaryButton, pressed && styles.buttonPressed]}
+          disabled={submitting}
+          style={({ pressed }) => [
+            styles.primaryButton,
+            pressed && styles.buttonPressed,
+            submitting && { opacity: 0.7 },
+          ]}
           accessibilityRole="button"
           accessibilityLabel="Save recipe changes"
         >
-          <Text style={styles.primaryButtonText}>Save changes</Text>
+          <Text style={styles.primaryButtonText}>{submitting ? 'Saving…' : 'Save changes'}</Text>
         </Pressable>
       </ScrollView>
     </SafeAreaView>


### PR DESCRIPTION
## Summary
Closes #616. RecipeCreate and RecipeEdit had no `submitting` flag, so rapid taps fired multiple concurrent POST/PATCH requests — the user could create duplicate recipes by accidentally double-tapping. RecipeCreate also never navigated after success: `navigation` was never destructured (`_props`), so the user just sat on the filled-in form with a "Recipe published!" toast and no way to verify the result short of opening the feed. StoryCreate already implements this pattern correctly and was the reference.

## Files
- `screens/RecipeCreateScreen.tsx` — destructure `navigation` from props; add a `submitting` state; gate `submit()` with `if (!isValid || submitting) return; setSubmitting(true);`; navigate to `RecipeDetail` with the freshly created id after success; reset `submitting` in a `finally` block; submit button shows "Publishing…" and is `disabled` while submitting.
- `screens/RecipeEditScreen.tsx` — same pattern: `submitting` state, gate, `disabled` button + "Saving…" label, `finally` reset. Edit already navigated via the existing `setTimeout` after a 1.5s delay (the cleanup of that timeout is still on M-8).

## Test
- `npx tsc --noEmit` clean
- Local docker stack as `ayse@example.com`:
  - **Create**: filled in title + one ingredient, spam-tapped Submit 5x in 1s — button switched to "Publishing…" and disabled, network log showed exactly 1 POST + 0 multipart PATCHes (no media), then auto-navigated to the new recipe's detail. Feed showed 1 new recipe, no duplicates.
  - **Edit**: changed the title on one of my recipes → tapped Save once → button became "Saving…" + disabled → 1 PATCH in the network log → after the existing 1.5s delay, navigated to RecipeDetail with the change reflected.

## Out of scope
- The `setTimeout` on RecipeEdit isn't cleaned up on unmount — covered separately under M-8 (#622).
- StoryCreate / StoryEdit already had this guard, no changes needed there.

Closes #616