### PR TITLE
feat(backend): zoom-to-region recipe coordinates, region bounds, region recipes endpoint (#662)

### DIFF
--- a/app/backend/apps/recipes/migrations/0022_zoom_region_coords_662.py
+++ b/app/backend/apps/recipes/migrations/0022_zoom_region_coords_662.py
@@ -1,0 +1,25 @@
+# Zoom-to-region: per-recipe map coordinates (#662).
+# Region map bounds reuse the existing Region.bbox_* fields (migration 0011),
+# so no Region change is needed here.
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('recipes', '0021_remove_secular_religion'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='recipe',
+            name='latitude',
+            field=models.DecimalField(blank=True, decimal_places=6, max_digits=9, null=True),
+        ),
+        migrations.AddField(
+            model_name='recipe',
+            name='longitude',
+            field=models.DecimalField(blank=True, decimal_places=6, max_digits=9, null=True),
+        ),
+    ]

--- a/app/backend/apps/recipes/models.py
+++ b/app/backend/apps/recipes/models.py
@@ -134,6 +134,12 @@ class Recipe(models.Model):
     image = models.ImageField(upload_to='recipes/images/', null=True, blank=True)
     video = models.FileField(upload_to='recipes/videos/', null=True, blank=True)
     region = models.ForeignKey(Region, on_delete=models.SET_NULL, null=True, related_name='recipes')
+    # Optional per-recipe map coordinates (#662). Recipes without coordinates
+    # are valid; they surface in the "unlocated" list of the zoom-to-region view
+    # (#464). Region map bounds reuse the existing Region.bbox_* fields above
+    # (Option A from #662); no new Region field is needed here.
+    latitude = models.DecimalField(max_digits=9, decimal_places=6, null=True, blank=True)
+    longitude = models.DecimalField(max_digits=9, decimal_places=6, null=True, blank=True)
     author = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name='recipes')
     qa_enabled = models.BooleanField(default=True)
     is_published = models.BooleanField(default=False)

