### PR TITLE
chore(backend): coverage tooling and gap-filling tests (#530)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,10 @@ app/frontend/.env.production
 .vscode/
 .idea/
 *.swp
+
+# Coverage artifacts
+app/backend/.coverage
+app/backend/htmlcov/
+app/backend/coverage_baseline.txt
+.coverage
+htmlcov/

--- a/app/backend/.coveragerc
+++ b/app/backend/.coveragerc
@@ -1,0 +1,13 @@
+[run]
+source = apps
+omit =
+    */migrations/*
+    */tests*
+    manage.py
+
+[report]
+exclude_lines =
+    pragma: no cover
+    def __repr__
+    raise NotImplementedError
+    if TYPE_CHECKING:

--- a/app/backend/apps/common/tests_middleware.py
+++ b/app/backend/apps/common/tests_middleware.py
@@ -40,3 +40,30 @@ class MiddlewareTests(TestCase):
         response = self.middleware.process_request(request)
         self.assertIsNone(response)
         self.assertEqual(request.user, self.user)
+
+    def test_middleware_authenticates_valid_jwt(self):
+        """A valid Bearer token in the header attaches the user (#530 gap)."""
+        from rest_framework_simplejwt.tokens import RefreshToken
+        access = str(RefreshToken.for_user(self.user).access_token)
+        request = self.factory.post(
+            '/api/some-endpoint/',
+            HTTP_AUTHORIZATION=f'Bearer {access}',
+        )
+        response = self.middleware.process_request(request)
+        self.assertIsNone(response)
+        self.assertEqual(request.user, self.user)
+
+    def test_middleware_handles_malformed_jwt_gracefully(self):
+        """A malformed token does not crash; the request continues unauthenticated.
+
+        The downstream 401 enforcement still fires because no user was attached,
+        but the middleware itself must not propagate the JWT decode error.
+        """
+        request = self.factory.post(
+            '/api/some-endpoint/',
+            HTTP_AUTHORIZATION='Bearer not.a.valid.jwt',
+        )
+        response = self.middleware.process_request(request)
+        # No authenticated user, so the write-method guard kicks in with 401
+        self.assertIsInstance(response, JsonResponse)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)

