### PR TITLE
feat(frontend): Heritage Page, map, journey, Did You Know, calendar view (#500, #515, #517, #527, #668, #669)

### DIFF
--- a/app/frontend/src/App.js
+++ b/app/frontend/src/App.js
@@ -19,6 +19,9 @@ import InboxPage from './pages/InboxPage';
 import ThreadPage from './pages/ThreadPage';
 import OnboardingPage from './pages/OnboardingPage';
 import ProfilePage from './pages/ProfilePage';
+import AccountPage from './pages/AccountPage';
+import HeritagePage from './pages/HeritagePage';
+import CalendarPage from './pages/CalendarPage';
 import MapPage from './pages/MapPage';
 import ExplorePage from './pages/ExplorePage';
 import EventDetailPage from './pages/EventDetailPage';
@@ -116,9 +119,16 @@ export default function App() {
             element={<ProtectedRoute><ProfilePage /></ProtectedRoute>}
           />
           <Route
+            path="/account"
+            element={<ProtectedRoute><AccountPage /></ProtectedRoute>}
+          />
+          <Route
             path="/admin/moderation"
             element={<ProtectedRoute><ModerationPage /></ProtectedRoute>}
           />
+
+          <Route path="/heritage/:id" element={<HeritagePage />} />
+          <Route path="/calendar" element={<CalendarPage />} />
 
           <Route path="*" element={<NotFoundPage />} />
         </Routes>

--- a/app/frontend/src/components/HeritageBadge.css
+++ b/app/frontend/src/components/HeritageBadge.css
@@ -1,0 +1,48 @@
+.heritage-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+  background: linear-gradient(135deg, #3d1500 0%, #6b2a0a 100%);
+  color: #f5e6c8;
+  border-radius: 10px;
+  padding: 0.7rem 1rem;
+  text-decoration: none;
+  margin-top: 1.5rem;
+  transition: opacity 0.15s;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.heritage-badge:hover {
+  opacity: 0.88;
+}
+
+.heritage-badge-icon {
+  font-size: 1.3rem;
+  flex-shrink: 0;
+}
+
+.heritage-badge-text {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  gap: 0.1rem;
+}
+
+.heritage-badge-label {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  opacity: 0.75;
+}
+
+.heritage-badge-name {
+  font-size: 0.97rem;
+  font-weight: 600;
+}
+
+.heritage-badge-arrow {
+  font-size: 1rem;
+  opacity: 0.6;
+  flex-shrink: 0;
+}

--- a/app/frontend/src/components/HeritageBadge.jsx
+++ b/app/frontend/src/components/HeritageBadge.jsx
@@ -1,0 +1,17 @@
+import { Link } from 'react-router-dom';
+import './HeritageBadge.css';
+
+export default function HeritageBadge({ heritageGroup }) {
+  if (!heritageGroup) return null;
+
+  return (
+    <Link to={`/heritage/${heritageGroup.id}`} className="heritage-badge">
+      <span className="heritage-badge-icon">🏛</span>
+      <span className="heritage-badge-text">
+        <span className="heritage-badge-label">Heritage</span>
+        <span className="heritage-badge-name">{heritageGroup.name}</span>
+      </span>
+      <span className="heritage-badge-arrow">→</span>
+    </Link>
+  );
+}

--- a/app/frontend/src/components/Navbar.jsx
+++ b/app/frontend/src/components/Navbar.jsx
@@ -84,6 +84,13 @@ export default function Navbar() {
                       Profile
                     </Link>
                     <Link
+                      to="/account"
+                      className="navbar-dropdown-item"
+                      onClick={() => setMenuOpen(false)}
+                    >
+                      My Account
+                    </Link>
+                    <Link
                       to="/recipes/new"
                       className="navbar-dropdown-item"
                       onClick={() => setMenuOpen(false)}

--- a/app/frontend/src/pages/AccountPage.css
+++ b/app/frontend/src/pages/AccountPage.css
@@ -1,0 +1,140 @@
+.account-page {
+  max-width: 760px;
+  margin: 0 auto;
+}
+
+.account-title {
+  margin-bottom: 1.4rem;
+}
+
+.account-info {
+  background: var(--color-surface-alt, #f2ede3);
+  border: 1px solid var(--color-border);
+  border-radius: 10px;
+  padding: 1rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  margin-bottom: 2rem;
+}
+
+.account-info-row {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+}
+
+.account-info-label {
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  min-width: 72px;
+}
+
+.account-info-value {
+  font-size: 1rem;
+  color: var(--color-text, #1a1a1a);
+}
+
+.account-prefs-heading {
+  font-size: 1.05rem;
+  margin-bottom: 1.2rem;
+}
+
+.account-pref-section {
+  margin-bottom: 1.6rem;
+}
+
+.account-pref-title {
+  font-size: 0.97rem;
+  margin-bottom: 0.25rem;
+}
+
+.account-pref-desc {
+  font-size: 0.88rem;
+  color: var(--color-text-muted);
+  margin: 0 0 0.75rem 0;
+}
+
+.account-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+}
+
+.account-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  padding: 0.38rem 0.75rem;
+  background: var(--color-surface);
+  cursor: pointer;
+  font-size: 0.9rem;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.account-chip input {
+  accent-color: var(--color-primary);
+}
+
+.account-chip-active {
+  border-color: var(--color-primary);
+  background: var(--color-primary-tint, rgba(196, 82, 30, 0.08));
+}
+
+.account-prefs-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1.2rem;
+}
+
+.account-prefs-header .account-prefs-heading {
+  margin-bottom: 0;
+}
+
+.account-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.account-tag {
+  display: inline-block;
+  background: var(--color-primary-tint, rgba(196, 82, 30, 0.08));
+  border: 1px solid rgba(196, 82, 30, 0.25);
+  color: var(--color-primary);
+  border-radius: 999px;
+  padding: 0.3rem 0.7rem;
+  font-size: 0.88rem;
+  font-weight: 500;
+}
+
+.account-tags-empty {
+  font-size: 0.88rem;
+  color: var(--color-text-muted);
+}
+
+.account-error {
+  color: var(--color-error, #c0392b);
+  margin: 0.5rem 0;
+  font-size: 0.9rem;
+}
+
+.account-saved {
+  color: #2e7d32;
+  margin: 0.5rem 0;
+  font-size: 0.9rem;
+}
+
+.account-actions {
+  margin-top: 1rem;
+  padding-top: 1.2rem;
+  border-top: 1px solid var(--color-border);
+  display: flex;
+  gap: 0.6rem;
+}

--- a/app/frontend/src/pages/AccountPage.jsx
+++ b/app/frontend/src/pages/AccountPage.jsx
@@ -1,0 +1,185 @@
+import { useContext, useState, useEffect, useRef } from 'react';
+import { AuthContext } from '../context/AuthContext';
+import { updateMe } from '../services/authService';
+import { extractApiError } from '../services/api';
+import './AccountPage.css';
+
+const PREFERENCE_SECTIONS = [
+  {
+    key: 'cultural_interests',
+    title: 'Cultural Interests',
+    description: 'Cuisines and traditions you want to explore.',
+    options: ['Ottoman', 'Anatolian', 'Balkan', 'Levantine', 'Mediterranean', 'Central Asian'],
+  },
+  {
+    key: 'regional_ties',
+    title: 'Regional Ties',
+    description: 'Regions connected to your family or roots.',
+    options: ['Aegean', 'Marmara', 'Central Anatolia', 'Black Sea', 'Mediterranean', 'Southeastern Anatolia'],
+  },
+  {
+    key: 'religious_preferences',
+    title: 'Dietary / Religious Preferences',
+    description: 'Preferences that personalize your recommendations.',
+    options: ['Halal', 'Kosher', 'Vegetarian', 'Vegan', 'Pescetarian', 'No Preference'],
+  },
+  {
+    key: 'event_interests',
+    title: 'Event Interests',
+    description: 'Occasions you cook for most often.',
+    options: ['Ramadan', 'Eid', 'Weddings', 'Family Gatherings', 'Religious Holidays', 'Weeknight Meals'],
+  },
+];
+
+function normalizeList(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function buildValues(user) {
+  return {
+    cultural_interests: normalizeList(user?.cultural_interests),
+    regional_ties: normalizeList(user?.regional_ties),
+    religious_preferences: normalizeList(user?.religious_preferences),
+    event_interests: normalizeList(user?.event_interests),
+  };
+}
+
+export default function AccountPage() {
+  const { user, updateUser } = useContext(AuthContext);
+
+  const [values, setValues] = useState(() => buildValues(user));
+  const initialized = useRef(!!user);
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(values);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (user && !initialized.current) {
+      initialized.current = true;
+      const v = buildValues(user);
+      setValues(v);
+      setDraft(v);
+    }
+  }, [user]);
+
+  function handleEdit() {
+    setDraft(values);
+    setError('');
+    setEditing(true);
+  }
+
+  function handleCancel() {
+    setEditing(false);
+    setError('');
+  }
+
+  function toggleOption(key, option) {
+    setDraft((prev) => {
+      const current = prev[key];
+      const next = current.includes(option)
+        ? current.filter((v) => v !== option)
+        : [...current, option];
+      return { ...prev, [key]: next };
+    });
+  }
+
+  async function handleSave() {
+    setSaving(true);
+    setError('');
+    try {
+      const updated = await updateMe(draft);
+      updateUser(updated);
+      const v = buildValues(updated);
+      setValues(v);
+      setDraft(v);
+      setEditing(false);
+    } catch (err) {
+      setError(extractApiError(err, 'Could not save changes. Please try again.'));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (!user) return <p className="page-status">Loading…</p>;
+
+  return (
+    <main className="page-card account-page">
+      <h1 className="account-title">My Account</h1>
+
+      <section className="account-info">
+        <div className="account-info-row">
+          <span className="account-info-label">Username</span>
+          <span className="account-info-value">@{user.username}</span>
+        </div>
+        <div className="account-info-row">
+          <span className="account-info-label">Email</span>
+          <span className="account-info-value">{user.email}</span>
+        </div>
+      </section>
+
+      <section className="account-preferences">
+        <div className="account-prefs-header">
+          <h2 className="account-prefs-heading">Preferences</h2>
+          {!editing && (
+            <button type="button" className="btn btn-outline btn-sm" onClick={handleEdit}>
+              Edit
+            </button>
+          )}
+        </div>
+
+        {PREFERENCE_SECTIONS.map((section) => {
+          const selected = editing ? draft[section.key] : values[section.key];
+          return (
+            <div key={section.key} className="account-pref-section">
+              <h3 className="account-pref-title">{section.title}</h3>
+
+              {editing ? (
+                <div className="account-chips">
+                  {section.options.map((option) => {
+                    const checked = draft[section.key].includes(option);
+                    return (
+                      <label
+                        key={option}
+                        className={`account-chip${checked ? ' account-chip-active' : ''}`}
+                      >
+                        <input
+                          type="checkbox"
+                          checked={checked}
+                          onChange={() => toggleOption(section.key, option)}
+                        />
+                        <span>{option}</span>
+                      </label>
+                    );
+                  })}
+                </div>
+              ) : (
+                <div className="account-tags">
+                  {selected.length > 0
+                    ? selected.map((item) => (
+                        <span key={item} className="account-tag">{item}</span>
+                      ))
+                    : <span className="account-tags-empty">None selected</span>
+                  }
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </section>
+
+      {error && <p className="account-error">{error}</p>}
+
+      {editing && (
+        <div className="account-actions">
+          <button type="button" className="btn btn-outline" onClick={handleCancel} disabled={saving}>
+            Cancel
+          </button>
+          <button type="button" className="btn btn-primary" onClick={handleSave} disabled={saving}>
+            {saving ? 'Saving…' : 'Save Changes'}
+          </button>
+        </div>
+      )}
+    </main>
+  );
+}

--- a/app/frontend/src/pages/CalendarPage.css
+++ b/app/frontend/src/pages/CalendarPage.css
@@ -1,0 +1,226 @@
+.calendar-page {
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.calendar-title {
+  margin-bottom: 0.3rem;
+}
+
+.calendar-subtitle {
+  margin: 0 0 1.5rem 0;
+  color: var(--color-text-muted);
+  font-size: 0.97rem;
+}
+
+.calendar-filters {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 1.8rem;
+  flex-wrap: wrap;
+}
+
+.calendar-filter-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.calendar-filter-group label {
+  font-size: 0.78rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-muted);
+}
+
+.calendar-filter-group select {
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  padding: 0.4rem 0.7rem;
+  font-size: 0.9rem;
+  background: var(--color-surface);
+  color: var(--color-text);
+  cursor: pointer;
+}
+
+.calendar-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 1.2rem;
+  margin-bottom: 1.5rem;
+}
+
+.calendar-month {
+  border: 1px solid var(--color-border);
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.calendar-movable {
+  border-color: rgba(196, 82, 30, 0.3);
+  background: rgba(196, 82, 30, 0.03);
+}
+
+.calendar-month-name {
+  font-size: 0.88rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 0.65rem 1rem;
+  background: var(--color-surface-alt, #f2ede3);
+  border-bottom: 1px solid var(--color-border);
+  margin: 0;
+  color: var(--color-text-muted);
+}
+
+.calendar-empty {
+  padding: 0.7rem 1rem;
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+  margin: 0;
+}
+
+.calendar-event-card {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: none;
+  border-bottom: 1px solid var(--color-border);
+  padding: 0.65rem 1rem;
+  cursor: pointer;
+  transition: background 0.12s;
+}
+
+.calendar-event-card:last-child {
+  border-bottom: none;
+}
+
+.calendar-event-card:hover,
+.calendar-event-card.selected {
+  background: rgba(196, 82, 30, 0.06);
+}
+
+.calendar-event-top {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+}
+
+.calendar-event-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  background: #f0e4d0;
+  color: #b85c2a;
+  font-size: 0.8rem;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.calendar-event-badge.lunar {
+  background: #1e1a2e;
+  color: #c9b8f0;
+}
+
+.calendar-event-name {
+  font-size: 0.92rem;
+  font-weight: 500;
+  flex: 1;
+}
+
+.calendar-event-region {
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  flex-shrink: 0;
+}
+
+.calendar-lunar-subline {
+  margin: 0.25rem 0 0 2.15rem;
+  font-size: 0.78rem;
+  font-style: italic;
+  color: var(--color-text-muted);
+}
+
+.calendar-lunar-subline.movable {
+  color: var(--color-text-muted);
+  opacity: 0.7;
+}
+
+/* Detail panel */
+.calendar-detail {
+  background: var(--color-surface-alt, #f2ede3);
+  border: 1px solid var(--color-border);
+  border-radius: 10px;
+  padding: 1.2rem 1.4rem;
+  margin-top: 0.5rem;
+}
+
+.calendar-detail-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.7rem;
+}
+
+.calendar-detail-header h2 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.calendar-detail-close {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1rem;
+  color: var(--color-text-muted);
+}
+
+.calendar-detail-region {
+  font-size: 0.88rem;
+  color: var(--color-text-muted);
+  margin: 0 0 0.6rem 0;
+}
+
+.calendar-detail-desc {
+  font-size: 0.92rem;
+  line-height: 1.55;
+  margin: 0 0 0.8rem 0;
+}
+
+.calendar-detail-recipes h3 {
+  font-size: 0.88rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-muted);
+  margin-bottom: 0.5rem;
+}
+
+.calendar-detail-recipes ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.calendar-detail-recipes a {
+  font-size: 0.9rem;
+  color: var(--color-primary);
+  text-decoration: none;
+}
+
+.calendar-detail-recipes a:hover {
+  text-decoration: underline;
+}
+
+@media (max-width: 640px) {
+  .calendar-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/app/frontend/src/pages/CalendarPage.jsx
+++ b/app/frontend/src/pages/CalendarPage.jsx
@@ -1,0 +1,177 @@
+import { useState, useEffect, useMemo } from 'react';
+import { Link } from 'react-router-dom';
+import { fetchCulturalEvents, parseEventDate } from '../services/calendarService';
+import { extractApiError } from '../services/api';
+import './CalendarPage.css';
+
+const MONTHS = ['January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December'];
+
+const MOVABLE_KEY = '__movable__';
+
+export default function CalendarPage() {
+  const [events, setEvents] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [selectedMonth, setSelectedMonth] = useState(null);
+  const [selectedEvent, setSelectedEvent] = useState(null);
+  const [regionFilter, setRegionFilter] = useState('');
+
+  useEffect(() => {
+    fetchCulturalEvents()
+      .then(setEvents)
+      .catch(err => setError(extractApiError(err, 'Could not load events.')))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const regions = useMemo(() => {
+    const names = new Set();
+    events.forEach(e => { if (e.region?.name) names.add(e.region.name); });
+    return [...names].sort();
+  }, [events]);
+
+  const filtered = useMemo(() => {
+    return regionFilter ? events.filter(e => e.region?.name === regionFilter) : events;
+  }, [events, regionFilter]);
+
+  // Group events by month index, unresolved lunar → movable bucket
+  const byMonth = useMemo(() => {
+    const map = {};
+    for (const ev of filtered) {
+      const parsed = parseEventDate(ev.date_rule);
+      const key = (!parsed || parsed.lunarUnresolved) ? MOVABLE_KEY : parsed.monthIndex;
+      if (!map[key]) map[key] = [];
+      map[key].push({ ev, parsed });
+    }
+    return map;
+  }, [filtered]);
+
+  const monthsToShow = selectedMonth !== null
+    ? [selectedMonth]
+    : [...Array(12).keys()];
+
+  if (loading) return <p className="page-status">Loading…</p>;
+  if (error) return <p className="page-status page-status-error">{error}</p>;
+
+  return (
+    <main className="page-card calendar-page">
+      <h1 className="calendar-title">Cultural Food Calendar</h1>
+      <p className="calendar-subtitle">Seasonal traditions, ritual meals, and cultural food events.</p>
+
+      <div className="calendar-filters">
+        <div className="calendar-filter-group">
+          <label htmlFor="cal-region">Region</label>
+          <select
+            id="cal-region"
+            value={regionFilter}
+            onChange={e => setRegionFilter(e.target.value)}
+          >
+            <option value="">All regions</option>
+            {regions.map(r => <option key={r} value={r}>{r}</option>)}
+          </select>
+        </div>
+        <div className="calendar-filter-group">
+          <label htmlFor="cal-month">Month</label>
+          <select
+            id="cal-month"
+            value={selectedMonth ?? ''}
+            onChange={e => setSelectedMonth(e.target.value === '' ? null : Number(e.target.value))}
+          >
+            <option value="">All months</option>
+            {MONTHS.map((m, i) => <option key={i} value={i}>{m}</option>)}
+          </select>
+        </div>
+      </div>
+
+      <div className="calendar-grid">
+        {monthsToShow.map(mi => {
+          const entries = byMonth[mi] ?? [];
+          if (entries.length === 0 && selectedMonth === null) return null;
+          return (
+            <div key={mi} className="calendar-month">
+              <h2 className="calendar-month-name">{MONTHS[mi]}</h2>
+              {entries.length === 0
+                ? <p className="calendar-empty">No events this month.</p>
+                : entries.map(({ ev, parsed }) => (
+                    <button
+                      key={ev.id}
+                      type="button"
+                      className={`calendar-event-card${selectedEvent?.id === ev.id ? ' selected' : ''}`}
+                      onClick={() => setSelectedEvent(selectedEvent?.id === ev.id ? null : ev)}
+                    >
+                      <div className="calendar-event-top">
+                        <span className={`calendar-event-badge${parsed?.isLunar ? ' lunar' : ''}`}>
+                          {parsed?.isLunar ? '☾' : parsed?.day ?? '?'}
+                        </span>
+                        <span className="calendar-event-name">{ev.name}</span>
+                        {ev.region?.name && (
+                          <span className="calendar-event-region">{ev.region.name}</span>
+                        )}
+                      </div>
+                      {parsed?.isLunar && !parsed?.lunarUnresolved && (
+                        <p className="calendar-lunar-subline">
+                          ☾ On the lunar calendar: {ev.name} this year
+                        </p>
+                      )}
+                      {parsed?.lunarUnresolved && (
+                        <p className="calendar-lunar-subline movable">(movable feast)</p>
+                      )}
+                    </button>
+                  ))
+              }
+            </div>
+          );
+        })}
+
+        {/* Movable feasts bucket */}
+        {byMonth[MOVABLE_KEY]?.length > 0 && selectedMonth === null && (
+          <div className="calendar-month calendar-movable">
+            <h2 className="calendar-month-name">Lunar / Movable Feasts</h2>
+            {byMonth[MOVABLE_KEY].map(({ ev }) => (
+              <button
+                key={ev.id}
+                type="button"
+                className={`calendar-event-card${selectedEvent?.id === ev.id ? ' selected' : ''}`}
+                onClick={() => setSelectedEvent(selectedEvent?.id === ev.id ? null : ev)}
+              >
+                <div className="calendar-event-top">
+                  <span className="calendar-event-badge lunar">☾</span>
+                  <span className="calendar-event-name">{ev.name}</span>
+                </div>
+                <p className="calendar-lunar-subline movable">(movable — date varies by year)</p>
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Event detail panel */}
+      {selectedEvent && (
+        <div className="calendar-detail">
+          <div className="calendar-detail-header">
+            <h2>{selectedEvent.name}</h2>
+            <button type="button" className="calendar-detail-close" onClick={() => setSelectedEvent(null)}>✕</button>
+          </div>
+          {selectedEvent.region?.name && (
+            <p className="calendar-detail-region">📍 {selectedEvent.region.name}</p>
+          )}
+          {selectedEvent.description && (
+            <p className="calendar-detail-desc">{selectedEvent.description}</p>
+          )}
+          {selectedEvent.recipes?.length > 0 && (
+            <div className="calendar-detail-recipes">
+              <h3>Related Recipes</h3>
+              <ul>
+                {selectedEvent.recipes.map(r => (
+                  <li key={r.id}>
+                    <Link to={`/recipes/${r.id}`}>🍽 {r.title}</Link>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      )}
+    </main>
+  );
+}

--- a/app/frontend/src/pages/HeritagePage.css
+++ b/app/frontend/src/pages/HeritagePage.css
@@ -1,0 +1,294 @@
+.heritage-page {
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.heritage-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.heritage-header-icon {
+  font-size: 2.2rem;
+  flex-shrink: 0;
+  margin-top: 0.15rem;
+}
+
+.heritage-title {
+  margin: 0 0 0.3rem 0;
+}
+
+.heritage-desc {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: 0.97rem;
+  line-height: 1.55;
+}
+
+.heritage-map-btn {
+  margin-bottom: 1.2rem;
+}
+
+/* Map */
+.heritage-map-wrap {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 2rem;
+  align-items: flex-start;
+}
+
+.heritage-leaflet-map {
+  flex: 1;
+  height: 340px;
+  border-radius: 10px;
+  border: 1px solid var(--color-border);
+  min-width: 0;
+}
+
+.heritage-map-panel {
+  width: 260px;
+  flex-shrink: 0;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.heritage-map-panel-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 0.9rem 1rem 0.6rem;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.heritage-map-panel-header h3 {
+  margin: 0 0 0.15rem 0;
+  font-size: 1rem;
+}
+
+.heritage-map-panel-sub {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+}
+
+.heritage-panel-close {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1rem;
+  color: var(--color-text-muted);
+  padding: 0;
+  line-height: 1;
+}
+
+.heritage-map-panel-list {
+  list-style: none;
+  margin: 0;
+  padding: 0.5rem 0;
+}
+
+.heritage-panel-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  color: var(--color-text);
+  text-decoration: none;
+  font-size: 0.9rem;
+  transition: background 0.12s;
+}
+
+.heritage-panel-item:hover {
+  background: rgba(196, 82, 30, 0.07);
+}
+
+.heritage-panel-icon {
+  flex-shrink: 0;
+}
+
+/* Content grid */
+.heritage-content {
+  margin-bottom: 2rem;
+}
+
+.heritage-content h2 {
+  margin-bottom: 1rem;
+}
+
+.heritage-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 0.75rem;
+}
+
+.heritage-card {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.7rem;
+  background: var(--color-surface-alt, #f2ede3);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 0.75rem 0.9rem;
+  text-decoration: none;
+  color: var(--color-text);
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.heritage-card:hover {
+  border-color: var(--color-primary);
+  background: rgba(196, 82, 30, 0.04);
+}
+
+.heritage-card-type {
+  font-size: 1.2rem;
+  flex-shrink: 0;
+  margin-top: 0.1rem;
+}
+
+.heritage-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.heritage-card-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.heritage-card-meta {
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+}
+
+/* Journey — #515 */
+.heritage-journey {
+  margin-bottom: 2rem;
+}
+
+.heritage-journey h2 {
+  margin-bottom: 1.2rem;
+}
+
+.heritage-journey-steps {
+  display: flex;
+  flex-direction: column;
+}
+
+.heritage-journey-step {
+  display: flex;
+  gap: 1rem;
+}
+
+.heritage-journey-connector {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  flex-shrink: 0;
+  width: 20px;
+}
+
+.heritage-journey-dot {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--color-primary);
+  flex-shrink: 0;
+  margin-top: 0.25rem;
+}
+
+.heritage-journey-line {
+  flex: 1;
+  width: 2px;
+  background: var(--color-border);
+  margin: 4px 0;
+  min-height: 24px;
+}
+
+.heritage-journey-body {
+  padding-bottom: 1.4rem;
+  flex: 1;
+}
+
+.heritage-journey-location {
+  font-weight: 600;
+  font-size: 0.97rem;
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin-bottom: 0.3rem;
+}
+
+.heritage-journey-era {
+  font-size: 0.78rem;
+  font-weight: 400;
+  color: var(--color-text-muted);
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  padding: 0.1rem 0.4rem;
+}
+
+.heritage-journey-story {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--color-text-muted);
+  line-height: 1.55;
+}
+
+/* Did You Know — #517 */
+.heritage-facts {
+  margin-bottom: 1rem;
+}
+
+.heritage-facts h2 {
+  margin-bottom: 1rem;
+}
+
+.heritage-facts-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.heritage-fact-card {
+  display: flex;
+  gap: 0.75rem;
+  background: rgba(196, 82, 30, 0.05);
+  border: 1px solid rgba(196, 82, 30, 0.2);
+  border-radius: 8px;
+  padding: 0.85rem 1rem;
+}
+
+.heritage-fact-icon {
+  font-size: 1.2rem;
+  flex-shrink: 0;
+  margin-top: 0.05rem;
+}
+
+.heritage-fact-body p {
+  margin: 0 0 0.3rem 0;
+  font-size: 0.92rem;
+  line-height: 1.55;
+}
+
+.heritage-fact-source {
+  font-size: 0.78rem;
+  color: var(--color-primary);
+}
+
+@media (max-width: 640px) {
+  .heritage-map-wrap {
+    flex-direction: column;
+  }
+  .heritage-map-panel {
+    width: 100%;
+  }
+  .heritage-leaflet-map {
+    height: 260px;
+  }
+}

--- a/app/frontend/src/pages/HeritagePage.jsx
+++ b/app/frontend/src/pages/HeritagePage.jsx
@@ -1,0 +1,251 @@
+import { useState, useEffect } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { MapContainer, TileLayer, CircleMarker, Polyline, Tooltip, useMap } from 'react-leaflet';
+import L from 'leaflet';
+import 'leaflet/dist/leaflet.css';
+import { fetchHeritageGroup, fetchCulturalFacts } from '../services/heritageService';
+import { extractApiError } from '../services/api';
+import './HeritagePage.css';
+
+// Fix Leaflet default icon issue with webpack
+delete L.Icon.Default.prototype._getIconUrl;
+L.Icon.Default.mergeOptions({
+  iconRetinaUrl: require('leaflet/dist/images/marker-icon-2x.png'),
+  iconUrl: require('leaflet/dist/images/marker-icon.png'),
+  shadowUrl: require('leaflet/dist/images/marker-shadow.png'),
+});
+
+function FitBounds({ points }) {
+  const map = useMap();
+  useEffect(() => {
+    if (points.length > 1) {
+      map.fitBounds(points, { padding: [40, 40] });
+    } else if (points.length === 1) {
+      map.setView(points[0], 6);
+    }
+  }, [map, points]);
+  return null;
+}
+
+// Group members by region, return sorted by recipe count desc
+function groupByRegion(members) {
+  const map = {};
+  for (const m of members) {
+    if (!m.region || m.latitude == null || m.longitude == null) continue;
+    if (!map[m.region]) {
+      map[m.region] = { region: m.region, lat: m.latitude, lng: m.longitude, items: [] };
+    }
+    map[m.region].items.push(m);
+  }
+  const groups = Object.values(map);
+  groups.sort((a, b) => {
+    const aR = a.items.filter(i => i.content_type === 'recipe').length;
+    const bR = b.items.filter(i => i.content_type === 'recipe').length;
+    return bR - aR;
+  });
+  return groups;
+}
+
+export default function HeritagePage() {
+  const { id } = useParams();
+  const [group, setGroup] = useState(null);
+  const [facts, setFacts] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [showMap, setShowMap] = useState(false);
+  const [panelRegion, setPanelRegion] = useState(null);
+
+  useEffect(() => {
+    setLoading(true);
+    Promise.all([
+      fetchHeritageGroup(id),
+      fetchCulturalFacts({ heritageGroupId: id }),
+    ])
+      .then(([g, f]) => { setGroup(g); setFacts(f); })
+      .catch((err) => setError(extractApiError(err, 'Could not load heritage group.')))
+      .finally(() => setLoading(false));
+  }, [id]);
+
+  if (loading) return <p className="page-status">Loading…</p>;
+  if (error) return <p className="page-status page-status-error">{error}</p>;
+  if (!group) return null;
+
+  const recipes = group.members.filter(m => m.content_type === 'recipe');
+  const stories = group.members.filter(m => m.content_type === 'story');
+  const regionGroups = groupByRegion(group.members);
+  const centerRegion = regionGroups[0] ?? null;
+  const otherRegions = regionGroups.slice(1);
+  const mapPoints = regionGroups.map(r => [r.lat, r.lng]);
+
+  return (
+    <main className="page-card heritage-page">
+
+      {/* Header */}
+      <div className="heritage-header">
+        <span className="heritage-header-icon">🏛</span>
+        <div>
+          <h1 className="heritage-title">{group.name}</h1>
+          {group.description && <p className="heritage-desc">{group.description}</p>}
+        </div>
+      </div>
+
+      {/* Map toggle */}
+      {regionGroups.length > 0 && (
+        <button
+          type="button"
+          className="btn btn-outline heritage-map-btn"
+          onClick={() => { setShowMap(v => !v); setPanelRegion(null); }}
+        >
+          {showMap ? 'Hide Map' : 'Show Heritage Map'}
+        </button>
+      )}
+
+      {/* Heritage Map — #500 + #668 */}
+      {showMap && (
+        <div className="heritage-map-wrap">
+          <MapContainer
+            center={centerRegion ? [centerRegion.lat, centerRegion.lng] : [39, 35]}
+            zoom={5}
+            className="heritage-leaflet-map"
+            scrollWheelZoom={false}
+          >
+            <TileLayer
+              url="https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png"
+              attribution='&copy; OpenStreetMap &copy; CARTO'
+            />
+            {mapPoints.length > 0 && <FitBounds points={mapPoints} />}
+
+            {/* Polylines: center → each region */}
+            {centerRegion && otherRegions.map(r => (
+              <Polyline
+                key={r.region}
+                positions={[[centerRegion.lat, centerRegion.lng], [r.lat, r.lng]]}
+                pathOptions={{ color: '#C4521E', weight: 2, dashArray: '5 5', opacity: 0.7 }}
+              />
+            ))}
+
+            {/* Center pin */}
+            {centerRegion && (
+              <CircleMarker
+                center={[centerRegion.lat, centerRegion.lng]}
+                radius={14}
+                pathOptions={{ color: '#3d1500', fillColor: '#C4521E', fillOpacity: 0.9, weight: 2 }}
+                eventHandlers={{ click: () => setPanelRegion(panelRegion?.region === centerRegion.region ? null : centerRegion) }}
+              >
+                <Tooltip direction="top" offset={[0, -10]} opacity={0.95}>🏛 {centerRegion.region}</Tooltip>
+              </CircleMarker>
+            )}
+
+            {/* Other region pins */}
+            {otherRegions.map(r => (
+              <CircleMarker
+                key={r.region}
+                center={[r.lat, r.lng]}
+                radius={9}
+                pathOptions={{ color: '#C4521E', fillColor: '#FAF7EF', fillOpacity: 0.85, weight: 2 }}
+                eventHandlers={{ click: () => setPanelRegion(panelRegion?.region === r.region ? null : r) }}
+              >
+                <Tooltip direction="top" offset={[0, -8]} opacity={0.95}>{r.region}</Tooltip>
+              </CircleMarker>
+            ))}
+          </MapContainer>
+
+          {/* Region side panel */}
+          {panelRegion && (
+            <div className="heritage-map-panel">
+              <div className="heritage-map-panel-header">
+                <div>
+                  <h3>{panelRegion.region}</h3>
+                  <p className="heritage-map-panel-sub">in {group.name}</p>
+                </div>
+                <button type="button" className="heritage-panel-close" onClick={() => setPanelRegion(null)}>✕</button>
+              </div>
+              <ul className="heritage-map-panel-list">
+                {panelRegion.items.map(item => (
+                  <li key={`${item.content_type}-${item.id}`}>
+                    <Link
+                      to={item.content_type === 'recipe' ? `/recipes/${item.id}` : `/stories/${item.id}`}
+                      className="heritage-panel-item"
+                    >
+                      <span className="heritage-panel-icon">{item.content_type === 'recipe' ? '🍽' : '📖'}</span>
+                      <span>{item.title}</span>
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Content grid */}
+      {(recipes.length > 0 || stories.length > 0) && (
+        <section className="heritage-content">
+          <h2>Content in this Heritage Group</h2>
+          <div className="heritage-grid">
+            {group.members.map(m => (
+              <Link
+                key={`${m.content_type}-${m.id}`}
+                to={m.content_type === 'recipe' ? `/recipes/${m.id}` : `/stories/${m.id}`}
+                className="heritage-card"
+              >
+                <span className="heritage-card-type">{m.content_type === 'recipe' ? '🍽' : '📖'}</span>
+                <div className="heritage-card-body">
+                  <span className="heritage-card-title">{m.title}</span>
+                  {m.author && <span className="heritage-card-meta">by {m.author}</span>}
+                  {m.region && <span className="heritage-card-meta">{m.region}</span>}
+                </div>
+              </Link>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* Heritage Journey — #515 */}
+      {group.journey_steps && group.journey_steps.length > 0 && (
+        <section className="heritage-journey">
+          <h2>Heritage Journey</h2>
+          <div className="heritage-journey-steps">
+            {group.journey_steps.map((step, i) => (
+              <div key={step.id} className="heritage-journey-step">
+                <div className="heritage-journey-connector">
+                  <span className="heritage-journey-dot" />
+                  {i < group.journey_steps.length - 1 && <span className="heritage-journey-line" />}
+                </div>
+                <div className="heritage-journey-body">
+                  <div className="heritage-journey-location">
+                    {step.location}
+                    {step.era && <span className="heritage-journey-era">{step.era}</span>}
+                  </div>
+                  <p className="heritage-journey-story">{step.story}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* Did You Know — #517 */}
+      {facts.length > 0 && (
+        <section className="heritage-facts">
+          <h2>Did You Know?</h2>
+          <div className="heritage-facts-list">
+            {facts.map(fact => (
+              <div key={fact.id} className="heritage-fact-card">
+                <span className="heritage-fact-icon">💡</span>
+                <div className="heritage-fact-body">
+                  <p>{fact.text}</p>
+                  {fact.source_url && (
+                    <a href={fact.source_url} target="_blank" rel="noopener noreferrer" className="heritage-fact-source">
+                      Source
+                    </a>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+    </main>
+  );
+}

--- a/app/frontend/src/pages/RecipeDetailPage.jsx
+++ b/app/frontend/src/pages/RecipeDetailPage.jsx
@@ -6,6 +6,7 @@ import { fetchRegions } from '../services/searchService';
 import { fetchSubstitutes } from '../services/ingredientService';
 import { fetchCheckedIngredients, toggleCheckedIngredient } from '../services/checkOffService';
 import RecipeCommentsSection from '../components/RecipeCommentsSection';
+import HeritageBadge from '../components/HeritageBadge';
 import './RecipeDetailPage.css';
 
 const MATCH_TYPE_LABELS = {
@@ -345,6 +346,8 @@ export default function RecipeDetailPage() {
           </div>
         )}
       </section>
+
+      {recipe.heritage_group && <HeritageBadge heritageGroup={recipe.heritage_group} />}
 
       <RecipeCommentsSection
         recipeId={recipe.id}

--- a/app/frontend/src/pages/StoryDetailPage.jsx
+++ b/app/frontend/src/pages/StoryDetailPage.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useContext, useCallback } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
 import { AuthContext } from '../context/AuthContext';
 import { fetchStory, deleteStory, publishStory, unpublishStory } from '../services/storyService';
+import HeritageBadge from '../components/HeritageBadge';
 import './StoryDetailPage.css';
 
 export default function StoryDetailPage() {
@@ -117,6 +118,8 @@ export default function StoryDetailPage() {
       )}
 
       <p className="story-body">{story.body}</p>
+
+      {story.heritage_group && <HeritageBadge heritageGroup={story.heritage_group} />}
 
       {story.linked_recipe && (
         <section className="story-linked-recipe">

--- a/app/frontend/src/services/calendarService.js
+++ b/app/frontend/src/services/calendarService.js
@@ -1,0 +1,52 @@
+import { apiClient } from './api';
+
+const USE_MOCK = process.env.REACT_APP_USE_MOCK === 'true';
+
+// Lunar event dates resolved to Gregorian, keyed by year then event name.
+// Keep in sync with mobile calendarService.ts — update both together each year.
+const LUNAR_YEARLY = {
+  2024: { ramadan: { month: 2, day: 10 }, 'eid-fitr': { month: 3, day: 10 }, 'eid-adha': { month: 5, day: 16 }, mevlid: { month: 9, day: 15 }, ashura: { month: 7, day: 17 } },
+  2025: { ramadan: { month: 2, day: 28 }, 'eid-fitr': { month: 3, day: 30 }, 'eid-adha': { month: 5, day: 6 }, mevlid: { month: 9, day: 4 }, ashura: { month: 7, day: 5 } },
+  2026: { ramadan: { month: 2, day: 17 }, 'eid-fitr': { month: 3, day: 19 }, 'eid-adha': { month: 4, day: 26 }, mevlid: { month: 8, day: 24 }, ashura: { month: 6, day: 24 } },
+};
+
+
+// Extracts month index (0-based) and day from a date_rule string.
+// date_rule formats: "YYYY-MM-DD", "MM-DD", "lunar:ramadan", etc.
+export function parseEventDate(rule) {
+  if (!rule) return null;
+
+  if (rule.startsWith('lunar:')) {
+    const lunarName = rule.replace('lunar:', '');
+    const year = new Date().getFullYear();
+    const yearTable = LUNAR_YEARLY[year];
+    if (yearTable && yearTable[lunarName]) {
+      const { month, day } = yearTable[lunarName];
+      return { monthIndex: month - 1, day, isLunar: true, lunarName, lunarUnresolved: false };
+    }
+    return { monthIndex: null, day: null, isLunar: true, lunarName, lunarUnresolved: true };
+  }
+
+  // "YYYY-MM-DD" or "MM-DD"
+  const parts = rule.split('-');
+  if (parts.length === 3) {
+    return { monthIndex: parseInt(parts[1], 10) - 1, day: parseInt(parts[2], 10), isLunar: false };
+  }
+  if (parts.length === 2) {
+    return { monthIndex: parseInt(parts[0], 10) - 1, day: parseInt(parts[1], 10), isLunar: false };
+  }
+  return null;
+}
+
+const MOCK_EVENTS = [
+  { id: 1, name: 'Ramadan', date_rule: 'lunar:ramadan', region: { id: 1, name: 'All Regions' }, description: 'Month of fasting and special foods.', recipes: [{ id: 1, title: 'Iftar Soup' }], created_at: '' },
+  { id: 2, name: 'Hıdırellez', date_rule: '05-06', region: { id: 2, name: 'Aegean' }, description: 'Spring festival marking the start of summer.', recipes: [], created_at: '' },
+  { id: 3, name: 'Eid al-Adha', date_rule: 'lunar:eid-adha', region: { id: 1, name: 'All Regions' }, description: 'Feast of sacrifice — special meats and sweets.', recipes: [{ id: 2, title: 'Kavurma' }], created_at: '' },
+];
+
+export async function fetchCulturalEvents({ region } = {}) {
+  if (USE_MOCK) return MOCK_EVENTS;
+  const params = region ? `?region=${region}` : '';
+  const res = await apiClient.get(`/api/cultural-events/${params}`);
+  return Array.isArray(res.data) ? res.data : (res.data.results ?? []);
+}

--- a/app/frontend/src/services/heritageService.js
+++ b/app/frontend/src/services/heritageService.js
@@ -1,0 +1,41 @@
+import { apiClient } from './api';
+
+const USE_MOCK = process.env.REACT_APP_USE_MOCK === 'true';
+
+const MOCK_GROUP = {
+  id: 1,
+  name: 'Sarma / Dolma',
+  description: 'Stuffed grape leaves and vegetables — a shared tradition across Anatolia, the Balkans, and the Middle East.',
+  members: [
+    { content_type: 'recipe', id: 1, title: 'Yaprak Sarma', author: 'chef_ali', region: 'Aegean', latitude: 38.4, longitude: 27.1 },
+    { content_type: 'story', id: 2, title: 'My Grandmother\'s Dolma', author: 'ayse_k', region: 'Marmara', latitude: 41.0, longitude: 29.0 },
+  ],
+  journey_steps: [
+    { id: 1, order: 1, location: 'Central Asia', story: 'Nomadic Turkic communities wrapped meat in leaves for portability.', era: 'Pre-Ottoman' },
+    { id: 2, order: 2, location: 'Ottoman Istanbul', story: 'Palace kitchens refined the technique with rice and spices.', era: '15th century' },
+    { id: 3, order: 3, location: 'Balkans', story: 'Spread through Ottoman rule, adapted with local herbs.', era: '17th century' },
+  ],
+};
+
+const MOCK_FACTS = [
+  { id: 1, heritage_group: { id: 1, name: 'Sarma / Dolma' }, region: null, text: '"Dolma" comes from the Turkish verb "doldurmak" (to stuff). It was standardized in Ottoman palace cuisine in the 15th century.', source_url: null },
+];
+
+export async function fetchHeritageGroup(id) {
+  if (USE_MOCK) return MOCK_GROUP;
+  const res = await apiClient.get(`/api/heritage-groups/${id}/`);
+  return res.data;
+}
+
+export async function fetchHeritageGroups() {
+  if (USE_MOCK) return [{ id: 1, name: 'Sarma / Dolma', member_count: 2 }];
+  const res = await apiClient.get('/api/heritage-groups/');
+  return res.data;
+}
+
+export async function fetchCulturalFacts({ heritageGroupId } = {}) {
+  if (USE_MOCK) return MOCK_FACTS;
+  const params = heritageGroupId ? `?heritage_group=${heritageGroupId}` : '';
+  const res = await apiClient.get(`/api/cultural-facts/${params}`);
+  return Array.isArray(res.data) ? res.data : (res.data.results ?? []);
+}


### PR DESCRIPTION
## Summary

- **HeritagePage** (`/heritage/:id`): group name + description header, mixed recipe/story content grid, interactive heritage map (region-centric pins, polylines center→regions, click-to-panel showing that region's content), Heritage Journey timeline steps (#515), "Did You Know?" cultural fact cards (#517)
- **HeritageBadge** component: appears on `RecipeDetailPage` and `StoryDetailPage` when `heritage_group` is present in the API response, links to `/heritage/:id`
- **CalendarPage** (`/calendar`): monthly grid view, region + month filters, lunar event resolution with ☾ badge and italic subline, unresolved lunar events fall back to a Movable Feasts bucket (#669)
- **heritageService.js** + **calendarService.js**: service layers for `/api/heritage-groups/`, `/api/cultural-facts/`, `/api/cultural-events/`
- **AccountPage** (`/account`): view/edit the 4 onboarding preferences (cultural interests, regional ties, dietary preferences, event interests) with view/edit mode toggle; "My Account" added to navbar dropdown

## Test plan
- [ ] Navigate to `/heritage/:id` for a group that has members — verify header, content grid, map, journey steps, and Did You Know cards all render
- [ ] Click "Show Heritage Map" — verify center pin is the region with most recipes, polylines fan out to other regions, clicking a pin opens the side panel with that region's content
- [ ] Open a recipe detail page where `heritage_group` is set — verify HeritageBadge appears and links to correct Heritage Page
- [ ] Open a story detail page where `heritage_group` is set — same check
- [ ] Navigate to `/calendar` — verify events appear in correct month groups, lunar events show ☾ badge and italic subline
- [ ] Select a region filter — verify events filter correctly
- [ ] Click an event card — verify detail panel expands with description and linked recipes
- [ ] Open navbar dropdown — verify "My Account" appears between Profile and New Recipe
- [ ] Navigate to `/account` — verify saved preferences are pre-filled, edit mode shows chips, save persists