### PR TITLE
fix(mobile): split create/edit into JSON + media phases, no orphan/duplicate on partial failure (#687)

### DIFF
--- a/app/mobile/src/screens/RecipeCreateScreen.tsx
+++ b/app/mobile/src/screens/RecipeCreateScreen.tsx
@@ -156,8 +156,9 @@ export default function RecipeCreateScreen({ navigation }: Props) {
     };
 
     void (async () => {
+      // Step 1 — JSON create. Failure means nothing exists, retry is safe.
+      let createdId: number | null = null;
       try {
-        // Same as web: JSON create, then multipart PATCH for video/thumbnail.
         const created = await apiPostJson<{ id: number }>('/api/recipes/', {
           title: title.trim(),
           description: payload.description,
@@ -169,10 +170,22 @@ export default function RecipeCreateScreen({ navigation }: Props) {
             unit: x.unit?.id ?? x.unit,
           })),
         });
-        if (payload.video || payload.image) {
+        createdId = created.id;
+      } catch {
+        showToast('Could not publish recipe. Please try again.', 'error');
+        setSubmitting(false);
+        return;
+      }
+
+      // Step 2 — multipart media upload. A failure here MUST NOT trigger a
+      // retry of step 1 (that creates an orphan + duplicate). We treat it as
+      // a soft failure: the recipe exists, user lands on its detail, and a
+      // toast tells them to re-upload from edit.
+      let mediaFailed = false;
+      if (payload.video || payload.image) {
+        try {
           const fd = new FormData();
           if (payload.video) {
-            // React Native file upload shape (not a web Blob).
             fd.append('video', {
               uri: payload.video.uri,
               name: payload.video.fileName ?? 'recipe-video.mp4',
@@ -186,15 +199,19 @@ export default function RecipeCreateScreen({ navigation }: Props) {
               type: payload.image.mimeType ?? 'image/jpeg',
             } as any);
           }
-          await apiPatchFormData(`/api/recipes/${created.id}/`, fd);
+          await apiPatchFormData(`/api/recipes/${createdId}/`, fd);
+        } catch {
+          mediaFailed = true;
         }
-        showToast('Recipe published!', 'success');
-        navigation.navigate('RecipeDetail', { id: String(created.id) });
-      } catch {
-        showToast('Failed to publish recipe. Please try again.', 'error');
-      } finally {
-        setSubmitting(false);
       }
+
+      if (mediaFailed) {
+        showToast('Recipe published — but media upload failed. Open it to retry from edit.', 'error');
+      } else {
+        showToast('Recipe published!', 'success');
+      }
+      setSubmitting(false);
+      navigation.navigate('RecipeDetail', { id: String(createdId) });
     })();
   }
 

