### PR TITLE
feat(mobile): logout button colour → #FC6C85 (#652)

### DIFF
--- a/app/mobile/src/screens/tabs/ProfileTabScreen.tsx
+++ b/app/mobile/src/screens/tabs/ProfileTabScreen.tsx
@@ -143,8 +143,8 @@ const styles = StyleSheet.create({
   messagesBtnText: { color: tokens.colors.surfaceDark, fontSize: 16, fontWeight: '800' },
   culturalBtn: { backgroundColor: '#C8E5EB' },
   culturalBtnText: { color: tokens.colors.surfaceDark, fontSize: 16, fontWeight: '800' },
-  logoutBtn: { backgroundColor: tokens.colors.error },
-  logoutBtnText: { color: tokens.colors.textOnDark, fontSize: 16, fontWeight: '800' },
+  logoutBtn: { backgroundColor: '#FC6C85' },
+  logoutBtnText: { color: tokens.colors.surfaceDark, fontSize: 16, fontWeight: '800' },
   registerBtn: {
     flex: 1,
     backgroundColor: '#EFBF04',


### PR DESCRIPTION
## Summary
Closes #652. Logout button on Profile was using `tokens.colors.error` (`#DC2626`), a saturated red. Design ask: switch to `#FC6C85` — a warmer pink-red that still reads as destructive but fits the rest of the Genipe warm palette. Also flipped the label colour to `surfaceDark` so it stays high-contrast on the lighter background.

## File
- `app/mobile/src/screens/tabs/ProfileTabScreen.tsx` — `styles.logoutBtn.backgroundColor` and `styles.logoutBtnText.color`.

## Test
- `npx tsc --noEmit` clean
- Profile tab: three buttons now read as three distinct affordances — Messages (light blue), Cultural preferences (light blue), Log out (warm pink-red).

Closes #652