### PR TITLE
fix(mobile): RecipeEdit validation parity with Create + show inline errors (#689)

### DIFF
--- a/app/mobile/src/components/recipe/buildRecipeUpdateFormData.ts
+++ b/app/mobile/src/components/recipe/buildRecipeUpdateFormData.ts
@@ -11,8 +11,13 @@ export function buildRecipePatchJsonBody(input: {
   qaEnabled: boolean;
   rows: AuthoringIngredientRow[];
 }): Record<string, unknown> {
+  // Require an ingredient + a non-empty amount. The unit is *not* required —
+  // backend accepts `null` and we no longer silently drop unit-less rows
+  // (the previous filter did, swallowing valid edits). UI-level validation
+  // in RecipeEditScreen still asks for a unit; this filter only catches
+  // rows that slipped through (e.g. legacy data with a missing unit).
   const validRows = input.rows.filter(
-    (r) => r.ingredient.id != null && r.amount.trim() !== '' && r.unit.id != null,
+    (r) => r.ingredient.id != null && r.amount.trim() !== '',
   );
 
   // Region intentionally omitted from the patch body. The detail API exposes
@@ -28,7 +33,7 @@ export function buildRecipePatchJsonBody(input: {
     ingredients_write: validRows.map((r) => ({
       ingredient: r.ingredient.id,
       amount: r.amount.trim(),
-      unit: r.unit.id,
+      unit: r.unit.id ?? null,
     })),
   };
 }

--- a/app/mobile/src/screens/RecipeEditScreen.tsx
+++ b/app/mobile/src/screens/RecipeEditScreen.tsx
@@ -114,19 +114,45 @@ export default function RecipeEditScreen({ route, navigation }: Props) {
     };
   }, [id, reloadToken, user, applyRecipe, isReady, isAuthenticated]);
 
+  // Mirrors RecipeCreateScreen validation (#689) so edit and create reject
+  // the same invalid payloads. Previously edit was permissive — only checked
+  // title + numeric amount — letting users save recipes without descriptions
+  // or with bare ingredient rows.
   const validation = useMemo(() => {
-    const e: { title?: string; amount?: string } = {};
-    if (!title.trim()) e.title = 'Title is required.';
-    for (const row of rows) {
-      if (row.amount.trim() !== '' && !isPositiveNumberString(row.amount.trim())) {
-        e.amount = 'Amount must be a positive number.';
-        break;
-      }
-    }
-    return e;
-  }, [title, rows]);
+    const next: {
+      title?: string;
+      description?: string;
+      rows?: Record<string, { amount?: string; ingredient?: string; unit?: string }>;
+      rowsTop?: string;
+    } = {};
 
-  const isValid = !validation.title && !validation.amount;
+    if (!title.trim()) next.title = 'Title is required.';
+    if (!description.trim()) next.description = 'Description is required.';
+
+    if (!rows.length) {
+      next.rowsTop = 'Add at least one ingredient.';
+    } else {
+      const rowErrors: NonNullable<typeof next.rows> = {};
+      for (const row of rows) {
+        const re: { amount?: string; ingredient?: string; unit?: string } = {};
+        if (!row.amount.trim()) re.amount = 'Amount is required.';
+        else if (!isPositiveNumberString(row.amount.trim()))
+          re.amount = 'Enter a positive number.';
+        if (!row.ingredient.name.trim()) re.ingredient = 'Choose an ingredient.';
+        if (!row.unit.name.trim()) re.unit = 'Choose a unit.';
+        if (re.amount || re.ingredient || re.unit) rowErrors[row.key] = re;
+      }
+      if (Object.keys(rowErrors).length) next.rows = rowErrors;
+    }
+
+    return next;
+  }, [title, description, rows]);
+
+  const isValid =
+    !validation.title &&
+    !validation.description &&
+    !validation.rowsTop &&
+    (!validation.rows || Object.keys(validation.rows).length === 0);
 
   async function pickVideo() {
     const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
@@ -330,10 +356,14 @@ export default function RecipeEditScreen({ route, navigation }: Props) {
             onChangeText={setDescription}
             placeholder="Description"
             placeholderTextColor="#94a3b8"
-            style={styles.textArea}
+            style={[
+              styles.textArea,
+              attemptedSubmit && !!validation.description && styles.inputError,
+            ]}
             multiline
             accessibilityLabel="Recipe description"
           />
+          {attemptedSubmit ? <InlineFieldError message={validation.description} /> : null}
         </View>
 
         <View style={styles.section}>
@@ -367,10 +397,10 @@ export default function RecipeEditScreen({ route, navigation }: Props) {
           onAddRow={addRow}
           onRemoveRow={removeRow}
           onUpdateRow={updateRow}
-          attemptedSubmit={false}
+          attemptedSubmit={attemptedSubmit}
+          rowsTopError={validation.rowsTop}
+          rowErrors={validation.rows}
         />
-
-        {attemptedSubmit ? <InlineFieldError message={validation.amount} /> : null}
 
         <View style={styles.section}>
           <Text style={styles.sectionTitle}>Thumbnail image (optional)</Text>
@@ -402,7 +432,7 @@ export default function RecipeEditScreen({ route, navigation }: Props) {
           onClearLocal={() => setLocalVideo(null)}
           remoteVideoUrl={remoteVideoUrl}
           requireSelection={false}
-          attemptedSubmit={false}
+          attemptedSubmit={attemptedSubmit}
         />
 
         <Pressable


### PR DESCRIPTION
## Summary
Closes #689. `RecipeEditScreen` was shipping weaker validation than `RecipeCreateScreen`, and two `attemptedSubmit={false}` props were hardcoded — so inline field errors never displayed on edit. Also, the patch-builder silently dropped unit-less ingredient rows.

## Bugs fixed
- **Validation gap**: edit only checked `title` (required) and `amount` (numeric). Create checks: description required, each ingredient row has an amount + ingredient + unit, and at least one row exists. Edit now mirrors all of those rules.
- **`attemptedSubmit={false}` hardcoded**: `<RecipeIngredientRowsSection>` and `<RecipeVideoSection>` were passed the literal `false`, so their inline errors never appeared on edit. Both now receive the live `attemptedSubmit` state.
- **Description input had no inline error block**: added the same `<InlineFieldError message={validation.description} />` pattern Create uses.
- **`buildRecipeUpdateFormData` filtered out unit-less rows**: backend accepts `unit: null`, so the filter was silently dropping otherwise-valid edits. Filter relaxed (still requires `ingredient` + `amount`); builder sends `unit: r.unit.id ?? null`.

## Files
- `screens/RecipeEditScreen.tsx`
- `components/recipe/buildRecipeUpdateFormData.ts`

## Test
- `npx tsc --noEmit` clean
- Validation logic verified via a Node simulation across 6 cases — all good, no description, no rows, row missing unit, negative amount, no title. Each one blocks/passes exactly as expected.
- Backend contract verified end-to-end: `PATCH /api/recipes/1/` with `ingredients_write: [{ingredient:1, amount:'1', unit:null}]` → **200 OK**. Backend accepts null unit; the old client filter was the silent-loss path.
- Live: edited a recipe with the description cleared → inline "Description is required." appears under the textarea (used to silently save). Cleared all ingredient rows → "Add at least one ingredient." top error. Added a row without a unit → "Choose a unit." row error. Filled everything → save works.

Closes #689