### PR TITLE
fix(mobile): UserProfile uses server-side ?author filter and follows pagination (#619)

### DIFF
--- a/app/mobile/src/screens/UserProfileScreen.tsx
+++ b/app/mobile/src/screens/UserProfileScreen.tsx
@@ -1,5 +1,5 @@
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { ErrorView } from '../components/ui/ErrorView';
@@ -19,13 +19,6 @@ type ListItem = {
   author?: { id?: number | string; username?: string } | number | string | null;
 };
 
-function authorIdOf(item: ListItem): string | null {
-  const a = item.author;
-  if (!a) return null;
-  if (typeof a === 'object') return a.id != null ? String(a.id) : null;
-  return String(a);
-}
-
 export default function UserProfileScreen({ route, navigation }: Props) {
   const { userId, username } = route.params;
   const userIdStr = String(userId);
@@ -44,9 +37,12 @@ export default function UserProfileScreen({ route, navigation }: Props) {
     setError(null);
     void (async () => {
       try {
+        // Backend `?author=<id>` filter (#637) lets us pull only this user's
+        // content instead of fetching everything and filtering client-side
+        // — which used to silently miss anyone past page 1 (#619).
         const [recipeList, storyList] = await Promise.all([
-          fetchRecipesList(),
-          fetchStoriesList(),
+          fetchRecipesList({ author: userIdStr }),
+          fetchStoriesList({ author: userIdStr }),
         ]);
         if (cancelled) return;
         setRecipes(Array.isArray(recipeList) ? recipeList : []);
@@ -64,16 +60,10 @@ export default function UserProfileScreen({ route, navigation }: Props) {
     return () => {
       cancelled = true;
     };
-  }, [reloadToken]);
+  }, [userIdStr, reloadToken]);
 
-  const myRecipes = useMemo(
-    () => recipes.filter((r) => authorIdOf(r) === userIdStr),
-    [recipes, userIdStr],
-  );
-  const myStories = useMemo(
-    () => stories.filter((s) => authorIdOf(s) === userIdStr),
-    [stories, userIdStr],
-  );
+  const myRecipes = recipes;
+  const myStories = stories;
 
   const initial = (username ?? 'U').slice(0, 1).toUpperCase();
 

--- a/app/mobile/src/services/recipeService.ts
+++ b/app/mobile/src/services/recipeService.ts
@@ -1,6 +1,6 @@
 import type { RecipeDetail, RecipeIngredientRow } from '../types/recipe';
 import { parseAuthorId } from '../utils/parseAuthorId';
-import { apiGetJson, apiPatchFormData, apiPatchJson } from './httpClient';
+import { apiGetJson, apiPatchFormData, apiPatchJson, nextPagePath } from './httpClient';
 
 /**
  * Same endpoint as web `fetchRecipe` in `recipeService.js`.
@@ -113,8 +113,12 @@ export async function updateRecipeById(id: string, formData: FormData): Promise<
   await apiPatchFormData(`/api/recipes/${id}/`, formData);
 }
 
-/** Minimal list for story linking / pickers (web: GET `/api/recipes/`). */
-export async function fetchRecipesList(): Promise<
+/** Minimal list for story linking / pickers (web: GET `/api/recipes/`).
+ * Optional `filter.author` adds `?author=<id>` so callers (e.g. profile) get
+ * server-filtered results instead of pulling the whole feed and filtering
+ * client-side. Walks the DRF `next` link to gather all pages — profiles can
+ * have more than the default page size. */
+export async function fetchRecipesList(filter?: { author?: number | string }): Promise<
   {
     id: string;
     title: string;
@@ -126,13 +130,25 @@ export async function fetchRecipesList(): Promise<
     rank_reason?: string | null;
   }[]
 > {
-  const data = await apiGetJson<any>(`/api/recipes/`);
-  const list: any[] = Array.isArray(data)
-    ? data
-    : data && Array.isArray(data.results)
-      ? data.results
-      : [];
-  return list.map((r) => {
+  const initialParams = new URLSearchParams();
+  if (filter?.author != null) initialParams.set('author', String(filter.author));
+  const initialQs = initialParams.toString();
+  const collected: any[] = [];
+  let path: string | null = `/api/recipes/${initialQs ? `?${initialQs}` : ''}`;
+  while (path) {
+    const data: any = await apiGetJson<any>(path);
+    if (Array.isArray(data)) {
+      collected.push(...data);
+      break;
+    }
+    if (data && Array.isArray(data.results)) {
+      collected.push(...data.results);
+      path = nextPagePath(data.next);
+    } else {
+      break;
+    }
+  }
+  return collected.map((r) => {
     const reg = r.region;
     const regionLabel =
       reg == null

--- a/app/mobile/src/services/storyService.ts
+++ b/app/mobile/src/services/storyService.ts
@@ -1,6 +1,6 @@
 import type { StoryDetail } from '../types/story';
 import { parseAuthorId } from '../utils/parseAuthorId';
-import { apiGetJson, apiPatchFormData, apiPatchJson } from './httpClient';
+import { apiGetJson, apiPatchFormData, apiPatchJson, nextPagePath } from './httpClient';
 
 /** Same endpoint as web `fetchStory` (`GET /api/stories/:id/`). */
 export async function fetchStoryById(id: string): Promise<StoryDetail> {
@@ -67,9 +67,26 @@ function unwrapStoriesPayload(data: unknown): any[] {
  * DRF-paginated `{results}` envelope. Returns the API objects untouched so
  * callers can read `author`, `linked_recipe`, `image`, etc. directly.
  */
-export async function fetchStoriesList(): Promise<any[]> {
-  const data = await apiGetJson<unknown>(`/api/stories/`);
-  return unwrapStoriesPayload(data);
+export async function fetchStoriesList(filter?: { author?: number | string }): Promise<any[]> {
+  const initialParams = new URLSearchParams();
+  if (filter?.author != null) initialParams.set('author', String(filter.author));
+  const initialQs = initialParams.toString();
+  const collected: any[] = [];
+  let path: string | null = `/api/stories/${initialQs ? `?${initialQs}` : ''}`;
+  while (path) {
+    const data = await apiGetJson<unknown>(path);
+    if (Array.isArray(data)) {
+      collected.push(...data);
+      break;
+    }
+    if (data && typeof data === 'object' && Array.isArray((data as { results?: unknown }).results)) {
+      collected.push(...((data as { results: any[] }).results));
+      path = nextPagePath((data as { next?: string | null }).next);
+    } else {
+      break;
+    }
+  }
+  return collected;
 }
 
 /** Stories where `linked_recipe` matches the given recipe id. Filters client-side. */


### PR DESCRIPTION
## Summary
Closes #619. UserProfileScreen had two distinct bugs that compounded into "wrong user content / silently incomplete":

1. **useEffect missing `userId` dependency** — navigating from profile A to profile B re-used the same screen instance with different params, but the data-fetching effect only depended on `[reloadToken]` so it never re-fired. The header showed B, but the recipes/stories still came from A.
2. **Global fetch + client-side filter, page 1 only** — `fetchRecipesList()` / `fetchStoriesList()` pulled the unfiltered first page and the screen filtered by `author.id` locally. Anyone whose content was on page 2+ was silently invisible.

The backend `?author=<id>` filter shipped in #637, so we can now ask the server for exactly the user's content and walk the DRF `next` link to gather all of it.

## Files
- `services/recipeService.ts` — `fetchRecipesList(filter?: { author? })` accepts the filter, sends `?author=<id>`, and walks `next` page-by-page (uses the existing `nextPagePath` helper from `httpClient`).
- `services/storyService.ts` — same pattern on `fetchStoriesList`.
- `screens/UserProfileScreen.tsx` — passes `userIdStr` to both services, adds `userIdStr` to the effect dep array, drops the now-redundant `authorIdOf` helper + `useMemo` client filter, and pulls `useMemo` out of imports.

## Test
- `npx tsc --noEmit` clean
- Verified counts match the database across 5 seeded users (per-API `?author=<id>` count exactly matches `Recipe.objects.filter(author=u).count()` and `Story.objects.filter(author=u).count()` for users 1-5: ayse 8/4, mehmet 3/2, elif 3/2, fatma 2/1, emily 0/0).
- On mobile, tapped from one user's profile to another via the recipe/story author pills — the screen immediately re-fetched and rendered the new user's content (used to keep showing the previous user's content until manual reload).
- Prolific author (ayse, 8 recipes): all 8 appear, not just page 1.

Closes #619