### PR TITLE
feat(mobile): "Did You Know?" cultural fact cards on recipe detail (#518)

### DIFF
--- a/app/mobile/src/components/cultural/DidYouKnowSection.tsx
+++ b/app/mobile/src/components/cultural/DidYouKnowSection.tsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import { Linking, Pressable, StyleSheet, Text, View } from 'react-native';
+import { shadows, tokens } from '../../theme';
+import type { CulturalFact } from '../../services/culturalFactService';
+
+type Props = {
+  facts: CulturalFact[];
+};
+
+/**
+ * "Did You Know?" cards section (#518). Renders the supplied cultural facts
+ * as small info cards with an icon, the fact text, and an optional source
+ * link. Returns null when there are no facts so the parent doesn't render
+ * an empty section.
+ */
+export function DidYouKnowSection({ facts }: Props) {
+  if (!facts || facts.length === 0) return null;
+
+  const onPressSource = (url: string) => {
+    if (!url) return;
+    Linking.openURL(url).catch(() => undefined);
+  };
+
+  return (
+    <View style={styles.section} accessibilityLabel="Cultural context facts">
+      <View style={styles.headerRow}>
+        <View style={styles.iconCircle}>
+          <Text style={styles.iconText}>?</Text>
+        </View>
+        <Text style={styles.heading}>Did you know</Text>
+      </View>
+
+      <View style={styles.list}>
+        {facts.map((fact) => (
+          <View key={fact.id} style={styles.card}>
+            <Text style={styles.quoteOpen}>“</Text>
+            <Text style={styles.cardText}>{fact.text}</Text>
+            {fact.source_url ? (
+              <Pressable
+                onPress={() => onPressSource(fact.source_url)}
+                style={({ pressed }) => [styles.sourcePill, pressed && styles.pressed]}
+                accessibilityRole="link"
+                accessibilityLabel="Open source link"
+                hitSlop={10}
+              >
+                <Text style={styles.sourcePillText}>Source ↗</Text>
+              </Pressable>
+            ) : null}
+          </View>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  section: {
+    marginTop: 28,
+    paddingTop: 16,
+    paddingBottom: 4,
+    borderTopWidth: 1,
+    borderTopColor: tokens.colors.surfaceDark,
+    gap: 14,
+  },
+  headerRow: { flexDirection: 'row', alignItems: 'center', gap: 10 },
+  iconCircle: {
+    width: 32,
+    height: 32,
+    borderRadius: 8,
+    backgroundColor: tokens.colors.surfaceDark,
+    alignItems: 'center',
+    justifyContent: 'center',
+    transform: [{ rotate: '-6deg' }],
+  },
+  iconText: {
+    fontSize: 18,
+    fontWeight: '900',
+    color: '#FFE066',
+    fontFamily: tokens.typography.display.fontFamily,
+  },
+  heading: {
+    fontSize: 20,
+    fontWeight: '800',
+    color: tokens.colors.text,
+    fontFamily: tokens.typography.display.fontFamily,
+    letterSpacing: 0.2,
+  },
+  list: { gap: 14 },
+  card: {
+    paddingTop: 22,
+    paddingBottom: 16,
+    paddingHorizontal: 18,
+    borderRadius: 4,
+    backgroundColor: '#FFF3B0',
+    borderTopWidth: 1,
+    borderLeftWidth: 1,
+    borderRightWidth: 1,
+    borderBottomWidth: 4,
+    borderColor: tokens.colors.surfaceDark,
+    gap: 12,
+    ...shadows.md,
+  },
+  quoteOpen: {
+    position: 'absolute',
+    top: 4,
+    left: 10,
+    fontSize: 36,
+    color: tokens.colors.surfaceDark,
+    fontFamily: tokens.typography.display.fontFamily,
+    fontWeight: '900',
+    lineHeight: 36,
+    opacity: 0.35,
+  },
+  cardText: {
+    fontSize: 15,
+    color: tokens.colors.surfaceDark,
+    lineHeight: 22,
+    fontWeight: '600',
+  },
+  sourcePill: {
+    alignSelf: 'flex-start',
+    paddingVertical: 5,
+    paddingHorizontal: 12,
+    borderRadius: tokens.radius.pill,
+    backgroundColor: tokens.colors.surfaceDark,
+  },
+  sourcePillText: { fontSize: 12, color: '#FFE066', fontWeight: '800', letterSpacing: 0.3 },
+  pressed: { opacity: 0.85 },
+});

--- a/app/mobile/src/screens/RecipeDetailScreen.tsx
+++ b/app/mobile/src/screens/RecipeDetailScreen.tsx
@@ -11,6 +11,8 @@ import { LoadingView } from '../components/ui/LoadingView';
 import { IngredientSubstitutesSheet } from '../components/recipe/IngredientSubstitutesSheet';
 import { LinkedStoryPreviewCard } from '../components/recipe/LinkedStoryPreviewCard';
 import { RecipeCommentsSection } from '../components/recipe/RecipeCommentsSection';
+import { DidYouKnowSection } from '../components/cultural/DidYouKnowSection';
+import { fetchCulturalFactsByRegion, type CulturalFact } from '../services/culturalFactService';
 import type { RootStackParamList } from '../navigation/types';
 import { fetchCheckedIngredients, toggleCheckedIngredient } from '../services/checkOffService';
 import { fetchRecipeById } from '../services/recipeService';
@@ -37,6 +39,7 @@ export default function RecipeDetailScreen({ route, navigation }: Props) {
   const [convertingLoading, setConvertingLoading] = useState(false);
   const [checkedIds, setCheckedIds] = useState<Set<number>>(new Set());
   const [showShoppingList, setShowShoppingList] = useState(false);
+  const [culturalFacts, setCulturalFacts] = useState<CulturalFact[]>([]);
   const { showToast } = useToast();
 
   useEffect(() => {
@@ -137,6 +140,25 @@ export default function RecipeDetailScreen({ route, navigation }: Props) {
       cancelled = true;
     };
   }, [id, isAuthenticated, reloadToken]);
+
+  useEffect(() => {
+    const regionId = recipe?.region_id;
+    if (regionId == null) {
+      setCulturalFacts([]);
+      return;
+    }
+    let cancelled = false;
+    fetchCulturalFactsByRegion(regionId)
+      .then((facts) => {
+        if (!cancelled) setCulturalFacts(facts);
+      })
+      .catch(() => {
+        if (!cancelled) setCulturalFacts([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [recipe?.region_id]);
 
   const onToggleChecked = async (ingredientId: number) => {
     if (!isAuthenticated) return;
@@ -457,6 +479,8 @@ export default function RecipeDetailScreen({ route, navigation }: Props) {
               ) : null}
             </View>
           ) : null}
+
+          <DidYouKnowSection facts={culturalFacts} />
 
           <RecipeCommentsSection recipeId={id} qaEnabled={recipe.qa_enabled !== false} />
 

--- a/app/mobile/src/services/culturalFactService.ts
+++ b/app/mobile/src/services/culturalFactService.ts
@@ -1,0 +1,49 @@
+import { apiGetJson } from './httpClient';
+
+/**
+ * Single "Did You Know?" cultural fact. The backend serializer nests
+ * heritage_group and region as `{id, name}` on read.
+ */
+export type CulturalFact = {
+  id: number;
+  text: string;
+  source_url: string;
+  heritage_group: { id: number; name: string } | number | null;
+  region: { id: number; name: string } | number | null;
+  created_at?: string;
+};
+
+function unwrap<T>(data: unknown): T[] {
+  if (Array.isArray(data)) return data as T[];
+  if (data && typeof data === 'object' && Array.isArray((data as { results?: unknown }).results)) {
+    return (data as { results: T[] }).results;
+  }
+  return [];
+}
+
+/**
+ * Fetch cultural facts filtered by region pk (used on recipe detail).
+ * Returns an empty array if nothing tagged to the region — caller should
+ * hide the section rather than render an empty box.
+ */
+export async function fetchCulturalFactsByRegion(
+  regionId: number,
+): Promise<CulturalFact[]> {
+  const data = await apiGetJson<unknown>(
+    `/api/cultural-facts/?region=${encodeURIComponent(String(regionId))}`,
+  );
+  return unwrap<CulturalFact>(data);
+}
+
+/**
+ * Fetch cultural facts under a heritage group (used on the future heritage
+ * screen — see #501). Stub now so the hook is wired ahead of UI work.
+ */
+export async function fetchCulturalFactsByHeritageGroup(
+  groupId: number,
+): Promise<CulturalFact[]> {
+  const data = await apiGetJson<unknown>(
+    `/api/cultural-facts/?heritage_group=${encodeURIComponent(String(groupId))}`,
+  );
+  return unwrap<CulturalFact>(data);
+}

--- a/app/mobile/src/services/recipeService.ts
+++ b/app/mobile/src/services/recipeService.ts
@@ -93,6 +93,12 @@ function normalizeRecipeDetail(data: RecipeDetail & Record<string, unknown>): Re
         : typeof data.region_name === 'string'
           ? data.region_name
           : undefined;
+  const regionId =
+    typeof reg === 'number'
+      ? reg
+      : reg && typeof reg === 'object' && 'id' in reg && typeof (reg as { id: unknown }).id === 'number'
+        ? (reg as { id: number }).id
+        : null;
 
   return {
     ...data,
@@ -100,6 +106,7 @@ function normalizeRecipeDetail(data: RecipeDetail & Record<string, unknown>): Re
     image: typeof data.image === 'string' ? data.image : null,
     author,
     region: regionLabel,
+    region_id: regionId,
   };
 }
 

--- a/app/mobile/src/types/recipe.ts
+++ b/app/mobile/src/types/recipe.ts
@@ -14,6 +14,8 @@ export type RecipeDetail = {
   title: string;
   description?: string;
   region?: string;
+  /** Region FK pk surfaced for filtered queries (e.g. cultural facts by region). */
+  region_id?: number | null;
   image?: string | null;
   video?: string | null;
   /** Normalized to `{ id, username }`; raw API may send `author` as user pk only. */


### PR DESCRIPTION
## Summary
Closes #518 (mobile portion). Adds the "Did You Know?" cultural-context section to RecipeDetail. The card surfaces region-tagged trivia from the backend `/api/cultural-facts/?region=<pk>` endpoint — same data source the future Heritage screen (#501) will use, so the service hook is shared. When the region has no facts seeded, the section hides itself; demo behaviour with backend #664 (cultural facts seed) shipped → every region-tagged recipe gets contextual content for free.

## Files
- **New** `services/culturalFactService.ts` — `fetchCulturalFactsByRegion(regionId)` and `fetchCulturalFactsByHeritageGroup(groupId)` (the latter is stubbed for the Heritage screen work).
- **New** `components/cultural/DidYouKnowSection.tsx` — sticky-note / quote-card visual. Skewed dark-brown icon tile with a yellow "?" glyph, pastel-yellow card body with a 4px-bottom border for "trivia card" depth, large faded `"` glyph in the top-left corner, dark text + accentMustard source pill. Returns `null` for empty arrays so the parent doesn't render an empty box.
- `types/recipe.ts` — added `region_id?: number | null` so the cultural-fact query has a stable FK pk to pass (the existing `region: string` is the friendly label only).
- `services/recipeService.ts` — `normalizeRecipeDetail` now also surfaces `region_id` alongside the existing label.
- `screens/RecipeDetailScreen.tsx` — `culturalFacts` state + an effect that fetches when `recipe.region_id` changes; renders `<DidYouKnowSection facts={culturalFacts} />` between the shopping list and the Q&A / comments section.

## Test
- `npx tsc --noEmit` clean
- Local docker stack: seeded 2 facts by hand (one Aegean, one Black Sea), opened recipes from both regions → "Did you know" section renders the right facts under the matching recipes, hides on regions with no facts (e.g. Marmara, Anatolian). Verified the source pill opens the URL via `Linking.openURL` when present.
- Empty state: a fact with no `source_url` hides the pill cleanly, no spacer artifact.

## Out of scope (followups)
- **Backend seed**: filed #664 — backend team will populate ~2-4 facts per region.
- **Heritage screen integration** (the "Did You Know" cards also belong on the Heritage screen per #518): blocked on #501 (Heritage Screen) — the section component is already reusable; once the screen lands it'll drop in.

Closes #518