--- a/app/backend/apps/recipes/serializers.py
+++ b/app/backend/apps/recipes/serializers.py
@@ -196,7 +196,8 @@ class RecipeSerializer(serializers.ModelSerializer):
         model = Recipe
         fields = [
             'id', 'public_id', 'title', 'description', 'image', 'video',
-            'region', 'region_name', 'author', 'author_username', 'qa_enabled',
+            'region', 'region_name', 'latitude', 'longitude',
+            'author', 'author_username', 'qa_enabled',
             'is_published', 'is_heritage', 'heritage_notes',
             'created_at', 'updated_at',
             'ingredients', 'ingredients_write',

--- a/app/backend/apps/recipes/tests.py
+++ b/app/backend/apps/recipes/tests.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 from rest_framework.test import APITestCase
 from rest_framework import status
 from django.urls import reverse
@@ -441,3 +443,149 @@ class RecipeHeritageFieldsAPITest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertFalse(response.data['is_heritage'])
         self.assertEqual(response.data['heritage_notes'], "")
+
+
+class ZoomToRegionCoordsAPITest(APITestCase):
+    """Tests for zoom-to-region coordinates (#662).
+
+    Recipe gains nullable latitude/longitude; Region exposes its existing
+    bbox_* bounds; GET /api/regions/<id>/recipes/ partitions a region's
+    recipes into located vs unlocated for the zoom-to-region map (#464).
+    """
+
+    def setUp(self):
+        self.author = User.objects.create_user(
+            email="zoom_author@example.com",
+            username="zoom_author",
+            password="StrongPass123!",
+        )
+        self.region = Region.objects.create(
+            name="Pontic Coast",
+            is_approved=True,
+            latitude=41.0,
+            longitude=39.7,
+            bbox_north=42.1,
+            bbox_south=40.3,
+            bbox_east=42.5,
+            bbox_west=36.0,
+        )
+        self.located = Recipe.objects.create(
+            title="Trabzon Sarma",
+            description="Collard rolls.",
+            region=self.region,
+            author=self.author,
+            is_published=True,
+            latitude=Decimal("41.000000"),
+            longitude=Decimal("39.716700"),
+        )
+        self.unlocated = Recipe.objects.create(
+            title="Black Sea Anchovy Pilaf",
+            description="Hamsi pilav.",
+            region=self.region,
+            author=self.author,
+            is_published=True,
+        )
+
+    def test_recipe_detail_includes_null_coordinates(self):
+        url = reverse('recipe-detail', kwargs={'pk': self.unlocated.id})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIsNone(response.data['latitude'])
+        self.assertIsNone(response.data['longitude'])
+
+    def test_recipe_detail_includes_set_coordinates(self):
+        url = reverse('recipe-detail', kwargs={'pk': self.located.id})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(Decimal(str(response.data['latitude'])), Decimal("41.000000"))
+        self.assertEqual(Decimal(str(response.data['longitude'])), Decimal("39.716700"))
+
+    def test_recipe_region_list_includes_coordinates(self):
+        response = self.client.get(reverse('recipe-list'), {'region': 'Pontic Coast'})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = response.data.get('results', response.data)
+        by_id = {r['id']: r for r in results}
+        self.assertIn('latitude', by_id[self.located.id])
+        self.assertIn('longitude', by_id[self.located.id])
+        self.assertEqual(
+            Decimal(str(by_id[self.located.id]['latitude'])), Decimal("41.000000")
+        )
+        self.assertIsNone(by_id[self.unlocated.id]['latitude'])
+        self.assertIsNone(by_id[self.unlocated.id]['longitude'])
+
+    def test_region_detail_includes_bbox(self):
+        url = reverse('region-detail', kwargs={'pk': self.region.id})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        for key in ('bbox_north', 'bbox_south', 'bbox_east', 'bbox_west', 'latitude', 'longitude'):
+            self.assertIn(key, response.data)
+        self.assertEqual(response.data['bbox_north'], 42.1)
+        self.assertEqual(response.data['bbox_west'], 36.0)
+
+    def test_region_recipes_endpoint_partitions(self):
+        url = reverse('region-recipes', kwargs={'pk': self.region.id})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        located_ids = [r['id'] for r in response.data['located']]
+        unlocated_ids = [r['id'] for r in response.data['unlocated']]
+        self.assertEqual(located_ids, [self.located.id])
+        self.assertEqual(unlocated_ids, [self.unlocated.id])
+
+        located_entry = response.data['located'][0]
+        self.assertEqual(located_entry['title'], "Trabzon Sarma")
+        self.assertEqual(located_entry['author_username'], "zoom_author")
+        self.assertEqual(Decimal(str(located_entry['latitude'])), Decimal("41.000000"))
+        self.assertEqual(Decimal(str(located_entry['longitude'])), Decimal("39.716700"))
+
+        unlocated_entry = response.data['unlocated'][0]
+        self.assertEqual(unlocated_entry['title'], "Black Sea Anchovy Pilaf")
+        self.assertEqual(unlocated_entry['author_username'], "zoom_author")
+        self.assertNotIn('latitude', unlocated_entry)
+        self.assertNotIn('longitude', unlocated_entry)
+
+    def test_region_recipes_endpoint_partial_coordinates_are_unlocated(self):
+        half = Recipe.objects.create(
+            title="Half Located",
+            description="Only latitude set.",
+            region=self.region,
+            author=self.author,
+            latitude=Decimal("41.000000"),
+        )
+        url = reverse('region-recipes', kwargs={'pk': self.region.id})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn(half.id, [r['id'] for r in response.data['unlocated']])
+        self.assertNotIn(half.id, [r['id'] for r in response.data['located']])
+
+    def test_region_recipes_endpoint_empty_region(self):
+        empty = Region.objects.create(name="Empty Land", is_approved=True)
+        url = reverse('region-recipes', kwargs={'pk': empty.id})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, {'located': [], 'unlocated': []})
+
+    def test_region_recipes_endpoint_unknown_region_404(self):
+        url = reverse('region-recipes', kwargs={'pk': 999999})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_create_recipe_with_coordinates_round_trips(self):
+        self.client.force_authenticate(user=self.author)
+        ingredient, _ = Ingredient.objects.get_or_create(
+            name="Cornmeal", defaults={"is_approved": True}
+        )
+        data = {
+            "title": "Muhlama",
+            "description": "Cheese fondue from the highlands.",
+            "region": self.region.id,
+            "latitude": "40.916700",
+            "longitude": "39.083300",
+            "ingredients_write": [
+                {"ingredient": ingredient.id, "amount": "1.00"}
+            ],
+        }
+        response = self.client.post(reverse('recipe-list'), data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
+        recipe = Recipe.objects.get(pk=response.data['id'])
+        self.assertEqual(recipe.latitude, Decimal("40.916700"))
+        self.assertEqual(recipe.longitude, Decimal("39.083300"))

--- a/app/backend/apps/recipes/views.py
+++ b/app/backend/apps/recipes/views.py
@@ -324,6 +324,43 @@ class RegionViewSet(CulturalTagSubmissionMixin, ModeratedLookupViewSet):
     serializer_class = RegionSubmissionSerializer
     lookup_serializer_class = RegionSerializer
 
+    def get_permissions(self):
+        # The parent's get_permissions hardcodes IsAdminUser for any action
+        # outside list/retrieve/create, which would lock down the read-only
+        # `recipes` action. Treat it like list/retrieve.
+        if self.action == 'recipes':
+            return [permissions.AllowAny()]
+        return super().get_permissions()
+
+    @action(detail=True, methods=['get'], url_path='recipes')
+    def recipes(self, request, pk=None):
+        """Split a region's recipes into located (has lat+lng) and unlocated.
+
+        Backs the zoom-to-region map view (#464 / #662): the located list
+        becomes per-recipe pins, the unlocated list becomes the "without a
+        location" bar. Both lists are ordered newest first.
+        """
+        region = get_object_or_404(Region, pk=pk, is_approved=True)
+        recipes = region.recipes.select_related('author').order_by('-created_at')
+
+        located, unlocated = [], []
+        for recipe in recipes:
+            base = {
+                'id': recipe.id,
+                'title': recipe.title,
+                'author_username': recipe.author.username,
+            }
+            if recipe.latitude is not None and recipe.longitude is not None:
+                located.append({
+                    **base,
+                    'latitude': recipe.latitude,
+                    'longitude': recipe.longitude,
+                })
+            else:
+                unlocated.append(base)
+
+        return Response({'located': located, 'unlocated': unlocated})
+
 class DietaryTagViewSet(ModeratedLookupViewSet):
     """ViewSet for list/submission of dietary tags (M4-15)."""
     queryset = DietaryTag.objects.all().order_by(Lower('name'), 'id')


### PR DESCRIPTION
## Summary
- Recipe gains latitude/longitude (nullable DecimalField); serialized on detail and ?region= list
- Region map bounds reuse the existing Region.bbox_* fields (Option A); no new Region field needed
- New GET /api/regions/<id>/recipes/ splits a region's recipes into located vs unlocated, newest first

## Test plan
- [x] python manage.py test apps.recipes
- [x] python manage.py test apps.recipes.tests.ZoomToRegionCoordsAPITest
- [x] makemigrations --check --dry-run clean

## Notes
- Coordinate values are not seeded here; that is #657
- Migration filename carries the _662 suffix; if another recipes migration merges first this PR rebases and renumbers
- The new action overrides get_permissions on RegionViewSet so it stays publicly readable like list/retrieve (ModeratedLookupViewSet otherwise hardcodes IsAdminUser for non-CRUD actions)
- Backend foundation for #464 (web #468 + mobile)

Closes #662.