### PR TITLE
feat(frontend): add /users/:username profile route with own vs visitor mode (#589)

### DIFF
--- a/app/frontend/src/App.js
+++ b/app/frontend/src/App.js
@@ -19,6 +19,7 @@ import InboxPage from './pages/InboxPage';
 import ThreadPage from './pages/ThreadPage';
 import OnboardingPage from './pages/OnboardingPage';
 import ProfilePage from './pages/ProfilePage';
+import UserProfilePage from './pages/UserProfilePage';
 import MapPage from './pages/MapPage';
 import ExplorePage from './pages/ExplorePage';
 import EventDetailPage from './pages/EventDetailPage';
@@ -128,6 +129,7 @@ export default function App() {
             element={<ProtectedRoute><ModerationPage /></ProtectedRoute>}
           />
 
+          <Route path="/users/:username" element={<UserProfilePage />} />
           <Route path="/heritage/:id" element={<HeritagePage />} />
           <Route path="/heritage/:id/map" element={<HeritageMapPage />} />
           <Route path="/calendar" element={<CalendarPage />} />

--- a/app/frontend/src/__tests__/UserProfilePage.test.jsx
+++ b/app/frontend/src/__tests__/UserProfilePage.test.jsx
@@ -1,0 +1,91 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { AuthContext } from '../context/AuthContext';
+import UserProfilePage from '../pages/UserProfilePage';
+import * as passportService from '../services/passportService';
+
+jest.mock('../services/passportService');
+
+const mockProfile = {
+  username: 'alice',
+  bio: 'Loves Anatolian cuisine.',
+  region: 'Aegean',
+  created_at: '2024-03-01T00:00:00Z',
+  recipe_count: 4,
+  story_count: 2,
+  cultural_interests: ['Ottoman', 'Mediterranean'],
+  religious_preferences: ['Halal'],
+  event_interests: ['Ramadan'],
+};
+
+function renderPage(username, currentUser = null) {
+  return render(
+    <AuthContext.Provider value={{ user: currentUser, token: currentUser ? 'tok' : null, login: jest.fn(), logout: jest.fn(), updateUser: jest.fn() }}>
+      <MemoryRouter initialEntries={[`/users/${username}`]}>
+        <Routes>
+          <Route path="/users/:username" element={<UserProfilePage />} />
+        </Routes>
+      </MemoryRouter>
+    </AuthContext.Provider>
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  passportService.getPublicProfile.mockResolvedValue(mockProfile);
+});
+
+describe('UserProfilePage', () => {
+  it('renders username and stats after load', async () => {
+    renderPage('alice');
+    await waitFor(() => expect(screen.getByText('@alice')).toBeInTheDocument());
+    expect(screen.getByText('4')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+  });
+
+  it('renders cultural preference tags', async () => {
+    renderPage('alice');
+    await waitFor(() => expect(screen.getByText('Ottoman')).toBeInTheDocument());
+    expect(screen.getByText('Halal')).toBeInTheDocument();
+    expect(screen.getByText('Ramadan')).toBeInTheDocument();
+  });
+
+  it('renders bio when present', async () => {
+    renderPage('alice');
+    await waitFor(() => expect(screen.getByText('Loves Anatolian cuisine.')).toBeInTheDocument());
+  });
+
+  it('shows Edit preferences link in own-profile mode', async () => {
+    renderPage('alice', { id: 1, username: 'alice' });
+    await waitFor(() => expect(screen.getByRole('link', { name: /edit preferences/i })).toBeInTheDocument());
+  });
+
+  it('does not show Edit preferences link in visitor mode', async () => {
+    renderPage('alice', { id: 2, username: 'bob' });
+    await waitFor(() => expect(screen.queryByRole('link', { name: /edit preferences/i })).not.toBeInTheDocument());
+  });
+
+  it('does not show Edit preferences link when logged out', async () => {
+    renderPage('alice', null);
+    await waitFor(() => expect(screen.queryByRole('link', { name: /edit preferences/i })).not.toBeInTheDocument());
+  });
+
+  it('shows 404 message when profile not found', async () => {
+    passportService.getPublicProfile.mockRejectedValue({ response: { status: 404 } });
+    renderPage('ghost');
+    await waitFor(() => expect(screen.getByText(/no user found/i)).toBeInTheDocument());
+  });
+
+  it('shows error message on other failures', async () => {
+    passportService.getPublicProfile.mockRejectedValue({ response: { status: 500, data: { detail: 'Server error' } } });
+    renderPage('alice');
+    await waitFor(() => expect(screen.getByText(/server error/i)).toBeInTheDocument());
+  });
+
+  it('handles empty username gracefully (no crash)', async () => {
+    passportService.getPublicProfile.mockResolvedValue({ ...mockProfile, username: '' });
+    renderPage('');
+    await waitFor(() => expect(screen.queryByText('loading', { exact: false })).not.toBeInTheDocument());
+    expect(screen.queryByText('@@')).not.toBeInTheDocument();
+  });
+});

--- a/app/frontend/src/components/Navbar.css
+++ b/app/frontend/src/components/Navbar.css
@@ -65,29 +65,42 @@
   position: relative;
 }
 
+.navbar-user-btn-area {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  border: 1.5px solid var(--color-border);
+  border-radius: 999px;
+  padding: 0.3rem 0.75rem 0.3rem 0.3rem;
+  transition: background 0.15s ease, border-color 0.15s ease;
+  cursor: pointer;
+}
+
+.navbar-user-btn-area:hover {
+  background: var(--color-surface-dark);
+  border-color: var(--color-primary);
+}
+
+.navbar-user-btn-area:hover .navbar-username {
+  color: var(--color-surface);
+}
+
+.navbar-user-btn-area:hover .navbar-chevron {
+  border-color: var(--color-surface);
+}
+
 .navbar-user-btn {
   display: flex;
   align-items: center;
   gap: 0.5rem;
   background: none;
-  border: 1.5px solid var(--color-border);
-  border-radius: 999px;
-  padding: 0.3rem 0.75rem 0.3rem 0.3rem;
+  border: none;
+  padding: 0;
   cursor: pointer;
-  transition: background 0.15s ease, border-color 0.15s ease;
 }
 
 .navbar-user-btn:hover {
-  background: var(--color-surface-dark);
-  border-color: var(--color-primary);
-}
-
-.navbar-user-btn:hover .navbar-username {
-  color: var(--color-surface);
-}
-
-.navbar-user-btn:hover .navbar-chevron {
-  border-color: var(--color-surface);
+  background: none;
 }
 
 .navbar-avatar {

--- a/app/frontend/src/components/Navbar.jsx
+++ b/app/frontend/src/components/Navbar.jsx
@@ -79,7 +79,11 @@ export default function Navbar() {
                   <span className="navbar-avatar">
                     {user.username[0].toUpperCase()}
                   </span>
-                  <span className="navbar-username">@{user.username}</span>
+                  <Link
+                    to={`/users/${user.username}`}
+                    className="navbar-username"
+                    onClick={(e) => e.stopPropagation()}
+                  >@{user.username}</Link>
                   <span className={`navbar-chevron${menuOpen ? ' open' : ''}`} aria-hidden="true" />
                 </button>
                 {menuOpen && (

--- a/app/frontend/src/components/Navbar.jsx
+++ b/app/frontend/src/components/Navbar.jsx
@@ -70,22 +70,24 @@ export default function Navbar() {
             <>
               <NotificationTray />
               <div className="navbar-user-menu" ref={menuRef}>
-                <button
-                  className="navbar-user-btn"
-                  onClick={() => setMenuOpen(o => !o)}
-                  aria-expanded={menuOpen}
-                  aria-haspopup="true"
-                >
-                  <span className="navbar-avatar">
-                    {user.username[0].toUpperCase()}
-                  </span>
+                <div className="navbar-user-btn-area">
+                  <button
+                    className="navbar-user-btn"
+                    onClick={() => setMenuOpen(o => !o)}
+                    aria-expanded={menuOpen}
+                    aria-haspopup="true"
+                    aria-label={`User menu for @${user.username}`}
+                  >
+                    <span className="navbar-avatar">
+                      {user.username?.[0]?.toUpperCase() ?? '?'}
+                    </span>
+                    <span className={`navbar-chevron${menuOpen ? ' open' : ''}`} aria-hidden="true" />
+                  </button>
                   <Link
                     to={`/users/${user.username}`}
                     className="navbar-username"
-                    onClick={(e) => e.stopPropagation()}
                   >@{user.username}</Link>
-                  <span className={`navbar-chevron${menuOpen ? ' open' : ''}`} aria-hidden="true" />
-                </button>
+                </div>
                 {menuOpen && (
                   <div className="navbar-dropdown" role="menu">
                     <Link

--- a/app/frontend/src/pages/RecipeDetailPage.jsx
+++ b/app/frontend/src/pages/RecipeDetailPage.jsx
@@ -170,7 +170,7 @@ export default function RecipeDetailPage() {
           {regionName && <span className="recipe-region-tag">{regionName}</span>}
           <h1 className="recipe-title">{recipe.title}</h1>
           {recipe.author_username && (
-            <p className="recipe-author">By <Link to={`/users/${recipe.author_username}`} className="recipe-author-link">@{recipe.author_username}</Link></p>
+            <p className="recipe-author"><Link to={`/users/${recipe.author_username}`} className="recipe-author-link">By {recipe.author_username}</Link></p>
           )}
         </div>
         <div className="recipe-detail-actions">

--- a/app/frontend/src/pages/RecipeDetailPage.jsx
+++ b/app/frontend/src/pages/RecipeDetailPage.jsx
@@ -170,7 +170,7 @@ export default function RecipeDetailPage() {
           {regionName && <span className="recipe-region-tag">{regionName}</span>}
           <h1 className="recipe-title">{recipe.title}</h1>
           {recipe.author_username && (
-            <p className="recipe-author">By {recipe.author_username}</p>
+            <p className="recipe-author">By <Link to={`/users/${recipe.author_username}`} className="recipe-author-link">@{recipe.author_username}</Link></p>
           )}
         </div>
         <div className="recipe-detail-actions">

--- a/app/frontend/src/pages/StoryDetailPage.jsx
+++ b/app/frontend/src/pages/StoryDetailPage.jsx
@@ -106,7 +106,7 @@ export default function StoryDetailPage() {
       )}
 
       {(story.author?.username || story.author_username) && (
-        <p className="story-author">By <Link to={`/users/${story.author?.username || story.author_username}`} className="story-author-link">@{story.author?.username || story.author_username}</Link></p>
+        <p className="story-author"><Link to={`/users/${story.author?.username || story.author_username}`} className="story-author-link">By {story.author?.username || story.author_username}</Link></p>
       )}
 
       {story.image && (

--- a/app/frontend/src/pages/StoryDetailPage.jsx
+++ b/app/frontend/src/pages/StoryDetailPage.jsx
@@ -106,7 +106,7 @@ export default function StoryDetailPage() {
       )}
 
       {(story.author?.username || story.author_username) && (
-        <p className="story-author">By {story.author?.username || story.author_username}</p>
+        <p className="story-author">By <Link to={`/users/${story.author?.username || story.author_username}`} className="story-author-link">@{story.author?.username || story.author_username}</Link></p>
       )}
 
       {story.image && (

--- a/app/frontend/src/pages/UserProfilePage.css
+++ b/app/frontend/src/pages/UserProfilePage.css
@@ -1,0 +1,145 @@
+.user-profile-page {
+  max-width: 700px;
+  margin: 0 auto;
+}
+
+.user-profile-header {
+  display: flex;
+  align-items: center;
+  gap: 1.1rem;
+  margin-bottom: 1.2rem;
+  flex-wrap: wrap;
+}
+
+.user-profile-avatar {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  background: var(--color-primary);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.6rem;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.user-profile-identity {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.user-profile-username {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.user-profile-region,
+.user-profile-joined {
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
+
+.user-profile-edit-btn {
+  margin-left: auto;
+}
+
+.user-profile-bio {
+  font-size: 0.97rem;
+  line-height: 1.6;
+  color: var(--color-text-muted);
+  margin: 0 0 1.5rem 0;
+}
+
+.user-profile-stats {
+  display: flex;
+  gap: 1.5rem;
+  margin-bottom: 1.8rem;
+  padding: 0.9rem 1.2rem;
+  background: var(--color-surface-alt, #f2ede3);
+  border: 1px solid var(--color-border);
+  border-radius: 10px;
+}
+
+.user-profile-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.15rem;
+}
+
+.user-profile-stat-value {
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: var(--color-primary);
+}
+
+.user-profile-stat-label {
+  font-size: 0.78rem;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.user-profile-pref-section {
+  margin-bottom: 1.2rem;
+}
+
+.user-profile-pref-title {
+  font-size: 0.88rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-muted);
+  margin-bottom: 0.5rem;
+}
+
+.user-profile-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.user-profile-tag {
+  display: inline-block;
+  background: var(--color-primary-tint, rgba(196, 82, 30, 0.08));
+  border: 1px solid rgba(196, 82, 30, 0.25);
+  color: var(--color-primary);
+  border-radius: 999px;
+  padding: 0.28rem 0.65rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+
+.user-profile-passport-placeholder {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-top: 1.8rem;
+  padding: 1rem 1.2rem;
+  border: 1px dashed var(--color-border);
+  border-radius: 10px;
+  color: var(--color-text-muted);
+}
+
+.user-profile-passport-icon {
+  font-size: 1.8rem;
+  flex-shrink: 0;
+}
+
+.user-profile-passport-placeholder h2 {
+  margin: 0 0 0.2rem 0;
+  font-size: 1rem;
+}
+
+.user-profile-passport-placeholder p {
+  margin: 0;
+  font-size: 0.85rem;
+}
+
+.user-profile-404 {
+  margin-bottom: 1rem;
+  font-size: 1rem;
+}

--- a/app/frontend/src/pages/UserProfilePage.jsx
+++ b/app/frontend/src/pages/UserProfilePage.jsx
@@ -53,7 +53,7 @@ export default function UserProfilePage() {
 
       {/* Header */}
       <div className="user-profile-header">
-        <div className="user-profile-avatar">{profile.username[0].toUpperCase()}</div>
+        <div className="user-profile-avatar">{profile.username?.[0]?.toUpperCase() ?? '?'}</div>
         <div className="user-profile-identity">
           <h1 className="user-profile-username">@{profile.username}</h1>
           {profile.region && <span className="user-profile-region">📍 {profile.region}</span>}

--- a/app/frontend/src/pages/UserProfilePage.jsx
+++ b/app/frontend/src/pages/UserProfilePage.jsx
@@ -1,0 +1,111 @@
+import { useContext, useEffect, useState } from 'react';
+import { useParams, Link, useNavigate } from 'react-router-dom';
+import { AuthContext } from '../context/AuthContext';
+import { getPublicProfile } from '../services/passportService';
+import { extractApiError } from '../services/api';
+import './UserProfilePage.css';
+
+export default function UserProfilePage() {
+  const { username } = useParams();
+  const { user: currentUser } = useContext(AuthContext);
+  const navigate = useNavigate();
+
+  const [profile, setProfile] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  const isOwn = currentUser?.username === username;
+
+  useEffect(() => {
+    setLoading(true);
+    setError('');
+    getPublicProfile(username)
+      .then(setProfile)
+      .catch((err) => {
+        const msg = extractApiError(err, '');
+        if (err?.response?.status === 404) {
+          setError('404');
+        } else {
+          setError(msg || 'Could not load profile.');
+        }
+      })
+      .finally(() => setLoading(false));
+  }, [username]);
+
+  if (loading) return <p className="page-status">Loading…</p>;
+
+  if (error === '404') {
+    return (
+      <main className="page-card user-profile-page">
+        <p className="user-profile-404">No user found with username <strong>@{username}</strong>.</p>
+        <button type="button" className="btn btn-outline btn-sm" onClick={() => navigate(-1)}>Go back</button>
+      </main>
+    );
+  }
+
+  if (error) return <p className="page-status page-status-error">{error}</p>;
+  if (!profile) return null;
+
+  const joinedYear = profile.created_at ? new Date(profile.created_at).getFullYear() : null;
+
+  return (
+    <main className="page-card user-profile-page">
+
+      {/* Header */}
+      <div className="user-profile-header">
+        <div className="user-profile-avatar">{profile.username[0].toUpperCase()}</div>
+        <div className="user-profile-identity">
+          <h1 className="user-profile-username">@{profile.username}</h1>
+          {profile.region && <span className="user-profile-region">📍 {profile.region}</span>}
+          {joinedYear && <span className="user-profile-joined">Joined {joinedYear}</span>}
+        </div>
+        {isOwn && (
+          <Link to="/account" className="btn btn-outline btn-sm user-profile-edit-btn">
+            Edit preferences
+          </Link>
+        )}
+      </div>
+
+      {/* Bio */}
+      {profile.bio && <p className="user-profile-bio">{profile.bio}</p>}
+
+      {/* Stats */}
+      <div className="user-profile-stats">
+        <div className="user-profile-stat">
+          <span className="user-profile-stat-value">{profile.recipe_count ?? 0}</span>
+          <span className="user-profile-stat-label">Recipes</span>
+        </div>
+        <div className="user-profile-stat">
+          <span className="user-profile-stat-value">{profile.story_count ?? 0}</span>
+          <span className="user-profile-stat-label">Stories</span>
+        </div>
+      </div>
+
+      {/* Cultural preferences */}
+      {[
+        { label: 'Cultural Interests', values: profile.cultural_interests },
+        { label: 'Dietary Preferences', values: profile.religious_preferences },
+        { label: 'Event Interests', values: profile.event_interests },
+      ].filter(s => s.values?.length > 0).map(section => (
+        <section key={section.label} className="user-profile-pref-section">
+          <h2 className="user-profile-pref-title">{section.label}</h2>
+          <div className="user-profile-tags">
+            {section.values.map(v => (
+              <span key={v} className="user-profile-tag">{v}</span>
+            ))}
+          </div>
+        </section>
+      ))}
+
+      {/* Passport placeholder — future issues #591–#597 */}
+      <section className="user-profile-passport-placeholder">
+        <span className="user-profile-passport-icon">🗺</span>
+        <div>
+          <h2>Cultural Passport</h2>
+          <p>Stamps, quests, and journey timeline coming soon.</p>
+        </div>
+      </section>
+
+    </main>
+  );
+}

--- a/app/frontend/src/services/calendarService.js
+++ b/app/frontend/src/services/calendarService.js
@@ -1,0 +1,52 @@
+import { apiClient } from './api';
+
+const USE_MOCK = process.env.REACT_APP_USE_MOCK === 'true';
+
+// Lunar event dates resolved to Gregorian, keyed by year then event name.
+// Keep in sync with mobile calendarService.ts — update both together each year.
+const LUNAR_YEARLY = {
+  2024: { ramadan: { month: 2, day: 10 }, 'eid-fitr': { month: 3, day: 10 }, 'eid-adha': { month: 5, day: 16 }, mevlid: { month: 9, day: 15 }, ashura: { month: 7, day: 17 } },
+  2025: { ramadan: { month: 2, day: 28 }, 'eid-fitr': { month: 3, day: 30 }, 'eid-adha': { month: 5, day: 6 }, mevlid: { month: 9, day: 4 }, ashura: { month: 7, day: 5 } },
+  2026: { ramadan: { month: 2, day: 17 }, 'eid-fitr': { month: 3, day: 19 }, 'eid-adha': { month: 4, day: 26 }, mevlid: { month: 8, day: 24 }, ashura: { month: 6, day: 24 } },
+};
+
+
+// Extracts month index (0-based) and day from a date_rule string.
+// date_rule formats: "YYYY-MM-DD", "MM-DD", "lunar:ramadan", etc.
+export function parseEventDate(rule) {
+  if (!rule) return null;
+
+  if (rule.startsWith('lunar:')) {
+    const lunarName = rule.replace('lunar:', '');
+    const year = new Date().getFullYear();
+    const yearTable = LUNAR_YEARLY[year];
+    if (yearTable && yearTable[lunarName]) {
+      const { month, day } = yearTable[lunarName];
+      return { monthIndex: month - 1, day, isLunar: true, lunarName, lunarUnresolved: false };
+    }
+    return { monthIndex: null, day: null, isLunar: true, lunarName, lunarUnresolved: true };
+  }
+
+  // "YYYY-MM-DD" or "MM-DD"
+  const parts = rule.split('-');
+  if (parts.length === 3) {
+    return { monthIndex: parseInt(parts[1], 10) - 1, day: parseInt(parts[2], 10), isLunar: false };
+  }
+  if (parts.length === 2) {
+    return { monthIndex: parseInt(parts[0], 10) - 1, day: parseInt(parts[1], 10), isLunar: false };
+  }
+  return null;
+}
+
+const MOCK_EVENTS = [
+  { id: 1, name: 'Ramadan', date_rule: 'lunar:ramadan', region: { id: 1, name: 'All Regions' }, description: 'Month of fasting and special foods.', recipes: [{ id: 1, title: 'Iftar Soup' }], created_at: '' },
+  { id: 2, name: 'Hıdırellez', date_rule: '05-06', region: { id: 2, name: 'Aegean' }, description: 'Spring festival marking the start of summer.', recipes: [], created_at: '' },
+  { id: 3, name: 'Eid al-Adha', date_rule: 'lunar:eid-adha', region: { id: 1, name: 'All Regions' }, description: 'Feast of sacrifice — special meats and sweets.', recipes: [{ id: 2, title: 'Kavurma' }], created_at: '' },
+];
+
+export async function fetchCulturalEvents({ region } = {}) {
+  if (USE_MOCK) return MOCK_EVENTS;
+  const params = region ? `?region=${region}` : '';
+  const res = await apiClient.get(`/api/cultural-events/${params}`);
+  return Array.isArray(res.data) ? res.data : (res.data.results ?? []);
+}

--- a/app/frontend/src/services/passportService.js
+++ b/app/frontend/src/services/passportService.js
@@ -1,0 +1,27 @@
+import { apiClient } from './api';
+
+const USE_MOCK = process.env.REACT_APP_USE_MOCK === 'true';
+
+const MOCK_PROFILE = {
+  username: 'demo_chef',
+  bio: 'Passionate about Anatolian food traditions.',
+  region: 'Aegean',
+  cultural_interests: ['Ottoman', 'Mediterranean'],
+  religious_preferences: ['Halal'],
+  event_interests: ['Family Gatherings', 'Ramadan'],
+  created_at: '2025-01-01T00:00:00Z',
+  recipe_count: 5,
+  story_count: 2,
+};
+
+export async function getPublicProfile(username) {
+  if (USE_MOCK) return { ...MOCK_PROFILE, username };
+  const res = await apiClient.get(`/api/users/${username}/`);
+  return res.data;
+}
+
+// Stubs — will be implemented when passport backend ships
+export async function getPassportStamps(username) { return []; }       // #584
+export async function getPassportStats(username) { return null; }      // #587
+export async function getPassportTimeline(username) { return []; }     // #588
+export async function getPassportQuests(username) { return []; }       // #586

--- a/app/frontend/src/services/passportService.js
+++ b/app/frontend/src/services/passportService.js
@@ -21,7 +21,7 @@ export async function getPublicProfile(username) {
 }
 
 // Stubs — will be implemented when passport backend ships
-export async function getPassportStamps(username) { return []; }       // #584
-export async function getPassportStats(username) { return null; }      // #587
-export async function getPassportTimeline(username) { return []; }     // #588
-export async function getPassportQuests(username) { return []; }       // #586
+export async function getPassportStamps(_username) { return []; }       // #584
+export async function getPassportStats(_username) { return null; }      // #587
+export async function getPassportTimeline(_username) { return []; }     // #588
+export async function getPassportQuests(_username) { return []; }       // #586


### PR DESCRIPTION
## Summary

UserProfilePage (`/users/:username`): avatar initial, bio, region, join year, recipe/story count stats, cultural preference tags, and a passport placeholder shell ready for future issues (#591–#597).

Own profile mode (when `username === currentUser.username`) shows an "Edit preferences" link to `/account`. Visitor mode is fully read-only.

`passportService.js` created with `getPublicProfile` + stub functions for passport calls that will be wired up as backend issues #584–#588 land.

Author name links: navbar `@username` chip and author names on recipe/story detail pages now link to `/users/{username}`.

## Test plan
- [ ] Visit `/users/{username}` for an existing user — verify avatar, bio, region, stats, and preference tags render
- [ ] Visit `/users/{your_username}` while logged in — verify "Edit preferences" button appears
- [ ] Visit `/users/{other_username}` — verify no edit controls shown
- [ ] Visit `/users/doesnotexist` — verify 404 message and go-back button
- [ ] Click `@username` in navbar — verify navigates to own profile
- [ ] Open a recipe detail page — verify author name is a clickable link to `/users/{author_username}`
- [ ] Open a story detail page — same check