### PR TITLE
fix(mobile): close error feedback and recovery gaps in 4 mutations (#621)

### DIFF
--- a/app/mobile/src/components/ContactabilityToggle.tsx
+++ b/app/mobile/src/components/ContactabilityToggle.tsx
@@ -23,12 +23,19 @@ export function ContactabilityToggle() {
     setError(null);
     setSaving(true);
     const previous = enabled;
-    await updateUser({ ...user, is_contactable: next });
     try {
+      // Optimistic local update is INSIDE the try so an AsyncStorage failure
+      // (rare but real on low-storage devices) is caught instead of becoming
+      // an unhandled promise rejection that crashes the toggle.
+      await updateUser({ ...user, is_contactable: next });
       const updated = await updateMe({ is_contactable: next });
       await updateUser({ ...user, ...updated });
     } catch (e) {
-      await updateUser({ ...user, is_contactable: previous });
+      try {
+        await updateUser({ ...user, is_contactable: previous });
+      } catch {
+        // best-effort revert; the error toast below still surfaces the issue
+      }
       setError(e instanceof Error ? e.message : 'Could not update messaging preference.');
     } finally {
       setSaving(false);

--- a/app/mobile/src/components/recipe/RecipeCommentsSection.tsx
+++ b/app/mobile/src/components/recipe/RecipeCommentsSection.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { ActivityIndicator, Alert, Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
 import { useAuth } from '../../context/AuthContext';
+import { useToast } from '../../context/ToastContext';
 import {
   deleteComment,
   fetchCommentsForRecipe,
@@ -41,6 +42,7 @@ function formatTime(iso: string): string {
 
 export function RecipeCommentsSection({ recipeId, qaEnabled }: Props) {
   const { user, isAuthenticated } = useAuth();
+  const { showToast } = useToast();
   const [comments, setComments] = useState<Comment[]>([]);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -99,7 +101,12 @@ export function RecipeCommentsSection({ recipeId, qaEnabled }: Props) {
         onPress: async () => {
           try {
             await deleteComment(id);
-            setComments((prev) => prev.filter((c) => c.id !== id && c.parent_comment !== id));
+            // Only drop the target comment. The backend doesn't cascade to
+            // replies, so removing them from local state too would create a
+            // mirage — they'd vanish from the UI and reappear on the next
+            // reload. Replies remain visible (orphaned) until backend cascade
+            // lands or they're individually deleted.
+            setComments((prev) => prev.filter((c) => c.id !== id));
           } catch (e) {
             Alert.alert('Delete failed', e instanceof Error ? e.message : 'Try again.');
           }
@@ -126,6 +133,7 @@ export function RecipeCommentsSection({ recipeId, qaEnabled }: Props) {
           c.id === id ? { ...c, has_voted: target.has_voted, helpful_count: target.helpful_count } : c,
         ),
       );
+      showToast('Could not save your vote. Please try again.', 'error');
     } finally {
       setVotePendingIds((prev) => prev.filter((x) => x !== id));
     }

--- a/app/mobile/src/context/AuthContext.tsx
+++ b/app/mobile/src/context/AuthContext.tsx
@@ -7,9 +7,11 @@ import React, {
   useMemo,
   useState,
 } from 'react';
+import { logoutRequest } from '../services/authService';
 import type { AuthUser } from '../services/mockAuthService';
 
 const TOKEN_KEY = 'token';
+const REFRESH_KEY = 'refresh';
 const USER_KEY = 'user';
 
 export type AuthContextValue = {
@@ -18,7 +20,7 @@ export type AuthContextValue = {
   /** Derived session state (mirrors web usage of token presence). */
   isAuthenticated: boolean;
   isReady: boolean;
-  login: (userData: AuthUser, accessToken: string) => Promise<void>;
+  login: (userData: AuthUser, accessToken: string, refreshToken?: string | null) => Promise<void>;
   logout: () => Promise<void>;
   updateUser: (userData: AuthUser) => Promise<void>;
 };
@@ -52,19 +54,39 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     };
   }, []);
 
-  const login = useCallback(async (userData: AuthUser, accessToken: string) => {
-    setUser(userData);
-    setToken(accessToken);
-    await AsyncStorage.multiSet([
-      [TOKEN_KEY, accessToken],
-      [USER_KEY, JSON.stringify(userData)],
-    ]);
-  }, []);
+  const login = useCallback(
+    async (userData: AuthUser, accessToken: string, refreshToken?: string | null) => {
+      setUser(userData);
+      setToken(accessToken);
+      const entries: [string, string][] = [
+        [TOKEN_KEY, accessToken],
+        [USER_KEY, JSON.stringify(userData)],
+      ];
+      if (refreshToken) entries.push([REFRESH_KEY, refreshToken]);
+      await AsyncStorage.multiSet(entries);
+      if (!refreshToken) {
+        // Older sessions may have a stale refresh from a previous login.
+        await AsyncStorage.removeItem(REFRESH_KEY);
+      }
+    },
+    [],
+  );
 
   const logout = useCallback(async () => {
+    // Best-effort: blacklist the refresh on the backend so a leaked access
+    // token can't be paired with a refresh to mint new sessions. Local
+    // logout still happens even if the request fails.
+    try {
+      const refresh = await AsyncStorage.getItem(REFRESH_KEY);
+      if (refresh) {
+        await logoutRequest(refresh);
+      }
+    } catch {
+      // ignore — local logout below will still happen
+    }
     setUser(null);
     setToken(null);
-    await AsyncStorage.multiRemove([TOKEN_KEY, USER_KEY]);
+    await AsyncStorage.multiRemove([TOKEN_KEY, REFRESH_KEY, USER_KEY]);
   }, []);
 
   const updateUser = useCallback(async (userData: AuthUser) => {

--- a/app/mobile/src/screens/LoginScreen.tsx
+++ b/app/mobile/src/screens/LoginScreen.tsx
@@ -40,7 +40,7 @@ export default function LoginScreen({ navigation }: Props) {
     setSubmitting(true);
     try {
       const data = await loginRequest(email, password);
-      await login(data.user, data.access);
+      await login(data.user, data.access, data.refresh);
       navigation.dispatch(
         CommonActions.reset({
           index: 0,

--- a/app/mobile/src/screens/RegisterScreen.tsx
+++ b/app/mobile/src/screens/RegisterScreen.tsx
@@ -41,7 +41,7 @@ export default function RegisterScreen({ navigation }: Props) {
     setSubmitting(true);
     try {
       const data = await registerRequest(username, email, password);
-      await login(data.user, data.access);
+      await login(data.user, data.access, data.refresh);
       navigation.dispatch(
         CommonActions.reset({
           index: 1,

--- a/app/mobile/src/services/authService.ts
+++ b/app/mobile/src/services/authService.ts
@@ -2,6 +2,21 @@ import type { AuthSuccess, AuthUser } from './mockAuthService';
 import { apiPatchJson, apiPostJson } from './httpClient';
 
 /**
+ * Best-effort server-side logout: blacklists the refresh token so a leaked
+ * access token can't be paired with the refresh to mint new sessions.
+ * Returns true on success, false on any failure — callers should still clear
+ * local auth state either way.
+ */
+export async function logoutRequest(refreshToken: string): Promise<boolean> {
+  try {
+    await apiPostJson<unknown>('/api/auth/logout/', { refresh: refreshToken });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Real backend auth service.
  * Mirrors web `authService.js` but uses the mobile fetch-based client.
  *

--- a/app/mobile/src/services/mockAuthService.ts
+++ b/app/mobile/src/services/mockAuthService.ts
@@ -16,6 +16,8 @@ export type AuthUser = {
 
 export type AuthSuccess = {
   access: string;
+  /** Refresh token. Real backend returns it; mock leaves it undefined. */
+  refresh?: string;
   user: AuthUser;
 };
 


### PR DESCRIPTION
## Summary
Closes #621. Four mutation paths had incomplete error/recovery flow — the UI optimistically updated, then either fell silent, left stale state, or leaked promise rejections. No single one was dramatic, but together they produced a "things sometimes go weird" feeling. All four are tightened here.

## Fixes

### 1. Comment delete cascaded replies in UI but not on the server
**File**: `components/recipe/RecipeCommentsSection.tsx:102`

The filter removed the target comment AND every reply (`c.parent_comment !== id`). Backend only deletes the single comment, so replies vanished from the UI and reappeared on the next reload. Filter now drops only the target; replies stay visible (orphaned) until either the user deletes them individually or backend cascade lands.

### 2. Comment vote failures were silent
**File**: `components/recipe/RecipeCommentsSection.tsx:122-132`

The catch block reverted the optimistic state but didn't tell the user. Their vote would flip and flip back without explanation. Added a toast on revert: "Could not save your vote. Please try again."

### 3. ContactabilityToggle had an `await` outside `try`
**File**: `components/ContactabilityToggle.tsx:21-37`

`await updateUser({ ...user, is_contactable: next })` was BEFORE the try block. `updateUser` calls AsyncStorage, which can throw on low-storage devices — that became an unhandled promise rejection that crashed the toggle. Moved the optimistic update inside try; the revert is now wrapped in its own try/catch so a second AsyncStorage failure doesn't blow up the recovery path either.

### 4. `logout()` never told the backend
**File**: `context/AuthContext.tsx` + `services/authService.ts`

Local-only logout. The refresh token was discarded at login (`data.refresh` ignored in `LoginScreen`), and there was no call to `POST /api/auth/logout/`. After "logout" the refresh token was still valid until natural expiry — a real security gap. Now:
- `AuthSuccess` type includes the optional `refresh` field
- `LoginScreen` and `RegisterScreen` pass `data.refresh` to `login()`
- `AuthContext.login()` accepts and stores `REFRESH_KEY` in AsyncStorage
- New helper `logoutRequest(refreshToken)` POSTs to `/api/auth/logout/` best-effort (catches errors, returns boolean)
- `AuthContext.logout()` retrieves the stored refresh, fires the request best-effort, then clears `TOKEN_KEY`, `REFRESH_KEY`, `USER_KEY`

If the server is unreachable or the refresh is already expired, local logout still happens — the user is never stranded.

## Test
- `npx tsc --noEmit` clean
- Local docker stack as `ayse@example.com`:
  - **Delete cascade**: posted a reply to one of my comments, deleted the parent → reply remained visible (used to disappear and resurface on reload).
  - **Contactability**: toggled the switch repeatedly, including during a brief network blip — no crash, no orphaned save state, error surfaces in the existing inline banner.
  - **Logout**: signed out → backend log shows `POST /api/auth/logout/ 205`; signed back in cleanly. Attempted logout with backend down — local logout still completed, no crash, no toast spam.
  - **Vote toast**: verified by killing the backend mid-vote — toast appeared, vote flipped back, no console error.

## Out of scope
- Backend `POST /api/auth/logout/` already exists (`apps/users/views.py:LogoutView`). No backend work needed.
- A proper JWT silent-refresh interceptor on `apiPostJson` / `apiPatchJson` is still tracked under #405 — that's a separate concern from this PR.

Closes #621