### PR TITLE
fix(mobile): use dedicated map endpoints for region pins and content (#620)

### DIFF
--- a/app/mobile/src/components/map/RegionDetailSheet.tsx
+++ b/app/mobile/src/components/map/RegionDetailSheet.tsx
@@ -6,13 +6,15 @@ import { shadows, tokens, useTheme } from '../../theme';
 type Tab = 'recipes' | 'stories';
 
 type Props = {
-  /** Region name to load content for. Null/undefined hides the sheet. */
+  /** Region PK to load content for. Null/undefined hides the sheet. */
+  regionId: number | null;
+  /** Region display name for header/a11y labels. */
   regionName: string | null;
   onDismiss: () => void;
   onItemPress: (kind: Tab, id: string) => void;
 };
 
-export function RegionDetailSheet({ regionName, onDismiss, onItemPress }: Props) {
+export function RegionDetailSheet({ regionId, regionName, onDismiss, onItemPress }: Props) {
   const { accent } = useTheme();
   const [content, setContent] = useState<RegionContent | null>(null);
   const [loading, setLoading] = useState(false);
@@ -20,7 +22,7 @@ export function RegionDetailSheet({ regionName, onDismiss, onItemPress }: Props)
   const [tab, setTab] = useState<Tab>('recipes');
 
   useEffect(() => {
-    if (!regionName) {
+    if (regionId == null) {
       setContent(null);
       setError(null);
       return;
@@ -29,7 +31,7 @@ export function RegionDetailSheet({ regionName, onDismiss, onItemPress }: Props)
     setLoading(true);
     setError(null);
     setTab('recipes');
-    fetchRegionContent(regionName)
+    fetchRegionContent(regionId)
       .then((res) => {
         if (!cancelled) setContent(res);
       })
@@ -42,9 +44,9 @@ export function RegionDetailSheet({ regionName, onDismiss, onItemPress }: Props)
     return () => {
       cancelled = true;
     };
-  }, [regionName]);
+  }, [regionId]);
 
-  const visible = regionName != null;
+  const visible = regionId != null;
   const items = tab === 'recipes' ? (content?.recipes ?? []) : (content?.stories ?? []);
 
   return (

--- a/app/mobile/src/screens/MapDiscoveryScreen.tsx
+++ b/app/mobile/src/screens/MapDiscoveryScreen.tsx
@@ -101,6 +101,7 @@ export default function MapDiscoveryScreen({ navigation }: Props) {
         ) : null}
 
         <RegionDetailSheet
+          regionId={focused?.id ?? null}
           regionName={focused?.name ?? null}
           onDismiss={() => setFocused(null)}
           onItemPress={(kind, id) => {

--- a/app/mobile/src/services/mapDataService.ts
+++ b/app/mobile/src/services/mapDataService.ts
@@ -10,13 +10,13 @@ export type RegionPin = {
 
 export type RegionOption = { id: number; name: string };
 
-type RawRegion = { id: number | string; name: string };
-
-/** Lightweight region list for pickers (id + name only). */
-export async function fetchRegions(): Promise<RegionOption[]> {
-  const data = await apiGetJson<unknown>('/api/regions/');
-  return unwrapList<RawRegion>(data).map((r) => ({ id: Number(r.id), name: r.name }));
-}
+type RawRegion = {
+  id: number | string;
+  name: string;
+  latitude?: number | null;
+  longitude?: number | null;
+  content_count?: { recipes?: number; stories?: number; cultural_content?: number };
+};
 
 function unwrapList<T>(data: unknown): T[] {
   if (Array.isArray(data)) return data as T[];
@@ -26,34 +26,40 @@ function unwrapList<T>(data: unknown): T[] {
   return [];
 }
 
-async function countRecipesForRegion(name: string): Promise<number> {
-  try {
-    const params = new URLSearchParams({ region: name });
-    const data = await apiGetJson<unknown>(`/api/recipes/?${params.toString()}`);
-    const list = unwrapList<unknown>(data);
-    return list.length;
-  } catch {
-    return 0;
-  }
+/** Lightweight region list for pickers (id + name only). */
+export async function fetchRegions(): Promise<RegionOption[]> {
+  const data = await apiGetJson<unknown>('/api/regions/');
+  return unwrapList<RawRegion>(data).map((r) => ({ id: Number(r.id), name: r.name }));
 }
 
 /**
- * Returns only regions we know how to plot. Unknown ones are dropped — they'll
- * surface again when `regionGeo.COORDS` learns their coordinates (or when the
- * backend exposes lat/lng directly).
+ * Returns regions to plot on the map. Uses the map index endpoint
+ * (`/api/map/regions/?geo_only=false`) so we get the recipe count and any
+ * seeded lat/lng in a single request, instead of fetching every region from
+ * the lookup CRUD endpoint and firing one extra `?region=<name>` count call
+ * per pin (the old N+1 waterfall in #620).
+ *
+ * Backend lat/lng are preferred when populated; otherwise we fall back to the
+ * hardcoded `regionGeo.COORDS` table. Regions with neither are dropped — they
+ * surface again once either side learns their coordinates.
  */
 export async function fetchRegionPins(): Promise<RegionPin[]> {
-  const data = await apiGetJson<unknown>('/api/regions/');
+  const data = await apiGetJson<unknown>('/api/map/regions/?geo_only=false');
   const regions = unwrapList<RawRegion>(data);
 
-  const plottable = regions
-    .map((r) => {
-      const coords = coordsForRegion(r.name);
-      if (!coords) return null;
-      return { id: Number(r.id), name: r.name, coords };
-    })
-    .filter((r): r is { id: number; name: string; coords: LatLng } => r !== null);
-
-  const counts = await Promise.all(plottable.map((r) => countRecipesForRegion(r.name)));
-  return plottable.map((r, idx) => ({ ...r, recipeCount: counts[idx] }));
+  const pins: RegionPin[] = [];
+  for (const r of regions) {
+    const lat = typeof r.latitude === 'number' ? r.latitude : null;
+    const lng = typeof r.longitude === 'number' ? r.longitude : null;
+    const coords: LatLng | null =
+      lat != null && lng != null ? { latitude: lat, longitude: lng } : coordsForRegion(r.name);
+    if (!coords) continue;
+    pins.push({
+      id: Number(r.id),
+      name: r.name,
+      coords,
+      recipeCount: r.content_count?.recipes ?? 0,
+    });
+  }
+  return pins;
 }

--- a/app/mobile/src/services/regionContentService.ts
+++ b/app/mobile/src/services/regionContentService.ts
@@ -13,20 +13,12 @@ export type RegionContent = {
   stories: RegionContentItem[];
 };
 
-type RawRecipe = {
+type RawRegionContent = {
+  content_type: 'recipe' | 'story' | 'cultural' | string;
   id: number | string;
   title?: string;
   image?: string | null;
   author_username?: string | null;
-};
-
-type RawStory = {
-  id: number | string;
-  title?: string;
-  image?: string | null;
-  author_username?: string | null;
-  linked_recipe?: { region?: { name?: string } | string | null } | null;
-  recipe_region?: string;
 };
 
 function unwrap<T>(data: unknown): T[] {
@@ -37,7 +29,7 @@ function unwrap<T>(data: unknown): T[] {
   return [];
 }
 
-function toItem(kind: 'recipe' | 'story', raw: RawRecipe | RawStory): RegionContentItem {
+function toItem(kind: 'recipe' | 'story', raw: RawRegionContent): RegionContentItem {
   return {
     key: `${kind}-${raw.id}`,
     id: String(raw.id),
@@ -47,24 +39,25 @@ function toItem(kind: 'recipe' | 'story', raw: RawRecipe | RawStory): RegionCont
   };
 }
 
-function storyMatchesRegion(story: RawStory, regionName: string): boolean {
-  const r = story.linked_recipe?.region;
-  if (typeof r === 'string') return r === regionName;
-  if (r && typeof r === 'object' && typeof r.name === 'string') return r.name === regionName;
-  if (typeof story.recipe_region === 'string') return story.recipe_region === regionName;
-  return false;
-}
-
-export async function fetchRegionContent(regionName: string): Promise<RegionContent> {
-  const recipesParams = new URLSearchParams({ region: regionName });
+/**
+ * Fetch region-tagged content from the dedicated map endpoint
+ * `GET /api/map/regions/<id>/content/?type={recipe|story}` instead of pulling
+ * every story in the system and filtering client-side (the old behaviour was
+ * the slow/incomplete path called out in #620). Two parallel requests, one
+ * for recipes and one for stories.
+ */
+export async function fetchRegionContent(regionId: number | string): Promise<RegionContent> {
+  const base = `/api/map/regions/${regionId}/content/`;
   const [recipesRaw, storiesRaw] = await Promise.all([
-    apiGetJson<unknown>(`/api/recipes/?${recipesParams.toString()}`).catch(() => null),
-    apiGetJson<unknown>(`/api/stories/`).catch(() => null),
+    apiGetJson<unknown>(`${base}?type=recipe`).catch(() => null),
+    apiGetJson<unknown>(`${base}?type=story`).catch(() => null),
   ]);
 
-  const recipes = unwrap<RawRecipe>(recipesRaw).map((r) => toItem('recipe', r));
-  const stories = unwrap<RawStory>(storiesRaw)
-    .filter((s) => storyMatchesRegion(s, regionName))
+  const recipes = unwrap<RawRegionContent>(recipesRaw)
+    .filter((r) => r.content_type === 'recipe')
+    .map((r) => toItem('recipe', r));
+  const stories = unwrap<RawRegionContent>(storiesRaw)
+    .filter((s) => s.content_type === 'story')
     .map((s) => toItem('story', s));
 
   return { recipes, stories };


### PR DESCRIPTION
## Summary
Closes #620. Two map-related services were hitting the wrong / inefficient endpoints:

1. **`mapDataService.fetchRegionPins`** called `GET /api/regions/` (the lookup CRUD) and then fired one extra `GET /api/recipes/?region=<name>` per region to count recipes — a classic N+1 waterfall. The proper map index endpoint already existed (`GET /api/map/regions/`) and returns everything in a single response, including content counts and seeded lat/lng.
2. **`regionContentService.fetchRegionContent`** fetched the *entire* `/api/stories/` list and filtered client-side by region — slow, page-1-only, and silently incomplete. The dedicated `GET /api/map/regions/<id>/content/` endpoint already supported `?type=recipe` / `?type=story` filtering on the server side.

Both endpoints already shipped on the backend (`apps/map_discovery/urls.py`); only the mobile client needed to switch over.

## Files
- `services/mapDataService.ts` — `fetchRegionPins` now calls `GET /api/map/regions/?geo_only=false` in a single request. Reads `content_count.recipes` directly, no per-region count call. Prefers backend `latitude`/`longitude` when populated, falls back to the hardcoded `regionGeo.COORDS` table otherwise (the seed data on staging hasn't populated lat/lng yet). The `countRecipesForRegion` helper is gone.
- `services/regionContentService.ts` — rewritten. `fetchRegionContent(regionId)` now hits `/api/map/regions/<id>/content/?type=recipe` and `?type=story` in parallel. Pulled in the response shape (`content_type`-tagged rows) from the new endpoint. Signature changed from `(regionName)` to `(regionId)` since the new endpoint keys on pk.
- `components/map/RegionDetailSheet.tsx` — accept a `regionId: number | null` prop alongside the existing `regionName: string | null` (still used for header / a11y labels). Fetch effect now depends on `regionId`.
- `screens/MapDiscoveryScreen.tsx` — pass `regionId={focused?.id ?? null}` through to the sheet.

## Test
- `npx tsc --noEmit` clean
- Local docker stack as `ayse@example.com`:
  - Opened the Map tab → pins loaded in a single request (was: 1 region list + 1 count per region). Verified the recipe counts on each pin match what the backend reports under `content_count.recipes`.
  - Tapped a pin → RegionDetailSheet opened with the correct region's recipes and stories. Tab switching between Recipes / Stories is immediate. Tap-through to RecipeDetail / StoryDetail still works.
  - On staging the backend has no lat/lng seeded; the hardcoded `regionGeo.COORDS` fallback kicks in and pins still render in the right places. If/when the backend ships seeded coordinates, those automatically take over without a mobile change.

## Out of scope
- `regionGeo.COORDS` is intentionally kept as a fallback. Once the backend seeds lat/lng for all regions, that table can be removed in a follow-up — covered under M-8 polish (#622).
- The new `regionContentService` doesn't paginate yet; the dedicated endpoint already returns up to 20 items per type and the sheet doesn't surface a "load more" affordance. If it becomes a real limit, pagination is cheap to add.

Closes #620