### PR TITLE
fix(mobile): debounce SearchScreen keystrokes (350ms) (#690)

### DIFF
--- a/app/mobile/src/screens/SearchScreen.tsx
+++ b/app/mobile/src/screens/SearchScreen.tsx
@@ -96,50 +96,61 @@ export default function SearchScreen({ navigation, route }: Props) {
       setLoading(false);
       return;
     }
+    // Debounce keystrokes: while the user is typing fast, hold the request
+    // back 350ms so a 7-character word fires a single API call instead of 7.
+    // `cancelled` still cancels any in-flight request when the next effect
+    // run fires. `retryToken` bumps work through the same delay; a single
+    // 350ms wait on Retry is fine.
     let cancelled = false;
-    setLoading(true);
-    setError(null);
     const filters: SearchFilters = {
       diet: dietInclude,
       diet_exclude: dietExclude,
       event: eventInclude,
       event_exclude: eventExclude,
     };
-    void (async () => {
-      try {
-        const data = await search(q, region.trim() || undefined, filters);
-        if (cancelled) return;
-        setResults(data);
 
-        // Mobile-only enhancement: hydrate story thumbnails by fetching story details (cached).
-        const candidates = data
-          .filter((r) => r.kind === 'story' && !r.thumbnail)
-          .slice(0, 8);
-        const cache = storyThumbCacheRef.current;
-        await Promise.allSettled(
-          candidates.map(async (item) => {
-            if (cache.has(item.id)) return;
-            const story = await fetchStoryById(item.id);
-            const url = story.image ?? null;
-            cache.set(item.id, url);
-          }),
-        );
-        if (cancelled) return;
-        setResults((prev) =>
-          prev.map((r) => {
-            if (r.kind !== 'story' || r.thumbnail) return r;
-            const url = cache.get(r.id);
-            return url ? { ...r, thumbnail: url } : r;
-          }),
-        );
-      } catch (e) {
-        if (!cancelled) setError(e instanceof Error ? e.message : 'Search failed');
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    })();
+    const timer = setTimeout(() => {
+      if (cancelled) return;
+      setLoading(true);
+      setError(null);
+      void (async () => {
+        try {
+          const data = await search(q, region.trim() || undefined, filters);
+          if (cancelled) return;
+          setResults(data);
+
+          // Mobile-only enhancement: hydrate story thumbnails by fetching story details (cached).
+          const candidates = data
+            .filter((r) => r.kind === 'story' && !r.thumbnail)
+            .slice(0, 8);
+          const cache = storyThumbCacheRef.current;
+          await Promise.allSettled(
+            candidates.map(async (item) => {
+              if (cache.has(item.id)) return;
+              const story = await fetchStoryById(item.id);
+              const url = story.image ?? null;
+              cache.set(item.id, url);
+            }),
+          );
+          if (cancelled) return;
+          setResults((prev) =>
+            prev.map((r) => {
+              if (r.kind !== 'story' || r.thumbnail) return r;
+              const url = cache.get(r.id);
+              return url ? { ...r, thumbnail: url } : r;
+            }),
+          );
+        } catch (e) {
+          if (!cancelled) setError(e instanceof Error ? e.message : 'Search failed');
+        } finally {
+          if (!cancelled) setLoading(false);
+        }
+      })();
+    }, 350);
+
     return () => {
       cancelled = true;
+      clearTimeout(timer);
     };
   }, [query, region, filtersKey, hasActiveFilters, retryToken]);
 


### PR DESCRIPTION
## Summary
Closes #690. `SearchScreen`'s effect used to fire an API call on every keystroke. Typing a 7-character word (e.g. "chicken") produced 7 sequential requests; the UI flickered as out-of-order responses arrived. Added a 350ms debounce so a single call goes out after the user stops typing.

## File
`app/mobile/src/screens/SearchScreen.tsx`

## How it works
- Effect's body is now wrapped in `setTimeout(..., 350)`; the timer id is cleared in the effect's cleanup, alongside the existing `cancelled` flag for the actual fetch.
- Pristine state (`!q && !region && !filters`) still short-circuits before scheduling a timer — no idle timers when the screen is empty.
- Retry button (`retryToken`) re-triggers the effect; the same 350ms delay applies before the request fires, which is fine for a deliberate retry.

## Test
- `npx tsc --noEmit` clean
- Simulated the debounce pattern in a small Node script (writes a typed effect/cleanup loop):
  - Fast typing (80ms gap between keystrokes, 7 chars in "chicken") → **1 API call** for the final string.
  - Slow typing (500ms gap, beyond the 350ms debounce window) → 1 call per character — the user has paused on each character, so this is the right behavior.
- Live test on the running app: search input updates without intermediate spinner flicker; the spinner appears once shortly after typing stops.

Closes #690