--- a/app/backend/apps/messaging/tests_coverage_gap.py
+++ b/app/backend/apps/messaging/tests_coverage_gap.py
@@ -1,0 +1,182 @@
+"""Coverage-gap tests for the messaging app (#530).
+
+Targets uncovered branches in views.py and models.py that the existing
+suite does not exercise:
+
+- thread creation error paths (missing other_user_id, user not found, self-thread)
+- send action body validation (empty/missing body)
+- delete on an already-soft-deleted message
+- inbox ordering by last_message_at (most recent thread first)
+- __str__ representations on Thread / ThreadParticipant / Message
+"""
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from .models import Message, Thread, ThreadParticipant
+
+User = get_user_model()
+
+
+def _user(username):
+    return User.objects.create_user(
+        username=username,
+        email=f"{username}@test.com",
+        password="TestPass123!",
+    )
+
+
+class ThreadCreateErrorPathTests(APITestCase):
+    """Covers the 400 / 404 / 403 branches of ThreadViewSet.create."""
+
+    def setUp(self):
+        self.user1 = _user("u1")
+        self.user2 = _user("u2")
+        self.client.force_authenticate(user=self.user1)
+        self.url = reverse('thread-list')
+
+    def test_missing_other_user_id_returns_400(self):
+        res = self.client.post(self.url, {})
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('other_user_id', res.data)
+
+    def test_unknown_other_user_id_returns_404(self):
+        res = self.client.post(self.url, {'other_user_id': 999999})
+        self.assertEqual(res.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertIn('other_user_id', res.data)
+
+    def test_thread_with_self_returns_400(self):
+        res = self.client.post(self.url, {'other_user_id': self.user1.id})
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('other_user_id', res.data)
+
+
+class SendValidationTests(APITestCase):
+    """Covers the serializer-error branch of ThreadViewSet.send."""
+
+    def setUp(self):
+        self.user1 = _user("send1")
+        self.user2 = _user("send2")
+        self.thread = Thread.objects.create()
+        ThreadParticipant.objects.create(thread=self.thread, user=self.user1)
+        ThreadParticipant.objects.create(thread=self.thread, user=self.user2)
+        self.client.force_authenticate(user=self.user1)
+
+    def test_missing_body_returns_400(self):
+        url = reverse('thread-send', args=[self.thread.id])
+        res = self.client.post(url, {})
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('body', res.data)
+
+    def test_empty_body_returns_400(self):
+        url = reverse('thread-send', args=[self.thread.id])
+        res = self.client.post(url, {'body': ''})
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('body', res.data)
+
+
+class MessageDeleteIdempotencyTests(APITestCase):
+    """Covers the already-deleted branch of MessageViewSet.destroy."""
+
+    def setUp(self):
+        self.user1 = _user("del1")
+        self.user2 = _user("del2")
+        self.thread = Thread.objects.create()
+        ThreadParticipant.objects.create(thread=self.thread, user=self.user1)
+        ThreadParticipant.objects.create(thread=self.thread, user=self.user2)
+        self.msg = Message.objects.create(
+            thread=self.thread, sender=self.user1, body="hello",
+        )
+
+    def test_delete_already_deleted_message_returns_400(self):
+        self.msg.soft_delete()
+        self.client.force_authenticate(user=self.user1)
+        url = reverse('message-detail', args=[self.msg.id])
+        res = self.client.delete(url)
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('detail', res.data)
+
+
+class InboxOrderingTests(APITestCase):
+    """Inbox lists threads ordered by last_message_at descending."""
+
+    def setUp(self):
+        self.me = _user("inbox-me")
+        self.peer1 = _user("inbox-peer1")
+        self.peer2 = _user("inbox-peer2")
+        self.peer3 = _user("inbox-peer3")
+        self.client.force_authenticate(user=self.me)
+
+    def _make_thread(self, other, last_at):
+        t = Thread.objects.create()
+        ThreadParticipant.objects.create(thread=t, user=self.me)
+        ThreadParticipant.objects.create(thread=t, user=other)
+        Thread.objects.filter(pk=t.pk).update(last_message_at=last_at)
+        return t
+
+    def test_inbox_orders_most_recent_first(self):
+        now = timezone.now()
+        old = self._make_thread(self.peer1, now - timezone.timedelta(hours=2))
+        newest = self._make_thread(self.peer2, now)
+        middle = self._make_thread(self.peer3, now - timezone.timedelta(hours=1))
+
+        res = self.client.get(reverse('thread-list'))
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        ids = [t['id'] for t in res.data]
+        self.assertEqual(ids, [newest.id, middle.id, old.id])
+
+    def test_inbox_excludes_threads_user_is_not_in(self):
+        not_mine = Thread.objects.create()
+        ThreadParticipant.objects.create(thread=not_mine, user=self.peer1)
+        ThreadParticipant.objects.create(thread=not_mine, user=self.peer2)
+
+        res = self.client.get(reverse('thread-list'))
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        ids = [t['id'] for t in res.data]
+        self.assertNotIn(not_mine.id, ids)
+
+
+class UnreadCountEdgeCaseTests(APITestCase):
+    """Soft-deleted messages do not contribute to the unread count."""
+
+    def setUp(self):
+        self.me = _user("unread-me")
+        self.peer = _user("unread-peer")
+        self.thread = Thread.objects.create()
+        ThreadParticipant.objects.create(thread=self.thread, user=self.me)
+        ThreadParticipant.objects.create(thread=self.thread, user=self.peer)
+        self.client.force_authenticate(user=self.me)
+
+    def test_soft_deleted_message_does_not_count_as_unread(self):
+        m1 = Message.objects.create(thread=self.thread, sender=self.peer, body="one")
+        Message.objects.create(thread=self.thread, sender=self.peer, body="two")
+        m1.soft_delete()
+
+        res = self.client.get(reverse('thread-list'))
+        self.assertEqual(res.data[0]['unread_count'], 1)
+
+
+class ModelStringRepresentationTests(APITestCase):
+    """Pin the __str__ output of messaging models so admin remains debuggable."""
+
+    def test_thread_str(self):
+        t = Thread.objects.create()
+        self.assertEqual(str(t), f"Thread #{t.pk}")
+
+    def test_thread_participant_str(self):
+        u = _user("strp")
+        t = Thread.objects.create()
+        tp = ThreadParticipant.objects.create(thread=t, user=u)
+        self.assertEqual(
+            str(tp),
+            f"ThreadParticipant(thread={t.pk}, user={u.pk})",
+        )
+
+    def test_message_str(self):
+        u = _user("strm")
+        t = Thread.objects.create()
+        ThreadParticipant.objects.create(thread=t, user=u)
+        m = Message.objects.create(thread=t, sender=u, body="hi")
+        self.assertEqual(str(m), f"Message #{m.pk} in Thread #{t.pk}")

--- a/app/backend/apps/notifications/tests_triggers.py
+++ b/app/backend/apps/notifications/tests_triggers.py
@@ -1,0 +1,267 @@
+"""Coverage-gap tests for the notifications app (#530).
+
+Targets uncovered branches in views.py and signals.py:
+
+- NotificationViewSet.mark_read: success path + cross-user 403
+- NotificationViewSet.mark_all_read: bulk update behavior
+- DeviceTokenView.post: create vs. re-claim, empty body validation
+- signals._send_expo_push: invocation path when DeviceTokens exist
+- model __str__ representations for Notification / DeviceToken
+"""
+from unittest import mock
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from apps.notifications.models import DeviceToken, Notification
+from apps.recipes.models import Comment, Recipe, Region
+
+User = get_user_model()
+
+
+def _user(username):
+    return User.objects.create_user(
+        username=username,
+        email=f"{username}@test.com",
+        password="TestPass123!",
+    )
+
+
+def _recipe(author):
+    return Recipe.objects.create(
+        title=f"{author.username}'s recipe",
+        description="desc",
+        author=author,
+        region=Region.objects.first(),
+        qa_enabled=True,
+        is_published=True,
+    )
+
+
+class MarkReadActionTests(APITestCase):
+    """POST /api/notifications/<id>/read/ — single notification flag."""
+
+    def setUp(self):
+        self.alice = _user("notif-alice")
+        self.bob = _user("notif-bob")
+        self.recipe = _recipe(self.alice)
+        # Triggering a question by Bob creates a Notification for Alice
+        Comment.objects.create(
+            recipe=self.recipe,
+            author=self.bob,
+            body="how long?",
+            type="QUESTION",
+        )
+        self.notif = Notification.objects.get(recipient=self.alice)
+
+    def test_recipient_can_mark_own_notification_read(self):
+        self.client.force_authenticate(user=self.alice)
+        url = reverse('notification-mark-read', args=[self.notif.id])
+        res = self.client.post(url)
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertTrue(res.data['is_read'])
+        self.notif.refresh_from_db()
+        self.assertTrue(self.notif.is_read)
+
+    def test_cross_user_cannot_see_notification(self):
+        """A different user's notification is not in their queryset (404)."""
+        self.client.force_authenticate(user=self.bob)
+        url = reverse('notification-mark-read', args=[self.notif.id])
+        res = self.client.post(url)
+        self.assertEqual(res.status_code, status.HTTP_404_NOT_FOUND)
+        self.notif.refresh_from_db()
+        self.assertFalse(self.notif.is_read)
+
+
+class MarkAllReadActionTests(APITestCase):
+    """POST /api/notifications/read-all/ — bulk mark."""
+
+    def setUp(self):
+        self.alice = _user("readall-alice")
+        self.bob = _user("readall-bob")
+        self.recipe = _recipe(self.alice)
+
+    def test_marks_only_unread_owned_notifications(self):
+        # Two unread notifications for Alice
+        Comment.objects.create(
+            recipe=self.recipe, author=self.bob, body="q1", type="QUESTION",
+        )
+        Comment.objects.create(
+            recipe=self.recipe, author=self.bob, body="q2", type="QUESTION",
+        )
+        # An unrelated notification for Bob should remain untouched
+        other_recipe = _recipe(self.bob)
+        Comment.objects.create(
+            recipe=other_recipe, author=self.alice, body="q3", type="QUESTION",
+        )
+
+        self.client.force_authenticate(user=self.alice)
+        url = reverse('notification-mark-all-read')
+        res = self.client.post(url)
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertEqual(res.data['marked_read'], 2)
+
+        # Bob's notification still unread
+        self.assertFalse(Notification.objects.get(recipient=self.bob).is_read)
+        # All of Alice's notifications are read
+        self.assertEqual(
+            Notification.objects.filter(recipient=self.alice, is_read=False).count(),
+            0,
+        )
+
+    def test_returns_zero_when_no_unread(self):
+        self.client.force_authenticate(user=self.alice)
+        url = reverse('notification-mark-all-read')
+        res = self.client.post(url)
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertEqual(res.data['marked_read'], 0)
+
+
+class DeviceTokenViewTests(APITestCase):
+    """POST /api/notifications/tokens/ — register / re-claim Expo tokens."""
+
+    def setUp(self):
+        self.alice = _user("dev-alice")
+        self.bob = _user("dev-bob")
+        self.url = reverse('device-token')
+
+    def test_create_returns_201(self):
+        self.client.force_authenticate(user=self.alice)
+        res = self.client.post(self.url, {'token': 'ExponentPushToken[ABC]'})
+        self.assertEqual(res.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(res.data['token'], 'ExponentPushToken[ABC]')
+        self.assertTrue(
+            DeviceToken.objects.filter(
+                token='ExponentPushToken[ABC]', user=self.alice,
+            ).exists(),
+        )
+
+    def test_reclaim_existing_token_returns_200(self):
+        DeviceToken.objects.create(user=self.bob, token='ExponentPushToken[REUSE]')
+        self.client.force_authenticate(user=self.alice)
+        res = self.client.post(self.url, {'token': 'ExponentPushToken[REUSE]'})
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        # Token row was rebound to alice (only one row per token)
+        token = DeviceToken.objects.get(token='ExponentPushToken[REUSE]')
+        self.assertEqual(token.user, self.alice)
+
+    def test_missing_token_returns_400(self):
+        self.client.force_authenticate(user=self.alice)
+        res = self.client.post(self.url, {})
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('token', res.data)
+
+    def test_whitespace_only_token_returns_400(self):
+        self.client.force_authenticate(user=self.alice)
+        res = self.client.post(self.url, {'token': '   '})
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('token', res.data)
+
+    def test_anonymous_rejected(self):
+        res = self.client.post(self.url, {'token': 'ExponentPushToken[X]'})
+        self.assertEqual(res.status_code, status.HTTP_401_UNAUTHORIZED)
+
+
+class PushNotificationHelperTests(TestCase):
+    """signals._send_expo_push is invoked when the recipient has tokens.
+
+    We patch it to confirm the dispatch happens — the real Expo SDK call is
+    mocked out so we don't depend on network or the SDK at test time.
+    """
+
+    def setUp(self):
+        self.author = _user("push-author")
+        self.questioner = _user("push-questioner")
+        self.recipe = _recipe(self.author)
+
+    def test_send_push_called_on_question_when_author_has_token(self):
+        DeviceToken.objects.create(
+            user=self.author, token='ExponentPushToken[AUTHOR]',
+        )
+        with mock.patch('apps.notifications.signals._send_expo_push') as send:
+            Comment.objects.create(
+                recipe=self.recipe,
+                author=self.questioner,
+                body="any tips?",
+                type="QUESTION",
+            )
+        send.assert_called_once()
+        args, kwargs = send.call_args
+        self.assertEqual(kwargs['tokens'], ['ExponentPushToken[AUTHOR]'])
+        self.assertIn(self.recipe.title, kwargs['body'])
+
+    def test_send_push_called_on_reply_when_asker_has_token(self):
+        question = Comment.objects.create(
+            recipe=self.recipe,
+            author=self.questioner,
+            body="?",
+            type="QUESTION",
+        )
+        DeviceToken.objects.create(
+            user=self.questioner, token='ExponentPushToken[ASKER]',
+        )
+        replier = _user("push-replier")
+        with mock.patch('apps.notifications.signals._send_expo_push') as send:
+            Comment.objects.create(
+                recipe=self.recipe,
+                author=replier,
+                parent_comment=question,
+                body="here you go",
+                type="COMMENT",
+            )
+        send.assert_called_once()
+        _, kwargs = send.call_args
+        self.assertEqual(kwargs['tokens'], ['ExponentPushToken[ASKER]'])
+
+    def test_send_push_skipped_when_recipient_has_no_token(self):
+        with mock.patch('apps.notifications.signals._send_expo_push') as send:
+            Comment.objects.create(
+                recipe=self.recipe,
+                author=self.questioner,
+                body="any tips?",
+                type="QUESTION",
+            )
+        send.assert_not_called()
+
+    def test_send_expo_push_no_ops_when_sdk_missing(self):
+        """If exponent_server_sdk import fails, the helper returns without raising."""
+        from apps.notifications import signals
+
+        # Force ImportError on the SDK import inside the helper
+        import builtins
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == 'exponent_server_sdk':
+                raise ImportError("simulated missing SDK")
+            return real_import(name, *args, **kwargs)
+
+        with mock.patch.object(builtins, '__import__', side_effect=fake_import):
+            # Should return cleanly, no exception
+            signals._send_expo_push(['ExponentPushToken[X]'], 'title', 'body')
+
+
+class NotificationModelStrTests(TestCase):
+    """Pin __str__ output for Notification and DeviceToken."""
+
+    def test_notification_str(self):
+        alice = _user("nstr-alice")
+        bob = _user("nstr-bob")
+        recipe = _recipe(alice)
+        n = Notification.objects.create(
+            recipient=alice, actor=bob, recipe=recipe, message="hi there",
+        )
+        self.assertIn(alice.username, str(n))
+        self.assertIn("hi there", str(n))
+
+    def test_device_token_str(self):
+        alice = _user("tstr-alice")
+        token_value = 'ExponentPushToken[1234567890ABCDEFGHIJ]'
+        t = DeviceToken.objects.create(user=alice, token=token_value)
+        s = str(t)
+        self.assertIn(alice.username, s)
+        # Truncated to 30 chars per __str__
+        self.assertIn(token_value[:30], s)

--- a/app/backend/apps/users/tests_role_permissions.py
+++ b/app/backend/apps/users/tests_role_permissions.py
@@ -1,0 +1,100 @@
+"""Coverage-gap tests for the users app (#530).
+
+Targets uncovered branches in users/models.py and users/views.py:
+
+- UserManager.create_user: ValueError when email or username is missing
+- TokenRefreshView: OutstandingToken.DoesNotExist branch
+- TokenRefreshView: generic Exception branch (e.g. user referenced by token deleted)
+- Role choices: superuser default, role assignment, role enum surface area
+"""
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from rest_framework import status
+from rest_framework.test import APITestCase
+from rest_framework_simplejwt.tokens import RefreshToken
+from rest_framework_simplejwt.token_blacklist.models import OutstandingToken
+
+User = get_user_model()
+
+
+class UserManagerEdgeCaseTests(TestCase):
+    """Validation branches of the custom UserManager.create_user."""
+
+    def test_create_user_without_email_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            User.objects.create_user(email='', username='someone', password='x')
+        self.assertIn('Email', str(ctx.exception))
+
+    def test_create_user_without_username_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            User.objects.create_user(email='a@b.com', username='', password='x')
+        self.assertIn('Username', str(ctx.exception))
+
+    def test_create_user_normalizes_email_domain(self):
+        u = User.objects.create_user(
+            email='Test@EXAMPLE.com', username='normal-eml', password='x',
+        )
+        # BaseUserManager.normalize_email lowercases the domain part
+        self.assertEqual(u.email, 'Test@example.com')
+
+    def test_create_superuser_sets_admin_role_and_flags(self):
+        admin = User.objects.create_superuser(
+            email='su@example.com', username='su', password='x',
+        )
+        self.assertEqual(admin.role, User.Role.ADMIN)
+        self.assertTrue(admin.is_staff)
+        self.assertTrue(admin.is_superuser)
+
+
+class RoleChoicesTests(TestCase):
+    """Role values can be assigned and round-trip through the DB."""
+
+    def test_role_choices_surface(self):
+        # Pin the enum surface area so dropping a role becomes a visible diff
+        values = {choice[0] for choice in User.Role.choices}
+        self.assertEqual(values, {'user', 'moderator', 'admin'})
+
+    def test_assigning_moderator_role_persists(self):
+        u = User.objects.create_user(
+            email='mod@example.com', username='moduser', password='x',
+        )
+        u.role = User.Role.MODERATOR
+        u.save()
+        u.refresh_from_db()
+        self.assertEqual(u.role, User.Role.MODERATOR)
+
+
+class TokenRefreshEdgeCaseTests(APITestCase):
+    """Pin the rarely-hit error branches of TokenRefreshView.post."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            email='ref-edge@example.com',
+            username='ref-edge',
+            password='StrongPass123!',
+        )
+        response = self.client.post(
+            '/api/auth/login/',
+            {"email": "ref-edge@example.com", "password": "StrongPass123!"},
+        )
+        self.refresh = response.data['refresh']
+
+    def test_refresh_with_outstanding_token_row_missing_returns_401(self):
+        """If the OutstandingToken row is gone, the refresh path returns 401.
+
+        Simulates a race / data-cleanup scenario where the signed JWT decodes
+        cleanly but the server-side tracking row no longer exists.
+        """
+        token = RefreshToken(self.refresh)
+        OutstandingToken.objects.filter(jti=token['jti']).delete()
+
+        res = self.client.post('/api/auth/refresh/', {"refresh": self.refresh})
+        self.assertEqual(res.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(res.data.get('code'), 'token_not_valid')
+
+    def test_refresh_when_token_user_deleted_returns_400(self):
+        """If the user referenced by the token is gone, the outer except returns 400."""
+        self.user.delete()
+        res = self.client.post('/api/auth/refresh/', {"refresh": self.refresh})
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('detail', res.data)

--- a/app/backend/requirements.txt
+++ b/app/backend/requirements.txt
@@ -14,3 +14,4 @@ django-storages==1.14.4
 boto3==1.38.11
 exponent-server-sdk==2.1.0
 django-cors-headers==4.9.0
+coverage==7.13.5


### PR DESCRIPTION
## Summary
- Add `coverage==7.13.5` to backend requirements and a `.coveragerc` that scopes measurement to `apps` and omits migrations, test files, and `manage.py`.
- Add 37 new tests covering branches called out in #530: messaging (soft delete, unread count, thread ordering, validation errors), notifications (mark read, mark all read, device token registration, push helper), users (UserManager edge cases, TokenRefresh failure paths), common (JWT auth middleware paths).
- Overall coverage moved from 91% to 93% (243 missed lines down to 204).

## Test plan
- [x] `python manage.py test` green (529 tests, was 492)
- [x] `coverage run --source=apps manage.py test && coverage report` shows the new numbers
- [x] No new flaky tests; suite is deterministic

## Coverage delta
| App | Before | After |
|---|---|---|
| common | 61% | 62% |
| cultural_content | 97% | 97% |
| drafts | 94% | 94% |
| map_discovery | 98% | 98% |
| messaging | 89% | 94% |
| notifications | 76% | 89% |
| recipes | 97% | 97% |
| search | 95% | 95% |
| stories | 95% | 95% |
| users | 96% | 99% |
| **TOTAL** | **91%** | **93%** |

Per-module highlights:
- `common/middleware.py` 85% to 100%
- `messaging/models.py` 91% to 100%, `messaging/views.py` 83% to 90%
- `notifications/models.py` 90% to 100%, `notifications/signals.py` 63% to 74%, `notifications/views.py` 66% to 97%
- `users/models.py` 96% to 100%, `users/views.py` 93% to 99%

## Notes
- Gaps left intentionally:
  - `apps/common/management/commands/seed_test_db.py` (0%): fixture seeder used only to bootstrap demo databases; not part of runtime code paths. Drives the `common` aggregate down.
  - `apps/stories/views.py` lines 51-59: untouched by this PR to avoid textual conflict with sister sessions on the stories module.
  - `apps/recipes/models.py` (91%) and `apps/search/views.py` (93%): recipes is already well-covered per the issue; remaining lines are defensive guards on out-of-domain inputs.
- `htmlcov/`, `.coverage`, and `coverage_baseline.txt` are gitignored.

Closes #530.