--- a/app/mobile/src/screens/RecipeEditScreen.tsx
+++ b/app/mobile/src/screens/RecipeEditScreen.tsx
@@ -201,9 +201,24 @@ export default function RecipeEditScreen({ route, navigation }: Props) {
     });
 
     void (async () => {
+      // Each PATCH step is independent. We don't roll back a successful step
+      // when a later one fails — that would re-PATCH on retry and clobber
+      // server state needlessly. The user gets a toast that names which
+      // piece didn't save so they know what to fix.
+      let jsonOk = false;
+      let imageFailed = false;
+      let videoFailed = false;
       try {
         await patchRecipeJson(id, jsonBody);
-        if (localImage) {
+        jsonOk = true;
+      } catch {
+        showToast('Could not save recipe changes. Please try again.', 'error');
+        setSubmitting(false);
+        return;
+      }
+
+      if (localImage) {
+        try {
           await updateRecipeById(
             id,
             buildRecipeImageOnlyFormData({
@@ -212,20 +227,38 @@ export default function RecipeEditScreen({ route, navigation }: Props) {
               type: localImage.mimeType,
             }),
           );
+          setLocalImage(null);
+        } catch {
+          imageFailed = true;
         }
-        if (localVideo) {
+      }
+
+      if (localVideo) {
+        try {
           await updateRecipeById(id, buildRecipeVideoOnlyFormData(localVideo));
+          setLocalVideo(null);
+        } catch {
+          videoFailed = true;
         }
+      }
+
+      if (imageFailed && videoFailed) {
+        showToast('Recipe saved — but image and video failed to upload.', 'error');
+      } else if (imageFailed) {
+        showToast('Recipe saved — but image upload failed.', 'error');
+      } else if (videoFailed) {
+        showToast('Recipe saved — but video upload failed.', 'error');
+      } else {
         showToast('Recipe updated!', 'success');
+      }
+
+      if (jsonOk) {
         navTimerRef.current = setTimeout(() => {
           navTimerRef.current = null;
           navigation.navigate('RecipeDetail', { id });
         }, 1500);
-      } catch {
-        showToast('Failed to save changes. Please try again.', 'error');
-      } finally {
-        setSubmitting(false);
       }
+      setSubmitting(false);
     })();
   }
 

--- a/app/mobile/src/screens/StoryCreateScreen.tsx
+++ b/app/mobile/src/screens/StoryCreateScreen.tsx
@@ -72,6 +72,8 @@ export default function StoryCreateScreen({ navigation }: Props) {
 
     setSubmitting(true);
     void (async () => {
+      // Step 1 — JSON create. Failure means nothing exists, retry is safe.
+      let createdId: string | null = null;
       try {
         const created = await apiPostJson<{ id: string }>('/api/stories/', {
           title: title.trim(),
@@ -81,19 +83,34 @@ export default function StoryCreateScreen({ navigation }: Props) {
           linked_recipe_id: linkedRecipe ? Number(linkedRecipe.id) : null,
           region: regionId,
         });
-        if (imageUri) {
-          await updateStoryImageById(String(created.id), { uri: imageUri });
-        }
-        showToast('Story published!', 'success');
-        navigation.navigate('StoryDetail', { id: created.id });
+        createdId = String(created.id);
       } catch (e) {
         showToast(
-          e instanceof Error ? e.message : 'Failed to publish story. Please try again.',
+          e instanceof Error ? e.message : 'Could not publish story. Please try again.',
           'error',
         );
-      } finally {
         setSubmitting(false);
+        return;
       }
+
+      // Step 2 — image upload. Soft failure: story exists, navigate to it,
+      // user can re-upload the image from edit if it fails.
+      let imageFailed = false;
+      if (imageUri) {
+        try {
+          await updateStoryImageById(createdId, { uri: imageUri });
+        } catch {
+          imageFailed = true;
+        }
+      }
+
+      if (imageFailed) {
+        showToast('Story published — but image upload failed. Open it to retry from edit.', 'error');
+      } else {
+        showToast('Story published!', 'success');
+      }
+      setSubmitting(false);
+      navigation.navigate('StoryDetail', { id: createdId });
     })();
   }
 


### PR DESCRIPTION
## Summary
Closes #687. Recipe and Story create flows are two-step: (1) JSON POST creates the record, (2) optional multipart PATCH uploads media. If step 2 failed, the previous code showed a generic "Failed to publish" toast even though the record already existed on the backend — users naturally retried, fired another POST, and ended up with a duplicate + an orphan record. RecipeEdit had the analogue across three PATCHes (JSON + image + video).

## Fix
Each step is now its own `try`, and a failed later step does **not** retry or roll back a successful earlier step.

### RecipeCreate / StoryCreate
- Step 1 fails → toast says "Could not publish", screen stays on the form (no orphan, retry-safe).
- Step 1 succeeds → `createdId` is captured.
- Step 2 (media) fails → soft fail: toast says "published — but media upload failed. Open it to retry from edit."
- **Always navigate to the detail screen after step 1 succeeds.** The user lands on the new record; the only way to "retry" is from the edit screen, so duplicate POST is impossible.

### RecipeEdit
- JSON PATCH fail → "Could not save", stay on form, no further attempts.
- JSON PATCH succeeds → image and video PATCHes attempted independently.
- Successful media PATCHes clear `localImage` / `localVideo` so a retry doesn't re-upload them.
- Toast names which piece didn't save: "image upload failed" / "video upload failed" / "image and video failed".
- Navigate to detail after the JSON succeeds, regardless of media outcome.

## Files
- `screens/RecipeCreateScreen.tsx`
- `screens/StoryCreateScreen.tsx`
- `screens/RecipeEditScreen.tsx`

## Test
- `npx tsc --noEmit` clean
- Logic simulated in Node across 4 cases (happy with media, happy no media, POST fails, POST ok / media fails) — toasts and navigation behave exactly as expected.
- Backend contract verified end-to-end: `POST /api/recipes/` returns 201 with id; subsequent bad multipart `PATCH /api/recipes/<id>/` returns 400; **the recipe persists** (`GET .../` 200). Confirms the orphan scenario was real and the fix's "always navigate after step 1" approach correctly takes the user to the existing record instead of leaving them to spawn a duplicate.

## Mobile parity
Web #703 covers the analogue partial-failure on `RecipeCreatePage`; same pattern applies there.

Closes #687