### PR TITLE
fix(mobile): auth-gate create screens and harden handleSkip (#691)

### DIFF
--- a/app/mobile/src/components/recipe/recipeFormStyles.ts
+++ b/app/mobile/src/components/recipe/recipeFormStyles.ts
@@ -157,4 +157,22 @@ export const recipeFormStyles = StyleSheet.create({
     marginBottom: 8,
   },
   summaryLine: { fontSize: 15, color: tokens.colors.text, marginBottom: 4 },
+  authGate: {
+    flex: 1,
+    padding: 24,
+    justifyContent: 'center',
+    gap: 14,
+  },
+  authGateHeading: {
+    fontSize: 24,
+    fontWeight: '800',
+    color: tokens.colors.text,
+    fontFamily: tokens.typography.display.fontFamily,
+  },
+  authGateBody: {
+    fontSize: 15,
+    color: tokens.colors.textMuted,
+    lineHeight: 22,
+    marginBottom: 8,
+  },
 });

--- a/app/mobile/src/screens/OnboardingScreen.tsx
+++ b/app/mobile/src/screens/OnboardingScreen.tsx
@@ -100,7 +100,12 @@ export default function OnboardingScreen({ navigation }: Props) {
   };
 
   const handleSkip = async () => {
-    await AsyncStorage.setItem(SKIP_FLAG, 'true');
+    try {
+      await AsyncStorage.setItem(SKIP_FLAG, 'true');
+    } catch {
+      // AsyncStorage can fail on low-storage devices; we still want the user
+      // out of the onboarding flow either way. Falling through to popToTop.
+    }
     navigation.popToTop();
   };
 

--- a/app/mobile/src/screens/RecipeCreateScreen.tsx
+++ b/app/mobile/src/screens/RecipeCreateScreen.tsx
@@ -12,6 +12,7 @@ import {
   type AuthoringIngredientRow,
 } from '../components/recipe/recipeFormState';
 import { recipeFormStyles as styles } from '../components/recipe/recipeFormStyles';
+import { useAuth } from '../context/AuthContext';
 import { useToast } from '../context/ToastContext';
 import type { RootStackParamList } from '../navigation/types';
 import { apiPatchFormData, apiPostJson } from '../services/httpClient';
@@ -21,6 +22,7 @@ type Props = NativeStackScreenProps<RootStackParamList, 'RecipeCreate'>;
 
 export default function RecipeCreateScreen({ navigation }: Props) {
   const { showToast } = useToast();
+  const { isAuthenticated, isReady } = useAuth();
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [qaEnabled, setQaEnabled] = useState(true);
@@ -196,6 +198,37 @@ export default function RecipeCreateScreen({ navigation }: Props) {
         setSubmitting(false);
       }
     })();
+  }
+
+  if (isReady && !isAuthenticated) {
+    return (
+      <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
+        <View style={styles.authGate}>
+          <Text style={styles.authGateHeading} accessibilityRole="header">
+            Sign in to share a recipe
+          </Text>
+          <Text style={styles.authGateBody}>
+            Log in to publish recipes — your drafts, comments, and saves all live under your account.
+          </Text>
+          <Pressable
+            onPress={() => navigation.navigate('Login')}
+            style={({ pressed }) => [styles.primaryButton, pressed && styles.buttonPressed]}
+            accessibilityRole="button"
+            accessibilityLabel="Go to log in"
+          >
+            <Text style={styles.primaryButtonText}>Log In</Text>
+          </Pressable>
+          <Pressable
+            onPress={() => navigation.navigate('Register')}
+            style={({ pressed }) => [styles.secondaryButton, pressed && styles.buttonPressed]}
+            accessibilityRole="button"
+            accessibilityLabel="Go to register"
+          >
+            <Text style={styles.secondaryButtonText}>Register</Text>
+          </Pressable>
+        </View>
+      </SafeAreaView>
+    );
   }
 
   return (

--- a/app/mobile/src/screens/StoryCreateScreen.tsx
+++ b/app/mobile/src/screens/StoryCreateScreen.tsx
@@ -25,7 +25,7 @@ const LANGS: { label: string; value: StoryLanguage }[] = [
 ];
 
 export default function StoryCreateScreen({ navigation }: Props) {
-  const { user } = useAuth();
+  const { user, isAuthenticated, isReady } = useAuth();
   const { showToast } = useToast();
 
   const [title, setTitle] = useState('');
@@ -95,6 +95,37 @@ export default function StoryCreateScreen({ navigation }: Props) {
         setSubmitting(false);
       }
     })();
+  }
+
+  if (isReady && !isAuthenticated) {
+    return (
+      <SafeAreaView style={form.safe} edges={['top', 'left', 'right']}>
+        <View style={form.authGate}>
+          <Text style={form.authGateHeading} accessibilityRole="header">
+            Sign in to share a story
+          </Text>
+          <Text style={form.authGateBody}>
+            Log in to publish stories — your drafts, comments, and saves all live under your account.
+          </Text>
+          <Pressable
+            onPress={() => navigation.navigate('Login')}
+            style={({ pressed }) => [form.primaryButton, pressed && form.buttonPressed]}
+            accessibilityRole="button"
+            accessibilityLabel="Go to log in"
+          >
+            <Text style={form.primaryButtonText}>Log In</Text>
+          </Pressable>
+          <Pressable
+            onPress={() => navigation.navigate('Register')}
+            style={({ pressed }) => [form.secondaryButton, pressed && form.buttonPressed]}
+            accessibilityRole="button"
+            accessibilityLabel="Go to register"
+          >
+            <Text style={form.secondaryButtonText}>Register</Text>
+          </Pressable>
+        </View>
+      </SafeAreaView>
+    );
   }
 
   return (


### PR DESCRIPTION
## Summary
Closes #691. Small form-UX bundle:
1. RecipeCreate and StoryCreate now render a sign-in gate when the user isn't authenticated, instead of letting them fill out the form and discover at submit-time that the API call fails.
2. `OnboardingScreen.handleSkip` wraps the AsyncStorage call in try/catch so a storage failure (rare on real devices, real on low-storage emulators) doesn't surface as an unhandled promise rejection — the user still exits the onboarding flow.

## Files
- `screens/RecipeCreateScreen.tsx` — import `useAuth`, render `authGate` view with heading + body + Log In / Register pills when `isReady && !isAuthenticated`.
- `screens/StoryCreateScreen.tsx` — same gate (StoryCreate already imported `useAuth` for the recipe picker; just destructured the missing fields).
- `screens/OnboardingScreen.tsx` — `handleSkip` wraps `AsyncStorage.setItem` in try/catch; falls through to `navigation.popToTop()` either way.
- `components/recipe/recipeFormStyles.ts` — shared `authGate` / `authGateHeading` / `authGateBody` styles so both create screens share the look.

## Test
- `npx tsc --noEmit` clean
- `handleSkip` simulated via Node test — even when `AsyncStorage.setItem` throws, `popToTop` still fires (no stuck-on-onboarding scenario).
- Code-path check: both create screens have `if (isReady && !isAuthenticated)` early return; the `isReady` guard prevents the bounce-before-auth-loads pattern that bit StoryEditPage on web (#694).
- Live test on device: signed out, opened both Share tabs → saw the sign-in gates instead of empty forms; tapped Log In / Register → routes correctly; signed back in → forms render normally.

Closes #691