### PR TITLE
feat(mobile): tab bar active state and tappable region pills on list cards (#651)

### DIFF
--- a/app/mobile/src/components/home/DailyCulturalSection.tsx
+++ b/app/mobile/src/components/home/DailyCulturalSection.tsx
@@ -61,7 +61,20 @@ export function DailyCulturalSection({ items }: Props) {
             >
               <View style={styles.kindRow}>
                 <Text style={styles.kindLabel}>{KIND_LABEL[item.kind]}</Text>
-                {item.region ? <Text style={styles.region}>{item.region}</Text> : null}
+                {item.region ? (
+                  <Pressable
+                    onPress={(e) => {
+                      e.stopPropagation?.();
+                      navigation.navigate('Search', { region: item.region });
+                    }}
+                    style={({ pressed }) => [styles.regionPill, pressed && { opacity: 0.85 }]}
+                    accessibilityRole="link"
+                    accessibilityLabel={`Browse ${item.region} content`}
+                    hitSlop={10}
+                  >
+                    <Text style={styles.regionPillText}>{item.region}</Text>
+                  </Pressable>
+                ) : null}
               </View>
               <Text style={styles.title} numberOfLines={2}>
                 {item.title}
@@ -142,7 +155,15 @@ const styles = StyleSheet.create({
     letterSpacing: 1,
     textTransform: 'uppercase',
   },
-  region: { fontSize: 11, color: tokens.colors.textMuted, fontWeight: '700' },
+  regionPill: {
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: tokens.radius.pill,
+    backgroundColor: tokens.colors.bg,
+    borderWidth: 1.5,
+    borderColor: tokens.colors.surfaceDark,
+  },
+  regionPillText: { fontSize: 11, color: tokens.colors.text, fontWeight: '800', letterSpacing: 0.2 },
   title: {
     fontSize: 16,
     fontWeight: '800',

--- a/app/mobile/src/components/home/RecommendationsRail.tsx
+++ b/app/mobile/src/components/home/RecommendationsRail.tsx
@@ -1,7 +1,10 @@
+import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { FlatList, Image, Pressable, StyleSheet, Text, View } from 'react-native';
 import { shadows, tokens } from '../../theme';
 import { RankReasonBadge } from '../personalization/RankReasonBadge';
 import type { RecommendationItem } from '../../services/recommendationsService';
+import type { RootStackParamList } from '../../navigation/types';
 
 type Props = {
   items: RecommendationItem[];
@@ -9,6 +12,7 @@ type Props = {
 };
 
 export function RecommendationsRail({ items, onItemPress }: Props) {
+  const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   if (items.length === 0) return null;
 
   return (
@@ -58,7 +62,20 @@ export function RecommendationsRail({ items, onItemPress }: Props) {
               ) : null}
               <View style={styles.metaRow}>
                 <Text style={styles.kind}>{item.kind === 'recipe' ? 'Recipe' : 'Story'}</Text>
-                {item.region ? <Text style={styles.region}>· {item.region}</Text> : null}
+                {item.region ? (
+                  <Pressable
+                    onPress={(e) => {
+                      e.stopPropagation?.();
+                      navigation.navigate('Search', { region: item.region as string });
+                    }}
+                    style={({ pressed }) => [styles.regionPill, pressed && { opacity: 0.85 }]}
+                    accessibilityRole="link"
+                    accessibilityLabel={`Browse ${item.region} content`}
+                    hitSlop={10}
+                  >
+                    <Text style={styles.regionPillText}>{item.region}</Text>
+                  </Pressable>
+                ) : null}
               </View>
               <RankReasonBadge reason={item.rankReason} style={styles.badge} />
             </View>
@@ -99,6 +116,14 @@ const styles = StyleSheet.create({
   cardSnippet: { fontSize: 12, color: tokens.colors.textMuted, lineHeight: 16 },
   metaRow: { flexDirection: 'row', alignItems: 'center', gap: 6 },
   kind: { fontSize: 11, color: tokens.colors.textMuted, fontWeight: '800', textTransform: 'uppercase' },
-  region: { fontSize: 11, color: tokens.colors.textMuted, fontWeight: '700' },
+  regionPill: {
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: tokens.radius.pill,
+    backgroundColor: tokens.colors.bg,
+    borderWidth: 1.5,
+    borderColor: tokens.colors.surfaceDark,
+  },
+  regionPillText: { fontSize: 11, color: tokens.colors.text, fontWeight: '800', letterSpacing: 0.2 },
   badge: { marginTop: 4 },
 });

--- a/app/mobile/src/navigation/RootTabsNavigator.tsx
+++ b/app/mobile/src/navigation/RootTabsNavigator.tsx
@@ -21,7 +21,7 @@ export function RootTabsNavigator() {
       initialRouteName="Feed"
       screenOptions={({ route }) => ({
         headerShown: false,
-        tabBarActiveTintColor: tokens.colors.surfaceDark,
+        tabBarActiveTintColor: tokens.colors.accentGreen,
         tabBarInactiveTintColor: tokens.colors.textMuted,
         tabBarStyle: {
           borderTopColor: tokens.colors.border,
@@ -29,6 +29,7 @@ export function RootTabsNavigator() {
           backgroundColor: tokens.colors.surface,
         },
         tabBarLabelStyle: { fontWeight: '900' },
+        tabBarActiveBackgroundColor: tokens.colors.bg,
         tabBarIcon: ({ color, size, focused }) => {
           const baseName =
             route.name === 'Feed'

--- a/app/mobile/src/screens/HomeScreen.tsx
+++ b/app/mobile/src/screens/HomeScreen.tsx
@@ -249,11 +249,28 @@ export default function HomeScreen({ navigation }: Props) {
                       </Text>
                     </Pressable>
                   ) : null}
-                  <View style={styles.tag}>
-                    <Text style={styles.tagText} numberOfLines={1}>
-                      {regionName ?? 'Recipe'}
-                    </Text>
-                  </View>
+                  {regionName ? (
+                    <Pressable
+                      onPress={(e) => {
+                        e.stopPropagation?.();
+                        navigation.navigate('Search', { region: regionName });
+                      }}
+                      style={({ pressed }) => [styles.tag, pressed && styles.pressed]}
+                      accessibilityRole="link"
+                      accessibilityLabel={`Browse ${regionName} recipes`}
+                      hitSlop={10}
+                    >
+                      <Text style={styles.tagText} numberOfLines={1}>
+                        {regionName}
+                      </Text>
+                    </Pressable>
+                  ) : (
+                    <View style={styles.tag}>
+                      <Text style={styles.tagText} numberOfLines={1}>
+                        Recipe
+                      </Text>
+                    </View>
+                  )}
                   <RankReasonBadge reason={item.rank_reason} style={styles.recipeBadge} />
                 </Pressable>
               );

--- a/app/mobile/src/screens/StoryDetailScreen.tsx
+++ b/app/mobile/src/screens/StoryDetailScreen.tsx
@@ -211,7 +211,11 @@ const styles = StyleSheet.create({
     alignSelf: 'flex-start',
     marginTop: 12,
     paddingVertical: 8,
-    paddingHorizontal: 4,
+    paddingHorizontal: 16,
+    borderRadius: tokens.radius.pill,
+    backgroundColor: tokens.colors.accentGreen,
+    borderWidth: 2,
+    borderColor: tokens.colors.surfaceDark,
   },
-  editLinkText: { fontSize: 16, color: tokens.colors.text, fontWeight: '800' },
+  editLinkText: { fontSize: 14, color: tokens.colors.textOnDark, fontWeight: '800', letterSpacing: 0.3 },
 });


### PR DESCRIPTION
## Summary
Closes #651. Manual QA pass flagged a cluster of "navigation/discovery affordances aren't legible" issues on Home and Story detail. All same flavour: meta labels (region, author) on list cards rendered as plain text instead of the tappable-pill convention used on detail screens, and the bottom tab bar's active state didn't read as clearly distinct from inactive. This PR bundles the fixes so they ship together.

## Fixes

### 1. Bottom tab bar — active state now distinct
`navigation/RootTabsNavigator.tsx`. The #617 palette sweep had set the active tint to `surfaceDark`, but on the orange tab-bar background both active and inactive read as similar dark tones. Switched the active tint to `accentGreen` and added a cream `tabBarActiveBackgroundColor` so the focused tab is unambiguous at a glance — different colour, different background, different weight (the existing `tabBarLabelStyle.fontWeight: '900'` carries through).

### 2. "From the kitchens" cards — region is now a tappable pill
`components/home/DailyCulturalSection.tsx`. The region label was a plain `<Text>` in the kind row. Wrapped in a `Pressable` with the standard `regionPill` style (cream `bg` + `surfaceDark` border + `text` colour, matching `RecipeDetailScreen.regionPill`). Tapping navigates to `Search` with the region pre-filtered. `e.stopPropagation()` prevents the card's outer onPress from firing.

### 3. "Recommended for you" rail cards — region is now a tappable pill
`components/home/RecommendationsRail.tsx`. Same fix and same pill style as above. Plain `· {region}` text replaced with a Pressable pill that opens Search filtered by that region. Hooked up `useNavigation` since the rail previously got nav from props.

### 4. "More recipes" horizontal list — region is now tappable
`screens/HomeScreen.tsx`. The card already used a pill-shaped `<View style={styles.tag}>` for the region, just no `onPress`. Wrapped in `Pressable` (only when `regionName` is non-null — falls back to a static "Recipe" pill otherwise). Author pill was already tappable from earlier work (#557); confirmed visually.

### 5. StoryDetail "Edit story" — now a real pill
`screens/StoryDetailScreen.tsx`. The Edit affordance was a plain text link, easy to miss. Now matches the RecipeDetail Edit pill from #543: `accentGreen` fill + `surfaceDark` border + `textOnDark` text, padded as a button.

## Files
- `navigation/RootTabsNavigator.tsx`
- `components/home/DailyCulturalSection.tsx`
- `components/home/RecommendationsRail.tsx`
- `screens/HomeScreen.tsx`
- `screens/StoryDetailScreen.tsx`

## Test
- `npx tsc --noEmit` clean
- Local docker stack as `ayse@example.com`:
  - Bottom tabs: active tab is now obviously different — cream background + green icon, while inactive sits flush on the orange bar.
  - Recommended for you / From the kitchens / More recipes: tapped each region pill, all three navigated to Search with the region locked in.
  - More recipes: author pill still works as before (UserProfile navigation).
  - StoryDetail: edit button now reads as a clear action; tapping opens StoryEdit.

Closes #651