### PR TITLE
fix(mobile): polish bundle — retry, cleanup, a11y, canonical field (#622)

### DIFF
--- a/app/mobile/src/components/ContactabilityToggle.tsx
+++ b/app/mobile/src/components/ContactabilityToggle.tsx
@@ -57,7 +57,7 @@ export function ContactabilityToggle() {
         {saving ? 'Updating…' : enabled ? 'Allow new threads' : 'Block new threads'}
       </Text>
       {error ? (
-        <Pressable onPress={() => setError(null)} hitSlop={6} accessibilityRole="button">
+        <Pressable onPress={() => setError(null)} hitSlop={10} accessibilityRole="button">
           <Text style={styles.error}>{error} (tap to dismiss)</Text>
         </Pressable>
       ) : null}

--- a/app/mobile/src/components/home/StoryFeatureCard.tsx
+++ b/app/mobile/src/components/home/StoryFeatureCard.tsx
@@ -59,7 +59,7 @@ export function StoryFeatureCard({
               style={({ pressed }) => [styles.pill, pressed && styles.pressed]}
               accessibilityRole="link"
               accessibilityLabel={`Open profile of ${authorUsername}`}
-              hitSlop={6}
+              hitSlop={10}
             >
               <Text style={styles.pillText}>By {authorUsername}</Text>
             </Pressable>
@@ -70,7 +70,7 @@ export function StoryFeatureCard({
               style={({ pressed }) => [styles.recipePill, pressed && styles.pressed]}
               accessibilityRole="link"
               accessibilityLabel={`Open linked recipe ${recipeTitle}`}
-              hitSlop={6}
+              hitSlop={10}
             >
               <Text style={styles.recipePillText} numberOfLines={1}>
                 Recipe: {recipeTitle}

--- a/app/mobile/src/components/recipe/LinkedStoryPreviewCard.tsx
+++ b/app/mobile/src/components/recipe/LinkedStoryPreviewCard.tsx
@@ -51,7 +51,7 @@ export function LinkedStoryPreviewCard({
               style={({ pressed }) => [styles.authorPill, pressed && styles.authorPillPressed]}
               accessibilityRole="link"
               accessibilityLabel={`Open profile of ${authorUsername}`}
-              hitSlop={6}
+              hitSlop={10}
             >
               <Text style={styles.authorPillText} numberOfLines={1}>
                 By {authorUsername}

--- a/app/mobile/src/components/recipe/RecipeCommentsSection.tsx
+++ b/app/mobile/src/components/recipe/RecipeCommentsSection.tsx
@@ -175,7 +175,7 @@ export function RecipeCommentsSection({ recipeId, qaEnabled }: Props) {
                 </Text>
                 <Pressable
                   onPress={() => setReplyTo(null)}
-                  hitSlop={6}
+                  hitSlop={10}
                   accessibilityRole="button"
                   accessibilityLabel="Cancel reply"
                 >
@@ -294,7 +294,7 @@ function CommentNodeView({
         <Pressable
           onPress={() => onToggleVote(node.id)}
           disabled={!isAuthenticated || votePending}
-          hitSlop={6}
+          hitSlop={10}
           accessibilityRole="button"
           accessibilityState={{ selected: node.has_voted, disabled: !isAuthenticated || votePending }}
           accessibilityLabel={node.has_voted ? 'Unmark helpful' : 'Mark helpful'}
@@ -315,7 +315,7 @@ function CommentNodeView({
         {isAuthenticated && depth === 0 ? (
           <Pressable
             onPress={() => onReply(node.id)}
-            hitSlop={6}
+            hitSlop={10}
             accessibilityRole="button"
             accessibilityLabel={`Reply to ${node.author_username}`}
           >
@@ -325,7 +325,7 @@ function CommentNodeView({
         {canDelete ? (
           <Pressable
             onPress={() => onDelete(node.id)}
-            hitSlop={6}
+            hitSlop={10}
             accessibilityRole="button"
             accessibilityLabel="Delete comment"
           >

--- a/app/mobile/src/components/story/RecipeLinkPicker.tsx
+++ b/app/mobile/src/components/story/RecipeLinkPicker.tsx
@@ -35,25 +35,32 @@ export function RecipeLinkPicker({ value, onChange, fetchRecipes, currentUserId 
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [items, setItems] = useState<ListItem[]>([]);
-
-  async function load() {
-    setLoading(true);
-    setError(null);
-    try {
-      const list = await fetchRecipes();
-      setItems(list);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : 'Could not load recipes.');
-    } finally {
-      setLoading(false);
-    }
-  }
+  const [retryToken, setRetryToken] = useState(0);
 
   useEffect(() => {
     if (!open) return;
-    void load();
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetchRecipes()
+      .then((list) => {
+        if (!cancelled) setItems(list);
+      })
+      .catch((e) => {
+        if (!cancelled) {
+          setError(e instanceof Error ? e.message : 'Could not load recipes.');
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+    // fetchRecipes is intentionally captured at mount; deps would re-run the
+    // effect on every parent render and cause flicker.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open]);
+  }, [open, retryToken]);
 
   const filtered = useMemo(() => {
     const q = normalize(query);
@@ -119,7 +126,7 @@ export function RecipeLinkPicker({ value, onChange, fetchRecipes, currentUserId 
             />
 
             {loading ? <LoadingView message="Loading recipes…" /> : null}
-            {!loading && error ? <ErrorView message={error} onRetry={() => void load()} /> : null}
+            {!loading && error ? <ErrorView message={error} onRetry={() => setRetryToken((t) => t + 1)} /> : null}
 
             {!loading && !error ? (
               <FlatList

--- a/app/mobile/src/screens/HomeScreen.tsx
+++ b/app/mobile/src/screens/HomeScreen.tsx
@@ -242,7 +242,7 @@ export default function HomeScreen({ navigation }: Props) {
                       style={({ pressed }) => [styles.authorPress, pressed && styles.pressed]}
                       accessibilityRole="link"
                       accessibilityLabel={`Open profile of ${authorUsername}`}
-                      hitSlop={6}
+                      hitSlop={10}
                     >
                       <Text style={styles.authorLink} numberOfLines={1}>
                         By {authorUsername}

--- a/app/mobile/src/screens/OnboardingScreen.tsx
+++ b/app/mobile/src/screens/OnboardingScreen.tsx
@@ -79,6 +79,10 @@ export default function OnboardingScreen({ navigation }: Props) {
   const current = STEPS[stepIndex];
   const progress = Math.round(((stepIndex + 1) / STEPS.length) * 100);
 
+  // Onboarding is intentionally lenient: users may skip without selecting
+  // anything on any step. The product preference is to lower the friction of
+  // signup; empty preferences are valid and culture cards still surface
+  // useful content without explicit picks.
   const isComplete = useMemo(
     () => STEPS.every((step) => Array.isArray(values[step.key])),
     [values],

--- a/app/mobile/src/screens/RecipeDetailScreen.tsx
+++ b/app/mobile/src/screens/RecipeDetailScreen.tsx
@@ -112,7 +112,13 @@ export default function RecipeDetailScreen({ route, navigation }: Props) {
     return () => {
       cancelled = true;
     };
-  }, [showConverted, recipe, convertedByLine]);
+    // Intentionally omit `convertedByLine`: keeping it in deps caused the
+    // effect to re-run after every batch result and produce a flicker /
+    // wasted render cycle. We only need the effect to fire when the toggle
+    // or the recipe itself changes; the inner `missing` filter still uses
+    // the current state via closure capture.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [showConverted, recipe]);
 
   useEffect(() => {
     if (!isAuthenticated) {
@@ -222,7 +228,7 @@ export default function RecipeDetailScreen({ route, navigation }: Props) {
               style={({ pressed }) => [styles.regionPill, pressed && { opacity: 0.85 }]}
               accessibilityRole="link"
               accessibilityLabel={`Browse ${recipe.region} recipes`}
-              hitSlop={6}
+              hitSlop={10}
             >
               <Text style={styles.regionPillText}>{recipe.region}</Text>
             </Pressable>
@@ -238,7 +244,7 @@ export default function RecipeDetailScreen({ route, navigation }: Props) {
               style={({ pressed }) => [styles.authorPill, pressed && { opacity: 0.85 }]}
               accessibilityRole="link"
               accessibilityLabel={`Open profile of ${authorObj.username}`}
-              hitSlop={6}
+              hitSlop={10}
             >
               <Text style={styles.authorPillText}>By {authorObj.username}</Text>
             </Pressable>

--- a/app/mobile/src/screens/RecipeEditScreen.tsx
+++ b/app/mobile/src/screens/RecipeEditScreen.tsx
@@ -1,6 +1,6 @@
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import * as ImagePicker from 'expo-image-picker';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Pressable, ScrollView, Switch, Text, TextInput, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import {
@@ -39,6 +39,18 @@ export default function RecipeEditScreen({ route, navigation }: Props) {
   );
   const [loadError, setLoadError] = useState<string | null>(null);
   const [reloadToken, setReloadToken] = useState(0);
+  /** Pending post-save navigation timer; cleared on unmount so a quick back
+   * press doesn't get bounced forward to RecipeDetail after the screen has gone. */
+  const navTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (navTimerRef.current) {
+        clearTimeout(navTimerRef.current);
+        navTimerRef.current = null;
+      }
+    };
+  }, []);
 
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
@@ -205,7 +217,10 @@ export default function RecipeEditScreen({ route, navigation }: Props) {
           await updateRecipeById(id, buildRecipeVideoOnlyFormData(localVideo));
         }
         showToast('Recipe updated!', 'success');
-        setTimeout(() => navigation.navigate('RecipeDetail', { id }), 1500);
+        navTimerRef.current = setTimeout(() => {
+          navTimerRef.current = null;
+          navigation.navigate('RecipeDetail', { id });
+        }, 1500);
       } catch {
         showToast('Failed to save changes. Please try again.', 'error');
       } finally {

--- a/app/mobile/src/screens/SearchScreen.tsx
+++ b/app/mobile/src/screens/SearchScreen.tsx
@@ -47,6 +47,10 @@ export default function SearchScreen({ navigation, route }: Props) {
   const [dietExclude, setDietExclude] = useState<string[]>([]);
   const [eventInclude, setEventInclude] = useState<string[]>([]);
   const [eventExclude, setEventExclude] = useState<string[]>([]);
+  /** Bumped by the Retry button so the search effect re-runs even when the
+   * query/filters haven't changed (`setQuery(q => q)` was a noop because
+   * React bails out on identical values). */
+  const [retryToken, setRetryToken] = useState(0);
 
   useEffect(() => {
     let cancelled = false;
@@ -137,7 +141,7 @@ export default function SearchScreen({ navigation, route }: Props) {
     return () => {
       cancelled = true;
     };
-  }, [query, region, filtersKey, hasActiveFilters]);
+  }, [query, region, filtersKey, hasActiveFilters, retryToken]);
 
   const selectedRegionLabel =
     REGIONS.find((r) => r.value === region)?.label ?? 'All regions';
@@ -262,7 +266,7 @@ export default function SearchScreen({ navigation, route }: Props) {
                 title="Search failed"
                 message={error}
                 glyph="!"
-                actions={[{ label: 'Retry', onPress: () => setQuery((q) => q) }]}
+                actions={[{ label: 'Retry', onPress: () => setRetryToken((t) => t + 1) }]}
               />
             ) : isPristine ? (
               <EmptyState

--- a/app/mobile/src/screens/StoryCreateScreen.tsx
+++ b/app/mobile/src/screens/StoryCreateScreen.tsx
@@ -78,7 +78,7 @@ export default function StoryCreateScreen({ navigation }: Props) {
           body: body.trim(),
           language,
           is_published: true,
-          linked_recipe: linkedRecipe ? Number(linkedRecipe.id) : null,
+          linked_recipe_id: linkedRecipe ? Number(linkedRecipe.id) : null,
           region: regionId,
         });
         if (imageUri) {

--- a/app/mobile/src/screens/StoryDetailScreen.tsx
+++ b/app/mobile/src/screens/StoryDetailScreen.tsx
@@ -94,7 +94,7 @@ export default function StoryDetailScreen({ route, navigation }: Props) {
               style={({ pressed }) => [styles.regionPill, pressed && { opacity: 0.85 }]}
               accessibilityRole="link"
               accessibilityLabel={`Browse ${story.region} content`}
-              hitSlop={6}
+              hitSlop={10}
             >
               <Text style={styles.regionPillText}>{story.region}</Text>
             </Pressable>
@@ -110,7 +110,7 @@ export default function StoryDetailScreen({ route, navigation }: Props) {
               style={({ pressed }) => [styles.authorPill, pressed && { opacity: 0.85 }]}
               accessibilityRole="link"
               accessibilityLabel={`Open profile of ${authorObj.username}`}
-              hitSlop={6}
+              hitSlop={10}
             >
               <Text style={styles.authorPillText}>By {authorObj.username}</Text>
             </Pressable>

--- a/app/mobile/src/screens/StoryEditScreen.tsx
+++ b/app/mobile/src/screens/StoryEditScreen.tsx
@@ -138,7 +138,7 @@ export default function StoryEditScreen({ route, navigation }: Props) {
           title: title.trim(),
           body: body.trim(),
           language,
-          linked_recipe: linkedRecipe ? Number(linkedRecipe.id) : null,
+          linked_recipe_id: linkedRecipe ? Number(linkedRecipe.id) : null,
           is_published: published,
           region: regionId,
         });

--- a/app/mobile/src/services/storyService.ts
+++ b/app/mobile/src/services/storyService.ts
@@ -157,7 +157,10 @@ export async function updateStoryById(
     title: string;
     body: string;
     language: string;
-    linked_recipe: number | null;
+    /** Backend canonical field is `linked_recipe_id`. Sending it directly so
+     * we don't depend on the legacy `linked_recipe` → `linked_recipe_id`
+     * shim in `StorySerializer.to_internal_value`. */
+    linked_recipe_id: number | null;
     is_published: boolean;
     region?: number | null;
   },


### PR DESCRIPTION
## Summary
Closes #622 (partial). Bundle of small correctness, perf, and a11y fixes called out during the M6 mobile walkthrough audit. Each one is tiny on its own, but together they remove a long tail of "things sometimes go weird" rough edges before demo.

## Done in this PR

### Correctness
- **D — Search retry button was a noop** (`SearchScreen.tsx`): the retry handler was `setQuery((q) => q)`, which React bails out on. Added a `retryToken` state, included it in the search effect deps, and the Retry button now bumps it. Re-runs the search with the same query/filters.
- **Q — storyService sent the legacy `linked_recipe` field** (`storyService.ts`, `StoryCreateScreen.tsx`, `StoryEditScreen.tsx`): backend `StorySerializer.to_internal_value` has a "legacy" shim that maps `linked_recipe` → `linked_recipe_id`. Mobile now sends the canonical `linked_recipe_id` directly, so the day the shim is removed nothing breaks. Verified end-to-end with curl: POST `linked_recipe_id: 1` → backend stores it, GET returns `linked_recipe: 1` + recipe title.

### Cleanup / leaks
- **P — RecipeEditScreen `setTimeout` not cleaned up** (`RecipeEditScreen.tsx`): post-save `setTimeout(() => navigate('RecipeDetail'), 1500)` had no cleanup. If the user pressed back within 1.5s, they got bounced forward to RecipeDetail after the screen had already gone. Stored the timer id in a ref and clear it on unmount.
- **V — RecipeLinkPicker missing `cancelled` flag** (`components/story/RecipeLinkPicker.tsx`): the fetch effect had no unmount guard, so closing the picker mid-load triggered "Can't perform state update on unmounted component" warnings. Refactored the effect to use the standard `cancelled` pattern; the Retry action now bumps a `retryToken` state to re-fire the effect cleanly.
- **W — RecipeDetail unit-conversion wasteful re-render loop** (`RecipeDetailScreen.tsx`): `convertedByLine` was in the effect deps, so every batch result re-ran the effect (saw no missing items, exited). Drop it from deps with an explanatory comment — the toggle / recipe deps are sufficient triggers.

### A11y
- **Hit slop bump 6 → 10** across 7 files (pill buttons, cancel-link affordances, etc.). Apple HIG and Material both want ≥ 44pt minimum touch target; previous hitSlop of 6 still left some sub-target pills awkward to tap.

## Not done in this PR (intentional)

- **H — Onboarding "Finish" allows empty submit**: audit flagged this as a bug because `Array.isArray([])` is always true. After confirming with the product owner, the intent is leniency — users should be able to skip without selecting anything. Kept the current behaviour; added an inline comment explaining the choice so the next audit doesn't re-flag it.
- **N — Explore N+1 query waterfall**: re-reading `exploreService.fetchExploreCategories`, it already uses `Promise.all`. The audit was based on an older revision. No-op.
- **S — FlatList nested inside ScrollView** (`HomeScreen`, `ExploreScreen`): true perf issue but the refactor (single FlatList with section data + ListHeaderComponent) is too big for this bundle. Leaving for a separate PR so the rest of the polish can ship without holding for that change.

## Test
- `npx tsc --noEmit` clean
- Local docker stack as `ayse@example.com`:
  - Searched with an active filter, killed the backend briefly, tapped Retry → search re-fired correctly (was a noop before).
  - Saved a recipe edit, immediately hit back → no unexpected RecipeDetail bounce.
  - Opened the story link picker, closed it during the fetch → no warning logged.
  - Toggled converted units on a recipe with many ingredients → no flicker on the toggle indicator; conversion happens once per line.
  - End-to-end backend test: `POST /api/stories/ {linked_recipe_id: 1, region: 1}` → 201, `GET /api/stories/<id>/` returns `linked_recipe: 1`, `recipe_title: "Black Sea Collard Green Sarma test"`, `region_name: "Aegean"`. Canonical field round-trips.
  - Onboarding: confirmed empty Finish still works (per product preference).

Closes #622