### PR TITLE
fix(mobile): tolerate empty bodies and malformed pagination links in httpClient (#618)

### DIFF
--- a/app/mobile/src/services/commentService.ts
+++ b/app/mobile/src/services/commentService.ts
@@ -1,4 +1,4 @@
-import { apiDelete, apiGetJson, apiPostJson } from './httpClient';
+import { apiDelete, apiGetJson, apiPostJson, nextPagePath } from './httpClient';
 
 export type CommentType = 'COMMENT' | 'QUESTION';
 
@@ -29,9 +29,7 @@ export async function fetchCommentsForRecipe(recipeId: string | number): Promise
       break;
     }
     collected.push(...data.results);
-    if (!data.next) break;
-    const url: URL = new URL(data.next);
-    path = `${url.pathname}${url.search}`;
+    path = nextPagePath(data.next);
   }
   return collected;
 }

--- a/app/mobile/src/services/httpClient.ts
+++ b/app/mobile/src/services/httpClient.ts
@@ -3,6 +3,36 @@ import { API_BASE_URL } from '../config/apiBase';
 
 const TOKEN_KEY = 'token';
 
+/**
+ * Read a JSON response safely. Returns `null` for 204 No Content and for any
+ * empty body — `res.json()` would otherwise throw `SyntaxError: Unexpected end
+ * of JSON input` on these inputs and crash the calling screen. Most mutation
+ * endpoints in this API do return JSON, so this only kicks in for the rare
+ * empty-body cases (delete-style responses, certain 200/204 toggles).
+ */
+async function parseJsonResponse<T>(res: Response): Promise<T> {
+  if (res.status === 204) return null as T;
+  const text = await res.text();
+  if (!text || !text.trim()) return null as T;
+  return JSON.parse(text) as T;
+}
+
+/**
+ * Convert the `next` URL from a DRF paginated response into a relative path
+ * the rest of the client can re-fetch. Bad/malformed links are tolerated by
+ * returning `null` (treated as last page) instead of throwing — `new URL()`
+ * is strict and used to take down the entire list fetch on a single bad link.
+ */
+export function nextPagePath(next: string | null | undefined): string | null {
+  if (!next) return null;
+  try {
+    const url = new URL(next);
+    return `${url.pathname}${url.search}`;
+  } catch {
+    return null;
+  }
+}
+
 async function readErrorMessage(res: Response): Promise<string> {
   const contentType = res.headers.get('content-type') ?? '';
   try {
@@ -48,7 +78,7 @@ export async function apiGetJson<T>(path: string): Promise<T> {
     const message = (await readErrorMessage(res)).trim();
     throw new Error(message || `GET ${path} failed (${res.status})`);
   }
-  return res.json() as Promise<T>;
+  return parseJsonResponse<T>(res);
 }
 
 /** POST JSON — mirrors axios `apiClient.post` usage on web. */
@@ -62,7 +92,7 @@ export async function apiPostJson<T>(path: string, body: object): Promise<T> {
     const message = (await readErrorMessage(res)).trim();
     throw new Error(message || `POST ${path} failed (${res.status})`);
   }
-  return res.json() as Promise<T>;
+  return parseJsonResponse<T>(res);
 }
 
 /** PATCH JSON — e.g. `PATCH /api/stories/:id/`. */
@@ -76,7 +106,7 @@ export async function apiPatchJson<T>(path: string, body: object): Promise<T> {
     const message = (await readErrorMessage(res)).trim();
     throw new Error(message || `PATCH ${path} failed (${res.status})`);
   }
-  return res.json() as Promise<T>;
+  return parseJsonResponse<T>(res);
 }
 
 /** DELETE — succeeds on 204 with no body. */

--- a/app/mobile/src/services/tagsService.ts
+++ b/app/mobile/src/services/tagsService.ts
@@ -1,4 +1,4 @@
-import { apiGetJson } from './httpClient';
+import { apiGetJson, nextPagePath } from './httpClient';
 
 export type Tag = { id: number; name: string; is_approved?: boolean };
 
@@ -14,9 +14,7 @@ async function fetchAll(path: string): Promise<Tag[]> {
       break;
     }
     collected.push(...data.results);
-    if (!data.next) break;
-    const u: URL = new URL(data.next);
-    cursor = `${u.pathname}${u.search}`;
+    cursor = nextPagePath(data.next);
   }
   // Server already filters list/retrieve by is_approved=True; the lookup
   // serializer doesn't expose the flag at all. No client-side filtering needed.


### PR DESCRIPTION
## Summary
Closes #618. Two robustness gaps in the mobile HTTP layer would crash the calling screen on perfectly valid backend responses:

1. **Empty / 204 No Content body** — `apiGetJson` / `apiPostJson` / `apiPatchJson` unconditionally called `res.json()`. `JSON.parse('')` throws `SyntaxError: Unexpected end of JSON input`, so any 204-returning endpoint (some toggles, some delete-style mutations) would crash the screen.
2. **Malformed pagination `next` link** — `commentService.fetchCommentsForRecipe` and `tagsService.fetchAll` did `new URL(data.next)` with no try/catch. A single bad link took down the entire list fetch.

Both are edge cases — they may not be firing on the staging stack today, but the failure modes are obvious from the code and the cost of guarding them is tiny.

## Files
- `services/httpClient.ts` — add `parseJsonResponse<T>(res)` helper that short-circuits on 204 and on empty/whitespace body (returns `null as T`), and an exported `nextPagePath(next)` helper that wraps `new URL(...)` in try/catch and returns `null` (treated as last page) on parse failure. `apiGetJson`/`apiPostJson`/`apiPatchJson` now route through `parseJsonResponse`.
- `services/commentService.ts` — paginated `fetchCommentsForRecipe` uses `nextPagePath(data.next)` instead of constructing `new URL` inline.
- `services/tagsService.ts` — same fix in `fetchAll`.

## Test
- `npx tsc --noEmit` clean
- Verified the helpers in isolation with a small Node script (mimicking `Response` shapes):
  - `nextPagePath`: `null` / `undefined` / `''` / `'not a url at all'` / relative paths all return `null` (no throw); valid absolute URL returns its `pathname + search`.
  - `parseJsonResponse`: status 204 → `null`; empty body → `null`; whitespace-only body → `null`; valid JSON → parsed object.
  - Confirmed the before-fix behaviour: `new URL('not a url')` throws `Invalid URL`, `JSON.parse('')` throws `Unexpected end of JSON input`.
- Local docker stack regression check: opened a recipe → comments still load (the only paginating consumer of the helper); search filter chip rail → event/dietary tags still load; recipe edit save / comment post / vote toggle — no regression on the normal flows.

The edge cases themselves are hard to trigger from a healthy backend; the value is defensive — if/when the backend emits a 204 or a bad next link, the screen no longer crashes.

Closes #618