### PR TITLE
feat(mobile): heritage journey timeline on heritage screen (#504)

### DIFF
--- a/app/mobile/src/screens/HeritageScreen.tsx
+++ b/app/mobile/src/screens/HeritageScreen.tsx
@@ -97,6 +97,40 @@ export default function HeritageScreen({ route, navigation }: Props) {
               <Text style={styles.mapCtaText}>Show heritage map →</Text>
             </Pressable>
 
+            {group.journey_steps.length > 0 ? (
+              <View style={styles.journeySection} accessibilityLabel="Heritage journey timeline">
+                <Text style={styles.sectionHeading}>Journey through time</Text>
+                <View style={styles.timeline}>
+                  {group.journey_steps
+                    .slice()
+                    .sort((a, b) => a.order - b.order)
+                    .map((step, idx, arr) => (
+                      <View key={`step-${step.id}`} style={styles.timelineRow}>
+                        <View style={styles.timelineSpine}>
+                          <View style={styles.timelineDot}>
+                            <Text style={styles.timelineDotText}>{step.order}</Text>
+                          </View>
+                          {idx < arr.length - 1 ? <View style={styles.timelineLine} /> : null}
+                        </View>
+                        <View style={styles.timelineBody}>
+                          <View style={styles.timelineMeta}>
+                            {step.era ? (
+                              <View style={styles.eraPill}>
+                                <Text style={styles.eraPillText}>{step.era}</Text>
+                              </View>
+                            ) : null}
+                            <Text style={styles.timelineLocation} numberOfLines={1}>
+                              {step.location}
+                            </Text>
+                          </View>
+                          <Text style={styles.timelineStory}>{step.story}</Text>
+                        </View>
+                      </View>
+                    ))}
+                </View>
+              </View>
+            ) : null}
+
             <Text style={styles.sectionHeading}>
               Recipes &amp; stories in this heritage ({group.members.length})
             </Text>
@@ -216,4 +250,57 @@ const styles = StyleSheet.create({
   memberAuthor: { fontSize: 12, color: tokens.colors.textMuted, fontWeight: '700' },
   memberArrow: { fontSize: 18, fontWeight: '900', color: tokens.colors.surfaceDark },
   pressed: { opacity: 0.85 },
+  journeySection: { gap: 12, marginTop: 6 },
+  timeline: { gap: 0 },
+  timelineRow: { flexDirection: 'row', gap: 14, paddingBottom: 4 },
+  timelineSpine: { alignItems: 'center', width: 36 },
+  timelineDot: {
+    width: 28,
+    height: 28,
+    borderRadius: 999,
+    backgroundColor: tokens.colors.surfaceDark,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 2,
+    borderColor: tokens.colors.accentMustard,
+  },
+  timelineDotText: {
+    fontSize: 12,
+    fontWeight: '900',
+    color: tokens.colors.accentMustard,
+  },
+  timelineLine: {
+    flex: 1,
+    width: 2,
+    backgroundColor: tokens.colors.surfaceDark,
+    marginTop: 4,
+    marginBottom: 4,
+  },
+  timelineBody: { flex: 1, paddingBottom: 18, gap: 6 },
+  timelineMeta: { flexDirection: 'row', alignItems: 'center', gap: 8, flexWrap: 'wrap' },
+  eraPill: {
+    paddingHorizontal: 10,
+    paddingVertical: 3,
+    borderRadius: tokens.radius.pill,
+    backgroundColor: tokens.colors.accentMustard,
+    borderWidth: 1.5,
+    borderColor: tokens.colors.surfaceDark,
+  },
+  eraPillText: {
+    fontSize: 11,
+    fontWeight: '900',
+    color: tokens.colors.surfaceDark,
+    letterSpacing: 0.4,
+  },
+  timelineLocation: {
+    fontSize: 14,
+    fontWeight: '800',
+    color: tokens.colors.text,
+    fontFamily: tokens.typography.display.fontFamily,
+  },
+  timelineStory: {
+    fontSize: 13,
+    color: tokens.colors.text,
+    lineHeight: 19,
+  },
 });


### PR DESCRIPTION
## Summary
Closes #504 (mobile portion). Adds the **Journey through time** timeline section to `HeritageScreen`. Renders the `journey_steps` array that the backend `HeritageGroupDetailSerializer` already returns under each heritage group — an ordered narrative arc (location, era, story) that traces the tradition through history. Hidden when the group has no steps.

## Dependency
- **Stacked on PR #666** (heritage feature, base branch `feat/mobile/heritage-feature-501`). This PR's diff only adds the timeline section and styles; it cannot land until #666 merges into main first. After #666 merges, this PR's base will auto-retarget to main.
- **Backend seed**: companion issue filed to populate `HeritageJourneyStep` rows. Endpoint and model already exist (`/api/heritage-journey-steps/`, see `apps/heritage/models.py`); the catalogue is empty. Mobile UI hides the section until rows arrive.

## Files
- `screens/HeritageScreen.tsx` — render a vertical timeline between the "Show heritage map" CTA and the members section. Each step gets:
  - A numbered dark circle on a vertical spine (mustard-bordered, sequential `step.order`).
  - A mustard era pill + bold location label + multi-line story body.
  - Connector line between consecutive steps; no line under the last step.
- Inline timeline styles (no new component file — section is contained, easy to extract later if reused).

## Test
- `npx tsc --noEmit` clean
- Seeded 4 journey steps for "Sarma / Dolma" (Persia → Anatolia → Black Sea → Aegean) and opened the heritage screen from a Sarma recipe. The timeline renders in order with era pills, locations, and stories, between the map CTA and the members list.
- API contract verified end-to-end: `GET /api/heritage-groups/1/` returns 4 journey_steps with order 1-4, each with era + location + story exactly matching the shape the timeline consumes.

## Out of scope / followups
- **Tap a journey step → expand or open a focused view**: possible v2; for now the rows are static narrative.
- **Lat/lng on journey steps**: not yet in the model; could later place the journey markers on the heritage map as a chronological polyline. Current map already polylines centroid → members; the journey would add a temporal layer that's independent.

Closes #504 (mobile)