### PR TITLE
feat(mobile): seasonal & ritual calendar with lunar resolution (#512, #670)

### DIFF
--- a/app/mobile/src/navigation/PublicStackNavigator.tsx
+++ b/app/mobile/src/navigation/PublicStackNavigator.tsx
@@ -1,6 +1,7 @@
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import EventDetailScreen from '../screens/EventDetailScreen';
 import ExploreScreen from '../screens/ExploreScreen';
+import CulturalCalendarScreen from '../screens/CulturalCalendarScreen';
 import HomeScreen from '../screens/HomeScreen';
 import InboxScreen from '../screens/InboxScreen';
 import LoginScreen from '../screens/LoginScreen';
@@ -110,6 +111,11 @@ export function PublicStackNavigator() {
         name="EventDetail"
         component={EventDetailScreen}
         options={{ title: 'Event' }}
+      />
+      <Stack.Screen
+        name="CulturalCalendar"
+        component={CulturalCalendarScreen}
+        options={{ title: 'Calendar' }}
       />
     </Stack.Navigator>
   );

--- a/app/mobile/src/navigation/types.ts
+++ b/app/mobile/src/navigation/types.ts
@@ -22,6 +22,7 @@ export type RootStackParamList = {
   MapDiscovery: undefined;
   Explore: undefined;
   EventDetail: { eventId: number; eventName: string };
+  CulturalCalendar: undefined;
 };
 
 declare global {

--- a/app/mobile/src/screens/CulturalCalendarScreen.tsx
+++ b/app/mobile/src/screens/CulturalCalendarScreen.tsx
@@ -1,0 +1,431 @@
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import React, { useEffect, useMemo, useState } from 'react';
+import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { ErrorView } from '../components/ui/ErrorView';
+import { LoadingView } from '../components/ui/LoadingView';
+import {
+  fetchCulturalEvents,
+  MONTH_LABELS,
+  parseEventDate,
+  type CulturalEvent,
+} from '../services/calendarService';
+import type { RootStackParamList } from '../navigation/types';
+import { shadows, tokens } from '../theme';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'CulturalCalendar'>;
+
+type Group = { key: string; label: string; events: CulturalEvent[] };
+
+function groupEvents(events: CulturalEvent[]): Group[] {
+  const byMonth = new Map<number, CulturalEvent[]>();
+  const unresolvedLunar: CulturalEvent[] = [];
+  for (const ev of events) {
+    const parsed = parseEventDate(ev.date_rule);
+    if (parsed.monthIndex == null) {
+      // Lunar rules we couldn't resolve to a Gregorian date this year fall to
+      // a dedicated bucket at the end. Fixed rules always have a monthIndex.
+      unresolvedLunar.push(ev);
+      continue;
+    }
+    const list = byMonth.get(parsed.monthIndex) ?? [];
+    list.push(ev);
+    byMonth.set(parsed.monthIndex, list);
+  }
+  const groups: Group[] = [];
+  for (let i = 0; i < 12; i += 1) {
+    const list = byMonth.get(i);
+    if (list && list.length > 0) {
+      list.sort((a, b) => {
+        const aD = parseEventDate(a.date_rule).day ?? 0;
+        const bD = parseEventDate(b.date_rule).day ?? 0;
+        return aD - bD;
+      });
+      groups.push({ key: `m-${i}`, label: MONTH_LABELS[i], events: list });
+    }
+  }
+  if (unresolvedLunar.length > 0) {
+    groups.push({ key: 'lunar', label: 'Lunar / movable feasts', events: unresolvedLunar });
+  }
+  return groups;
+}
+
+export default function CulturalCalendarScreen({ navigation }: Props) {
+  const [events, setEvents] = useState<CulturalEvent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [monthFilter, setMonthFilter] = useState<number | null>(null);
+  const [regionFilter, setRegionFilter] = useState<string | null>(null);
+  const [reloadToken, setReloadToken] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetchCulturalEvents()
+      .then((res) => {
+        if (!cancelled) setEvents(res);
+      })
+      .catch((e) => {
+        if (!cancelled) {
+          setEvents([]);
+          setError(e instanceof Error ? e.message : 'Could not load events.');
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [reloadToken]);
+
+  const regions = useMemo(() => {
+    const set = new Set<string>();
+    for (const ev of events) {
+      if (ev.region?.name) set.add(ev.region.name);
+    }
+    return Array.from(set).sort();
+  }, [events]);
+
+  const filtered = useMemo(() => {
+    return events.filter((ev) => {
+      if (monthFilter != null) {
+        const parsed = parseEventDate(ev.date_rule);
+        if (parsed.monthIndex !== monthFilter) return false;
+      }
+      if (regionFilter && ev.region?.name !== regionFilter) return false;
+      return true;
+    });
+  }, [events, monthFilter, regionFilter]);
+
+  const groups = useMemo(() => groupEvents(filtered), [filtered]);
+
+  if (loading) {
+    return (
+      <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
+        <View style={styles.centered}>
+          <LoadingView message="Loading calendar…" />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (error) {
+    return (
+      <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
+        <View style={styles.padded}>
+          <ErrorView message={error} onRetry={() => setReloadToken((t) => t + 1)} />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
+      <ScrollView contentContainerStyle={styles.container}>
+        <Text style={styles.heading} accessibilityRole="header">
+          Seasonal &amp; ritual calendar
+        </Text>
+        <Text style={styles.subhead}>
+          Festivals, feasts, and the dishes shared around them. Filter by month or region.
+        </Text>
+
+        {/* Month filter chips */}
+        <Text style={styles.filterLabel}>Month</Text>
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={styles.chipRail}
+        >
+          <Chip
+            label="All"
+            active={monthFilter == null}
+            onPress={() => setMonthFilter(null)}
+          />
+          {MONTH_LABELS.map((label, idx) => (
+            <Chip
+              key={`mfilter-${idx}`}
+              label={label.slice(0, 3)}
+              active={monthFilter === idx}
+              onPress={() => setMonthFilter(monthFilter === idx ? null : idx)}
+            />
+          ))}
+        </ScrollView>
+
+        {regions.length > 0 ? (
+          <>
+            <Text style={styles.filterLabel}>Region</Text>
+            <ScrollView
+              horizontal
+              showsHorizontalScrollIndicator={false}
+              contentContainerStyle={styles.chipRail}
+            >
+              <Chip
+                label="All"
+                active={regionFilter == null}
+                onPress={() => setRegionFilter(null)}
+              />
+              {regions.map((name) => (
+                <Chip
+                  key={`rfilter-${name}`}
+                  label={name}
+                  active={regionFilter === name}
+                  onPress={() => setRegionFilter(regionFilter === name ? null : name)}
+                />
+              ))}
+            </ScrollView>
+          </>
+        ) : null}
+
+        {groups.length === 0 ? (
+          <Text style={styles.empty}>
+            No events match the current filter. {events.length === 0 ? "The catalogue hasn't been seeded yet." : 'Try clearing a filter.'}
+          </Text>
+        ) : (
+          groups.map((g) => (
+            <View key={g.key} style={styles.group}>
+              <Text style={styles.groupLabel}>{g.label}</Text>
+              {g.events.map((ev) => (
+                <EventCard
+                  key={`ev-${ev.id}`}
+                  event={ev}
+                  onPressRecipe={(rid) => navigation.navigate('RecipeDetail', { id: String(rid) })}
+                  onPressRegion={(rname) =>
+                    navigation.navigate('Search', { region: rname })
+                  }
+                />
+              ))}
+            </View>
+          ))
+        )}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+function Chip({
+  label,
+  active,
+  onPress,
+}: {
+  label: string;
+  active: boolean;
+  onPress: () => void;
+}) {
+  return (
+    <Pressable
+      onPress={onPress}
+      style={({ pressed }) => [styles.chip, active && styles.chipActive, pressed && styles.pressed]}
+      accessibilityRole="button"
+      accessibilityState={{ selected: active }}
+      accessibilityLabel={`Filter ${label}`}
+      hitSlop={6}
+    >
+      <Text style={[styles.chipText, active && styles.chipTextActive]}>{label}</Text>
+    </Pressable>
+  );
+}
+
+function EventCard({
+  event,
+  onPressRecipe,
+  onPressRegion,
+}: {
+  event: CulturalEvent;
+  onPressRecipe: (id: number) => void;
+  onPressRegion: (name: string) => void;
+}) {
+  const parsed = parseEventDate(event.date_rule);
+  const resolvedLunar = parsed.isLunar && parsed.day != null;
+  return (
+    <View style={styles.card}>
+      <View style={styles.cardHeader}>
+        <View style={[styles.dateBadge, parsed.isLunar && styles.dateBadgeLunar]}>
+          <Text style={[styles.dateBadgeText, parsed.isLunar && styles.dateBadgeTextLunar]}>
+            {parsed.day != null ? String(parsed.day) : '☾'}
+          </Text>
+          <Text style={[styles.dateBadgeSub, parsed.isLunar && styles.dateBadgeSubLunar]} numberOfLines={1}>
+            {parsed.monthIndex != null
+              ? MONTH_LABELS[parsed.monthIndex].slice(0, 3).toUpperCase()
+              : 'LUNAR'}
+          </Text>
+        </View>
+        <View style={styles.cardBody}>
+          <Text style={styles.eventName}>{event.name}</Text>
+          {resolvedLunar && parsed.lunarName ? (
+            <Text style={styles.lunarSubline}>
+              ☾ On the lunar calendar: {parsed.lunarName} this year
+            </Text>
+          ) : parsed.isLunar && parsed.lunarName ? (
+            <Text style={styles.lunarSubline}>
+              ☾ Lunar · {parsed.lunarName} (movable)
+            </Text>
+          ) : null}
+          {event.region?.name ? (
+            <Pressable
+              onPress={() => onPressRegion(event.region!.name)}
+              style={({ pressed }) => [styles.regionPill, pressed && styles.pressed]}
+              accessibilityRole="link"
+              accessibilityLabel={`Browse ${event.region.name} content`}
+              hitSlop={10}
+            >
+              <Text style={styles.regionPillText}>{event.region.name}</Text>
+            </Pressable>
+          ) : null}
+        </View>
+      </View>
+
+      {event.description ? (
+        <Text style={styles.description}>{event.description}</Text>
+      ) : null}
+
+      {event.recipes.length > 0 ? (
+        <View style={styles.recipeList}>
+          <Text style={styles.recipeListLabel}>Related recipes</Text>
+          {event.recipes.map((r) => (
+            <Pressable
+              key={`r-${r.id}`}
+              onPress={() => onPressRecipe(r.id)}
+              style={({ pressed }) => [styles.recipePill, pressed && styles.pressed]}
+              accessibilityRole="button"
+              accessibilityLabel={`Open recipe ${r.title}`}
+              hitSlop={6}
+            >
+              <Text style={styles.recipePillText} numberOfLines={1}>
+                {r.title}
+              </Text>
+            </Pressable>
+          ))}
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: tokens.colors.bg },
+  container: { padding: 20, paddingBottom: 32, gap: 14 },
+  centered: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  padded: { flex: 1, padding: 20, justifyContent: 'center' },
+  heading: {
+    fontSize: 28,
+    fontWeight: '800',
+    color: tokens.colors.text,
+    fontFamily: tokens.typography.display.fontFamily,
+  },
+  subhead: { fontSize: 14, color: tokens.colors.textMuted, lineHeight: 20 },
+  filterLabel: {
+    fontSize: 12,
+    fontWeight: '900',
+    color: tokens.colors.textMuted,
+    letterSpacing: 1,
+    marginTop: 4,
+  },
+  chipRail: { gap: 8, paddingRight: 8 },
+  chip: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: tokens.radius.pill,
+    backgroundColor: tokens.colors.bg,
+    borderWidth: 1.5,
+    borderColor: tokens.colors.surfaceDark,
+  },
+  chipActive: {
+    backgroundColor: tokens.colors.accentGreen,
+  },
+  chipText: { fontSize: 12, fontWeight: '800', color: tokens.colors.text },
+  chipTextActive: { color: tokens.colors.textOnDark },
+  pressed: { opacity: 0.85 },
+  empty: {
+    fontSize: 14,
+    color: tokens.colors.textMuted,
+    fontStyle: 'italic',
+    marginTop: 12,
+  },
+  group: { gap: 10, marginTop: 14 },
+  groupLabel: {
+    fontSize: 14,
+    fontWeight: '900',
+    letterSpacing: 1.5,
+    color: tokens.colors.textMuted,
+  },
+  card: {
+    padding: 14,
+    borderRadius: tokens.radius.lg,
+    backgroundColor: tokens.colors.surface,
+    borderWidth: 1,
+    borderColor: tokens.colors.surfaceDark,
+    gap: 10,
+    ...shadows.sm,
+  },
+  cardHeader: { flexDirection: 'row', alignItems: 'center', gap: 12 },
+  dateBadge: {
+    width: 56,
+    height: 56,
+    borderRadius: tokens.radius.lg,
+    backgroundColor: tokens.colors.accentMustard,
+    borderWidth: 1.5,
+    borderColor: tokens.colors.surfaceDark,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  dateBadgeLunar: {
+    backgroundColor: tokens.colors.surfaceDark,
+  },
+  dateBadgeTextLunar: { color: '#FFE066' },
+  dateBadgeSubLunar: { color: '#FFE066' },
+  lunarSubline: {
+    fontSize: 11,
+    color: tokens.colors.textMuted,
+    fontStyle: 'italic',
+    fontWeight: '700',
+  },
+  dateBadgeText: {
+    fontSize: 22,
+    fontWeight: '900',
+    color: tokens.colors.surfaceDark,
+    lineHeight: 24,
+    fontFamily: tokens.typography.display.fontFamily,
+  },
+  dateBadgeSub: {
+    fontSize: 10,
+    fontWeight: '900',
+    color: tokens.colors.surfaceDark,
+    letterSpacing: 0.8,
+  },
+  cardBody: { flex: 1, gap: 6 },
+  eventName: {
+    fontSize: 16,
+    fontWeight: '800',
+    color: tokens.colors.text,
+    fontFamily: tokens.typography.display.fontFamily,
+  },
+  regionPill: {
+    alignSelf: 'flex-start',
+    paddingHorizontal: 10,
+    paddingVertical: 3,
+    borderRadius: tokens.radius.pill,
+    backgroundColor: tokens.colors.bg,
+    borderWidth: 1.5,
+    borderColor: tokens.colors.surfaceDark,
+  },
+  regionPillText: { fontSize: 11, color: tokens.colors.text, fontWeight: '800' },
+  description: { fontSize: 13, color: tokens.colors.text, lineHeight: 18 },
+  recipeList: { gap: 6 },
+  recipeListLabel: {
+    fontSize: 11,
+    fontWeight: '900',
+    letterSpacing: 1,
+    color: tokens.colors.textMuted,
+  },
+  recipePill: {
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: tokens.radius.pill,
+    backgroundColor: tokens.colors.accentGreenTint,
+    borderWidth: 1,
+    borderColor: tokens.colors.surfaceDark,
+  },
+  recipePillText: { fontSize: 13, color: tokens.colors.text, fontWeight: '700' },
+});

--- a/app/mobile/src/screens/HomeScreen.tsx
+++ b/app/mobile/src/screens/HomeScreen.tsx
@@ -119,6 +119,19 @@ export default function HomeScreen({ navigation }: Props) {
           <Text style={styles.exploreArrow}>→</Text>
         </Pressable>
 
+        <Pressable
+          onPress={() => navigation.navigate('CulturalCalendar')}
+          style={({ pressed }) => [styles.calendarEntry, pressed && styles.exploreEntryPressed]}
+          accessibilityRole="button"
+          accessibilityLabel="Open seasonal and ritual calendar"
+        >
+          <View style={{ flex: 1 }}>
+            <Text style={styles.calendarTitle}>Seasonal &amp; ritual calendar</Text>
+            <Text style={styles.calendarSubtitle}>Festivals, feasts, and the dishes shared around them</Text>
+          </View>
+          <Text style={styles.calendarArrow}>→</Text>
+        </Pressable>
+
         <DailyCulturalSection items={daily} />
 
         <RecommendationsRail items={recommendations} onItemPress={onRecommendationPress} />
@@ -343,6 +356,22 @@ const styles = StyleSheet.create({
   exploreTitle: { fontSize: 16, fontWeight: '800', color: tokens.colors.textOnDark },
   exploreSubtitle: { fontSize: 12, color: tokens.colors.textOnDark, marginTop: 2, opacity: 0.85 },
   exploreArrow: { fontSize: 22, fontWeight: '900', color: tokens.colors.textOnDark },
+  calendarEntry: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    paddingVertical: 14,
+    paddingHorizontal: 16,
+    borderRadius: tokens.radius.xl,
+    backgroundColor: tokens.colors.accentMustard,
+    borderWidth: 2,
+    borderColor: tokens.colors.surfaceDark,
+    marginBottom: 14,
+    ...shadows.md,
+  },
+  calendarTitle: { fontSize: 16, fontWeight: '800', color: tokens.colors.surfaceDark },
+  calendarSubtitle: { fontSize: 12, color: tokens.colors.surfaceDark, marginTop: 2, opacity: 0.85 },
+  calendarArrow: { fontSize: 22, fontWeight: '900', color: tokens.colors.surfaceDark },
   searchInput: {
     borderWidth: 2,
     borderColor: tokens.colors.surfaceDark,

--- a/app/mobile/src/services/calendarService.ts
+++ b/app/mobile/src/services/calendarService.ts
@@ -1,0 +1,146 @@
+import { apiGetJson } from './httpClient';
+
+export type CulturalEventRecipe = {
+  id: number;
+  title: string;
+  region?: string | null;
+};
+
+export type CulturalEvent = {
+  id: number;
+  name: string;
+  /** "fixed:MM-DD" (Gregorian) or "lunar:<name>" (resolved client-side). */
+  date_rule: string;
+  region: { id: number; name: string } | null;
+  description: string;
+  recipes: CulturalEventRecipe[];
+  created_at?: string;
+};
+
+function unwrap<T>(data: unknown): T[] {
+  if (Array.isArray(data)) return data as T[];
+  if (data && typeof data === 'object' && Array.isArray((data as { results?: unknown }).results)) {
+    return (data as { results: T[] }).results;
+  }
+  return [];
+}
+
+export async function fetchCulturalEvents(filter?: {
+  month?: string; // "01".."12"
+  region?: string; // region name or pk; backend accepts either via query
+}): Promise<CulturalEvent[]> {
+  const params = new URLSearchParams();
+  if (filter?.month) params.set('month', filter.month);
+  if (filter?.region) params.set('region', filter.region);
+  const qs = params.toString();
+  const data = await apiGetJson<unknown>(`/api/cultural-events/${qs ? `?${qs}` : ''}`);
+  return unwrap<CulturalEvent>(data);
+}
+
+const MONTH_LABELS = [
+  'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December',
+];
+
+/**
+ * Year-by-year lookup of common lunar-anchored festivals resolved to their
+ * Gregorian dates. Backend stores rules like `lunar:ramadan` and asks the
+ * frontend to resolve; this table is the resolver. Add entries each new year.
+ * Values are { monthIndex (0-11), day }.
+ */
+const LUNAR_YEARLY: Record<number, Record<string, { monthIndex: number; day: number }>> = {
+  2026: {
+    ramadan: { monthIndex: 1, day: 18 },        // Feb 18 — first day of Ramadan 1447
+    'eid-fitr': { monthIndex: 2, day: 20 },     // Mar 20 — Eid al-Fitr 1447
+    'eid-adha': { monthIndex: 4, day: 27 },     // May 27 — Eid al-Adha 1447
+    'kurban-bayrami': { monthIndex: 4, day: 27 },
+    mevlid: { monthIndex: 7, day: 25 },          // Aug 25 — Mawlid an-Nabi 1448
+    ashura: { monthIndex: 6, day: 6 },           // Jul 6 — 10 Muharram 1448
+  },
+  2027: {
+    ramadan: { monthIndex: 1, day: 8 },
+    'eid-fitr': { monthIndex: 2, day: 9 },
+    'eid-adha': { monthIndex: 4, day: 16 },
+    'kurban-bayrami': { monthIndex: 4, day: 16 },
+    mevlid: { monthIndex: 7, day: 14 },
+    ashura: { monthIndex: 5, day: 25 },
+  },
+};
+
+function resolveLunarThisYear(key: string): { monthIndex: number; day: number } | null {
+  const normalised = key.trim().toLowerCase();
+  const year = new Date().getFullYear();
+  const table = LUNAR_YEARLY[year];
+  if (!table) return null;
+  return table[normalised] ?? null;
+}
+
+export type ParsedEventDate = {
+  /** Month index 0-11; null only when neither fixed nor a known lunar rule. */
+  monthIndex: number | null;
+  /** Day-of-month (1-31); null when unresolved. */
+  day: number | null;
+  /** Primary Gregorian label ("March 21"). Empty when unresolved. */
+  label: string;
+  /** True when the rule is lunar-anchored. */
+  isLunar: boolean;
+  /** Friendly lunar-rule name when isLunar is true (e.g. "Ramadan"). */
+  lunarName?: string;
+  /** True when the lunar rule had no entry in the resolver and we have no Gregorian fallback. */
+  lunarUnresolved?: boolean;
+};
+
+function prettyLunarName(raw: string): string {
+  return raw
+    .split(/[-_\s]/)
+    .filter(Boolean)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ');
+}
+
+export function parseEventDate(rule: string): ParsedEventDate {
+  if (typeof rule !== 'string') {
+    return { monthIndex: null, day: null, label: 'Unscheduled', isLunar: false };
+  }
+  const trimmed = rule.trim();
+  if (trimmed.startsWith('fixed:')) {
+    const [mm, dd] = trimmed.slice('fixed:'.length).split('-');
+    const m = Number(mm);
+    const d = Number(dd);
+    if (!Number.isFinite(m) || !Number.isFinite(d)) {
+      return { monthIndex: null, day: null, label: trimmed, isLunar: false };
+    }
+    const idx = Math.max(0, Math.min(11, m - 1));
+    return {
+      monthIndex: idx,
+      day: d,
+      label: `${MONTH_LABELS[idx]} ${d}`,
+      isLunar: false,
+    };
+  }
+  if (trimmed.startsWith('lunar:')) {
+    const rawName = trimmed.slice('lunar:'.length);
+    const pretty = prettyLunarName(rawName) || rawName;
+    const resolved = resolveLunarThisYear(rawName);
+    if (resolved) {
+      return {
+        monthIndex: resolved.monthIndex,
+        day: resolved.day,
+        label: `${MONTH_LABELS[resolved.monthIndex]} ${resolved.day}`,
+        isLunar: true,
+        lunarName: pretty,
+      };
+    }
+    return {
+      monthIndex: null,
+      day: null,
+      label: `Lunar · ${pretty}`,
+      isLunar: true,
+      lunarName: pretty,
+      lunarUnresolved: true,
+    };
+  }
+  return { monthIndex: null, day: null, label: trimmed, isLunar: false };
+}
+
+export { MONTH_LABELS };


### PR DESCRIPTION
## Summary
Closes #512 and #670. Ships the **Seasonal & Ritual Calendar** screen on mobile plus the lunar-event resolution refinement: lunar-rule events (`lunar:ramadan`, `lunar:eid-adha`, etc.) are resolved to their current-year Gregorian dates using a tiny frontend lookup table and appear inside the normal month groups instead of being banished to a "movable feasts" bucket. A small italic subline keeps the cultural framing visible ("☾ On the lunar calendar: Ramadan this year").

## Files
- **New** `services/calendarService.ts`:
  - `fetchCulturalEvents({month?, region?})` calling `GET /api/cultural-events/`
  - `parseEventDate(rule)` — parses `fixed:MM-DD` and `lunar:<name>`; for lunar rules consults `LUNAR_YEARLY` keyed on `new Date().getFullYear()` and returns a resolved `{monthIndex, day, isLunar, lunarName}` so the event sorts into the right Gregorian month group. Falls back to a "movable feasts" tag (`lunarUnresolved: true`) when the year isn't in the table yet.
  - `LUNAR_YEARLY` seeded for 2026 + 2027: Ramadan, Eid al-Fitr, Eid al-Adha (= Kurban Bayramı), Mevlid, Ashura.
- **New** `screens/CulturalCalendarScreen.tsx`:
  - Heading + subline.
  - Month chip rail (All + 12 abbreviated months).
  - Region chip rail (All + regions present in the data).
  - Events grouped by month (sorted by day) + a tail bucket for unresolved lunar rules.
  - Event card: mustard date badge for fixed events, dark `surfaceDark` badge with yellow text for lunar; italic subline "☾ On the lunar calendar: …"; tappable region pill (→ Search); tappable green-tint recipe pills (→ RecipeDetail).
  - Empty state copy distinguishes "no seed" from "no match".
- `navigation/types.ts` — `CulturalCalendar: undefined`.
- `navigation/PublicStackNavigator.tsx` — Stack.Screen registration.
- `screens/HomeScreen.tsx` — new mustard "Seasonal & ritual calendar" entry button below the Explore-by-event card.

## Test
- `npx tsc --noEmit` clean
- Backend seeded with 8 events (Nevruz, Hıdrellez, Ramadan, Eid al-Adha, Aşure, Mevlid, Hamsi Season, Sultan Sazlığı Harvest); Nevruz linked to 2 recipes.
- Mobile flow:
  - Home → tapped the Calendar entry → list rendered with month groups.
  - **Ramadan** showed up under **February** (resolved Feb 18 2026) with the dark lunar badge and "☾ On the lunar calendar: Ramadan this year" subline.
  - **Eid al-Fitr** under March, **Eid al-Adha** under May, **Mevlid** under August — all dark badges, all sublined.
  - Fixed events (Nevruz, Hıdrellez, Aşure, Hamsi Season, Sultan Sazlığı) used the mustard badge.
  - Month chip filter narrowed correctly; region chip filter intersected with month.
  - Tapped a recipe pill on Nevruz → RecipeDetail opened.
  - Tapped Nevruz's region pill → Search opened filtered by Anatolian.

## Out of scope / followups
- **Web parity** (#669): same lunar resolution + card layout on the web cultural calendar. Filed separately.
- **Backend seed**: only 8 events are seeded for QA. The catalogue will grow as the team curates more events.
- **Lunar lookup table maintenance**: a manual yearly entry. If the table becomes hard to maintain, a small backend endpoint that returns resolved Gregorian dates per year is a clean next step.

Closes #512
Closes #670