### PR TITLE
feat(backend): allow profile field editing via PATCH /api/users/me/ (#659)

### DIFF
--- a/app/backend/apps/users/serializers.py
+++ b/app/backend/apps/users/serializers.py
@@ -89,6 +89,13 @@ class StringTagListField(serializers.ListField):
 
 
 class UserPreferencesUpdateSerializer(serializers.ModelSerializer):
+    """Self-service update for `PATCH /api/users/me/`.
+
+    Covers cultural-onboarding tags, contactability, and basic profile fields
+    (#659). Privilege-sensitive fields (email, role, is_staff, is_superuser)
+    are intentionally excluded so they cannot be changed through this endpoint.
+    All fields are optional; the view uses partial updates.
+    """
     cultural_interests = StringTagListField()
     regional_ties = StringTagListField()
     religious_preferences = StringTagListField()
@@ -99,4 +106,13 @@ class UserPreferencesUpdateSerializer(serializers.ModelSerializer):
         fields = [
             'cultural_interests', 'regional_ties', 'religious_preferences', 'event_interests',
             'is_contactable',
+            'username', 'bio', 'region', 'preferred_language',
         ]
+
+    def validate_username(self, value):
+        qs = User.objects.filter(username__iexact=value)
+        if self.instance is not None:
+            qs = qs.exclude(pk=self.instance.pk)
+        if qs.exists():
+            raise serializers.ValidationError('This username is already taken.')
+        return value

--- a/app/backend/apps/users/tests.py
+++ b/app/backend/apps/users/tests.py
@@ -441,6 +441,107 @@ class ContactabilityProfileTest(APITestCase):
         self.assertTrue(self.user.is_contactable)
 
 
+class ProfileFieldEditTest(APITestCase):
+    """Tests for editing basic profile fields via PATCH /api/users/me/ (#659)."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            email='profile@example.com', username='profileuser', password='StrongPass123!',
+            bio='old bio', region='Aegean', preferred_language='en',
+        )
+        response = self.client.post(
+            '/api/auth/login/', {"email": "profile@example.com", "password": "StrongPass123!"}
+        )
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {response.data["access"]}')
+
+    def test_patch_updates_profile_fields(self):
+        payload = {
+            'username': 'newhandle',
+            'bio': 'new bio text',
+            'region': 'Black Sea',
+            'preferred_language': 'tr',
+        }
+        response = self.client.patch('/api/users/me/', payload, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        for field, expected in payload.items():
+            self.assertEqual(response.data[field], expected)
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.username, 'newhandle')
+        self.assertEqual(self.user.bio, 'new bio text')
+        self.assertEqual(self.user.region, 'Black Sea')
+        self.assertEqual(self.user.preferred_language, 'tr')
+
+    def test_patch_partial_profile_update(self):
+        response = self.client.patch('/api/users/me/', {'bio': 'just the bio'}, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.bio, 'just the bio')
+        self.assertEqual(self.user.username, 'profileuser')
+        self.assertEqual(self.user.region, 'Aegean')
+
+    def test_patch_taken_username_returns_400(self):
+        User.objects.create_user(
+            email='other@example.com', username='takenname', password='StrongPass123!'
+        )
+        response = self.client.patch('/api/users/me/', {'username': 'takenname'}, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('username', response.data)
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.username, 'profileuser')
+
+    def test_patch_taken_username_case_insensitive_returns_400(self):
+        User.objects.create_user(
+            email='other@example.com', username='TakenName', password='StrongPass123!'
+        )
+        response = self.client.patch('/api/users/me/', {'username': 'takenname'}, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('username', response.data)
+
+    def test_patch_same_username_is_allowed(self):
+        response = self.client.patch('/api/users/me/', {'username': 'profileuser'}, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.username, 'profileuser')
+
+    def test_patch_does_not_allow_privilege_escalation(self):
+        response = self.client.patch(
+            '/api/users/me/',
+            {
+                'email': 'hijack@example.com',
+                'role': 'admin',
+                'is_staff': True,
+                'is_superuser': True,
+                'bio': 'still updates',
+            },
+            format='json',
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.email, 'profile@example.com')
+        self.assertEqual(self.user.role, User.Role.USER)
+        self.assertFalse(self.user.is_staff)
+        self.assertFalse(self.user.is_superuser)
+        self.assertEqual(self.user.bio, 'still updates')
+
+    def test_patch_profile_fields_unauthenticated_rejected(self):
+        self.client.credentials()
+        response = self.client.patch('/api/users/me/', {'bio': 'nope'}, format='json')
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_patch_preserves_cultural_and_contactability_behavior(self):
+        response = self.client.patch(
+            '/api/users/me/',
+            {'cultural_interests': ['Fermentation'], 'is_contactable': False},
+            format='json',
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['cultural_interests'], ['Fermentation'])
+        self.assertFalse(response.data['is_contactable'])
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.cultural_interests, ['Fermentation'])
+        self.assertFalse(self.user.is_contactable)
+
+
 class TokenRefreshTest(APITestCase):
     """Tests for POST /api/auth/token/refresh/ (Issue #405)."""
 


### PR DESCRIPTION
## Summary
- PATCH /api/users/me/ now accepts username, bio, region, preferred_language alongside existing cultural-preference and is_contactable fields
- username uniqueness validated (400 on conflict, case-insensitive); email/role/is_staff/is_superuser stay blocked

## Test plan
- [x] python manage.py test apps.users
- [x] makemigrations --check --dry-run clean

## Notes
- No migration: bio/region/preferred_language already on the User model
- Unblocks web #660 and mobile #661 profile editing screens

Closes #659.