### PR TITLE
feat(frontend): milestone 8 web — heritage, journey, did-you-know, calendar

### DIFF
--- a/app/frontend/src/App.js
+++ b/app/frontend/src/App.js
@@ -23,6 +23,9 @@ import MapPage from './pages/MapPage';
 import ExplorePage from './pages/ExplorePage';
 import EventDetailPage from './pages/EventDetailPage';
 import ModerationPage from './pages/ModerationPage';
+import HeritagePage from './pages/HeritagePage';
+import HeritageMapPage from './pages/HeritageMapPage';
+import CalendarPage from './pages/CalendarPage';
 import NotFoundPage from './pages/NotFoundPage';
 
 const IMAGES = [
@@ -120,6 +123,9 @@ export default function App() {
             element={<ProtectedRoute><ModerationPage /></ProtectedRoute>}
           />
 
+          <Route path="/heritage/:id" element={<HeritagePage />} />
+          <Route path="/heritage/:id/map" element={<HeritageMapPage />} />
+          <Route path="/calendar" element={<CalendarPage />} />
           <Route path="*" element={<NotFoundPage />} />
         </Routes>
       </div>

--- a/app/frontend/src/__tests__/CalendarPage.test.jsx
+++ b/app/frontend/src/__tests__/CalendarPage.test.jsx
@@ -1,0 +1,88 @@
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import CalendarPage from '../pages/CalendarPage';
+import * as culturalEventService from '../services/culturalEventService';
+import * as searchService from '../services/searchService';
+
+jest.mock('../services/culturalEventService');
+jest.mock('../services/searchService');
+
+const EVENTS_ALL_YEAR = [
+  {
+    id: 1, name: 'Nevruz', date_rule: 'fixed:03-21',
+    region: { id: 1, name: 'Anatolia' }, description: 'Spring equinox.',
+    recipes: [{ id: 10, title: 'Sumalak' }],
+  },
+  {
+    id: 2, name: 'Iftar', date_rule: 'lunar:ramadan',
+    region: { id: 1, name: 'Anatolia' }, description: 'Ramadan break-fast.',
+    recipes: [],
+  },
+  {
+    id: 3, name: 'Dia de los Muertos', date_rule: 'fixed:11-02',
+    region: null, description: 'Day of the dead.',
+    recipes: [{ id: 20, title: 'Pan de Muerto' }],
+  },
+];
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <CalendarPage />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  searchService.fetchRegions.mockResolvedValue([{ id: 1, name: 'Anatolia' }]);
+  culturalEventService.fetchCulturalEvents.mockResolvedValue(EVENTS_ALL_YEAR);
+});
+
+describe('CalendarPage', () => {
+  it('renders all 12 month panels', async () => {
+    const { container } = renderPage();
+    expect(await screen.findByRole('heading', { name: /cultural food calendar/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'January' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'December' })).toBeInTheDocument();
+    expect(container.querySelectorAll('[data-testid^="calendar-month-"]').length).toBe(12);
+  });
+
+  it('places fixed events under the correct month and lunar events under a dedicated panel', async () => {
+    renderPage();
+    const march = await screen.findByTestId('calendar-month-3');
+    expect(within(march).getByText('Nevruz')).toBeInTheDocument();
+    const lunar = screen.getByTestId('calendar-lunar');
+    expect(within(lunar).getByText('Iftar')).toBeInTheDocument();
+    const november = screen.getByTestId('calendar-month-11');
+    expect(within(november).getByText('Dia de los Muertos')).toBeInTheDocument();
+  });
+
+  it('filters events when the month filter is changed', async () => {
+    renderPage();
+    await screen.findByText('Nevruz');
+    await userEvent.selectOptions(screen.getByLabelText(/month/i), '03');
+    await waitFor(() => {
+      expect(culturalEventService.fetchCulturalEvents).toHaveBeenLastCalledWith({ month: '03', region: '' });
+    });
+  });
+
+  it('filters events when the region filter is changed', async () => {
+    renderPage();
+    await screen.findByText('Nevruz');
+    await userEvent.selectOptions(screen.getByLabelText(/region/i), '1');
+    await waitFor(() => {
+      expect(culturalEventService.fetchCulturalEvents).toHaveBeenLastCalledWith({ month: '', region: '1' });
+    });
+  });
+
+  it('reveals an event detail panel with linked recipes when an event card is clicked', async () => {
+    renderPage();
+    const card = await screen.findByRole('button', { name: /open nevruz details/i });
+    await userEvent.click(card);
+    const panel = await screen.findByTestId('event-detail');
+    expect(within(panel).getByRole('heading', { name: /nevruz/i })).toBeInTheDocument();
+    expect(within(panel).getByRole('link', { name: /sumalak/i })).toHaveAttribute('href', '/recipes/10');
+  });
+});

--- a/app/frontend/src/__tests__/CulturalFactCard.test.jsx
+++ b/app/frontend/src/__tests__/CulturalFactCard.test.jsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import CulturalFactCard from '../components/CulturalFactCard';
+
+const FULL = {
+  id: 1,
+  text: 'Dolma comes from the Turkish verb doldurmak.',
+  source_url: 'https://example.com/dolma',
+  heritage_group: { id: 1, name: 'Sarma / Dolma' },
+  region: { id: 2, name: 'Anatolia' },
+};
+
+describe('CulturalFactCard', () => {
+  it('renders the fact text and the bulb header', () => {
+    render(<CulturalFactCard fact={FULL} />);
+    expect(screen.getByText(/did you know/i)).toBeInTheDocument();
+    expect(screen.getByText(/dolma comes from the turkish verb/i)).toBeInTheDocument();
+  });
+
+  it('renders a source link with the source URL', () => {
+    render(<CulturalFactCard fact={FULL} />);
+    const link = screen.getByRole('link', { name: /source/i });
+    expect(link).toHaveAttribute('href', 'https://example.com/dolma');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', expect.stringContaining('noopener'));
+  });
+
+  it('omits the source link when source_url is empty', () => {
+    render(<CulturalFactCard fact={{ ...FULL, source_url: '' }} />);
+    expect(screen.queryByRole('link', { name: /source/i })).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when fact is falsy', () => {
+    const { container } = render(<CulturalFactCard fact={null} />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/app/frontend/src/__tests__/HeritageBadge.test.jsx
+++ b/app/frontend/src/__tests__/HeritageBadge.test.jsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import HeritageBadge from '../components/HeritageBadge';
+
+function renderBadge(group) {
+  return render(
+    <MemoryRouter>
+      <HeritageBadge group={group} />
+    </MemoryRouter>,
+  );
+}
+
+describe('HeritageBadge', () => {
+  it('renders nothing when group is null', () => {
+    const { container } = renderBadge(null);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing when group is undefined', () => {
+    const { container } = renderBadge(undefined);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the heritage name with the building icon', () => {
+    renderBadge({ id: 1, name: 'Sarma / Dolma' });
+    expect(screen.getByText(/Sarma \/ Dolma/)).toBeInTheDocument();
+    expect(screen.getByText(/🏛/)).toBeInTheDocument();
+  });
+
+  it('links to /heritage/:id', () => {
+    renderBadge({ id: 7, name: 'Köfte' });
+    const link = screen.getByRole('link', { name: /heritage: köfte/i });
+    expect(link).toHaveAttribute('href', '/heritage/7');
+  });
+});

--- a/app/frontend/src/__tests__/HeritageJourneySection.test.jsx
+++ b/app/frontend/src/__tests__/HeritageJourneySection.test.jsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react';
+import HeritageJourneySection from '../components/HeritageJourneySection';
+
+const STEPS = [
+  { id: 1, order: 1, location: 'Central Asia', story: 'Nomadic Turkic ground meat.', era: 'Pre-Ottoman' },
+  { id: 2, order: 2, location: 'Anatolia', story: 'Dozens of variations.', era: '' },
+  { id: 3, order: 3, location: 'Sweden', story: 'Brought back as köttbullar.', era: '1700s' },
+];
+
+describe('HeritageJourneySection', () => {
+  it('renders nothing when steps is empty', () => {
+    const { container } = render(<HeritageJourneySection steps={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing when steps is undefined', () => {
+    const { container } = render(<HeritageJourneySection />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders one card per step with location, story, era', () => {
+    render(<HeritageJourneySection steps={STEPS} />);
+    expect(screen.getByRole('heading', { name: /journey/i })).toBeInTheDocument();
+    expect(screen.getByText('Central Asia')).toBeInTheDocument();
+    expect(screen.getByText('Anatolia')).toBeInTheDocument();
+    expect(screen.getByText('Sweden')).toBeInTheDocument();
+    expect(screen.getByText(/nomadic turkic/i)).toBeInTheDocument();
+    expect(screen.getByText('Pre-Ottoman')).toBeInTheDocument();
+    expect(screen.getByText('1700s')).toBeInTheDocument();
+  });
+
+  it('sorts steps by order ascending regardless of input order', () => {
+    const shuffled = [STEPS[2], STEPS[0], STEPS[1]];
+    render(<HeritageJourneySection steps={shuffled} />);
+    const locations = screen.getAllByTestId('journey-step-location').map((n) => n.textContent);
+    expect(locations).toEqual(['Central Asia', 'Anatolia', 'Sweden']);
+  });
+
+  it('does not render an era badge when era is empty', () => {
+    render(<HeritageJourneySection steps={[STEPS[1]]} />);
+    expect(screen.queryByTestId('journey-step-era')).not.toBeInTheDocument();
+  });
+});

--- a/app/frontend/src/__tests__/HeritageMapPage.test.jsx
+++ b/app/frontend/src/__tests__/HeritageMapPage.test.jsx
@@ -1,0 +1,101 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import HeritageMapPage from '../pages/HeritageMapPage';
+import * as heritageService from '../services/heritageService';
+
+jest.mock('../services/heritageService');
+
+jest.mock('react-leaflet', () => ({
+  MapContainer: ({ children, center }) => (
+    <div data-testid="map-container" data-center={JSON.stringify(center)}>{children}</div>
+  ),
+  TileLayer: () => null,
+  CircleMarker: ({ children, center, eventHandlers }) => (
+    <div
+      data-testid="circle-marker"
+      data-center={JSON.stringify(center)}
+      onClick={eventHandlers?.click}
+    >{children}</div>
+  ),
+  Marker: ({ children, position, eventHandlers }) => (
+    <div
+      data-testid="center-marker"
+      data-center={JSON.stringify(position)}
+      onClick={eventHandlers?.click}
+    >{children}</div>
+  ),
+  Polyline: ({ positions }) => (
+    <div data-testid="polyline" data-positions={JSON.stringify(positions)} />
+  ),
+  Tooltip: ({ children }) => <span>{children}</span>,
+}));
+
+const GROUP = {
+  id: 1,
+  name: 'Sarma / Dolma',
+  description: '',
+  members: [
+    { content_type: 'recipe', id: 11, title: 'Black Sea Sarma', author: 'zeynep', region: 'Black Sea', latitude: 41.0, longitude: 39.7 },
+    { content_type: 'story',  id: 22, title: 'Wedding sarma',    author: 'fatma',  region: 'Konya',     latitude: 37.9, longitude: 32.5 },
+    { content_type: 'recipe', id: 33, title: 'Located somewhere', author: 'x',     region: 'Unknown',   latitude: null, longitude: null },
+  ],
+  journey_steps: [],
+};
+
+function renderPage(id = 1) {
+  return render(
+    <MemoryRouter initialEntries={[`/heritage/${id}/map`]}>
+      <Routes>
+        <Route path="/heritage/:id/map" element={<HeritageMapPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  heritageService.fetchHeritageGroup.mockResolvedValue(GROUP);
+});
+
+describe('HeritageMapPage', () => {
+  it('renders one circle marker per locatable member (unlocatable members are skipped)', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getAllByTestId('circle-marker')).toHaveLength(2));
+  });
+
+  it('centres the map on the midpoint of locatable members', async () => {
+    renderPage();
+    await screen.findByTestId('map-container');
+    const center = JSON.parse(screen.getByTestId('map-container').getAttribute('data-center'));
+    expect(center[0]).toBeCloseTo((41.0 + 37.9) / 2, 3);
+    expect(center[1]).toBeCloseTo((39.7 + 32.5) / 2, 3);
+  });
+
+  it('renders a polyline from the midpoint to each locatable member', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getAllByTestId('polyline')).toHaveLength(2));
+  });
+
+  it('renders a central building marker at the midpoint', async () => {
+    renderPage();
+    await screen.findByTestId('center-marker');
+    const center = JSON.parse(screen.getByTestId('center-marker').getAttribute('data-center'));
+    expect(center[0]).toBeCloseTo((41.0 + 37.9) / 2, 3);
+  });
+
+  it('links "Back to Heritage Page" to /heritage/:id', async () => {
+    renderPage(1);
+    const link = await screen.findByRole('link', { name: /back to heritage page/i });
+    expect(link).toHaveAttribute('href', '/heritage/1');
+  });
+
+  it('shows an empty-state message when no members have coordinates', async () => {
+    heritageService.fetchHeritageGroup.mockResolvedValue({
+      ...GROUP,
+      members: GROUP.members.map((m) => ({ ...m, latitude: null, longitude: null })),
+    });
+    renderPage();
+    expect(await screen.findByText(/no locations to plot/i)).toBeInTheDocument();
+    expect(screen.queryByTestId('circle-marker')).not.toBeInTheDocument();
+  });
+});

--- a/app/frontend/src/__tests__/HeritagePage.test.jsx
+++ b/app/frontend/src/__tests__/HeritagePage.test.jsx
@@ -1,0 +1,83 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import HeritagePage from '../pages/HeritagePage';
+import * as heritageService from '../services/heritageService';
+import * as culturalFactService from '../services/culturalFactService';
+
+jest.mock('../services/heritageService');
+jest.mock('../services/culturalFactService');
+
+const GROUP = {
+  id: 1,
+  name: 'Sarma / Dolma',
+  description: 'A shared tradition.',
+  members: [
+    { content_type: 'recipe', id: 11, title: 'Black Sea Sarma', author: 'zeynep', region: 'Black Sea', latitude: 41.0, longitude: 39.7 },
+    { content_type: 'story',  id: 22, title: 'Wedding sarma',    author: 'fatma',  region: 'Konya',     latitude: 37.9, longitude: 32.5 },
+  ],
+  journey_steps: [
+    { id: 1, order: 1, location: 'Central Asia', story: 'Origins.', era: 'Pre-Ottoman' },
+  ],
+};
+
+function renderPage(id = 1) {
+  return render(
+    <MemoryRouter initialEntries={[`/heritage/${id}`]}>
+      <Routes>
+        <Route path="/heritage/:id" element={<HeritagePage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  heritageService.fetchHeritageGroup.mockResolvedValue(GROUP);
+  culturalFactService.fetchCulturalFacts.mockResolvedValue([]);
+});
+
+describe('HeritagePage', () => {
+  it('shows loading state then renders the heritage name and description', async () => {
+    renderPage();
+    expect(screen.getByText(/loading/i)).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: /sarma \/ dolma/i })).toBeInTheDocument();
+    expect(screen.getByText('A shared tradition.')).toBeInTheDocument();
+  });
+
+  it('renders a "Show Heritage Map" link to /heritage/:id/map', async () => {
+    renderPage(1);
+    const link = await screen.findByRole('link', { name: /show heritage map/i });
+    expect(link).toHaveAttribute('href', '/heritage/1/map');
+  });
+
+  it('renders one card per member with title, author, region and link', async () => {
+    renderPage();
+    expect(await screen.findByText('Black Sea Sarma')).toBeInTheDocument();
+    expect(screen.getByText('Wedding sarma')).toBeInTheDocument();
+    expect(screen.getByText('@zeynep')).toBeInTheDocument();
+    expect(screen.getByText('@fatma')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /black sea sarma/i })).toHaveAttribute('href', '/recipes/11');
+    expect(screen.getByRole('link', { name: /wedding sarma/i })).toHaveAttribute('href', '/stories/22');
+  });
+
+  it('renders the journey section when the group has steps', async () => {
+    renderPage();
+    expect(await screen.findByText('Central Asia')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /journey/i })).toBeInTheDocument();
+  });
+
+  it('renders cultural facts when present', async () => {
+    culturalFactService.fetchCulturalFacts.mockResolvedValue([
+      { id: 1, text: 'Dolma standardized in Ottoman cuisine.', source_url: '', heritage_group: { id: 1, name: 'Sarma / Dolma' }, region: null },
+    ]);
+    renderPage();
+    expect(await screen.findByText(/dolma standardized/i)).toBeInTheDocument();
+    expect(culturalFactService.fetchCulturalFacts).toHaveBeenCalledWith({ heritageGroup: '1' });
+  });
+
+  it('shows an error message when fetch fails', async () => {
+    heritageService.fetchHeritageGroup.mockRejectedValue(new Error('boom'));
+    renderPage();
+    expect(await screen.findByText(/could not load heritage group/i)).toBeInTheDocument();
+  });
+});

--- a/app/frontend/src/__tests__/HomePage.test.jsx
+++ b/app/frontend/src/__tests__/HomePage.test.jsx
@@ -4,9 +4,11 @@ import { AuthContext } from '../context/AuthContext';
 import HomePage from '../pages/HomePage';
 import * as searchService from '../services/searchService';
 import * as culturalContentService from '../services/culturalContentService';
+import * as culturalFactService from '../services/culturalFactService';
 
 jest.mock('../services/searchService');
 jest.mock('../services/culturalContentService');
+jest.mock('../services/culturalFactService');
 const mockNavigate = jest.fn();
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
@@ -22,6 +24,10 @@ beforeEach(() => {
   culturalContentService.fetchDailyCulturalContent.mockResolvedValue([
     { id: 10, title: 'Cultural Card', body: 'Body', tags: ['Aegean'] },
   ]);
+  culturalFactService.fetchRandomCulturalFact.mockResolvedValue({
+    id: 99, text: 'Köfte traveled to Sweden.', source_url: '',
+    heritage_group: null, region: null,
+  });
 });
 
 function renderPage(user = null) {
@@ -91,5 +97,20 @@ describe('HomePage', () => {
     renderPage({ id: 1, username: 'u1', cultural_interests: ['Aegean'], regional_ties: [], religious_preferences: [], event_interests: [] });
     expect(await screen.findByRole('heading', { name: /for you: cultural highlights/i })).toBeInTheDocument();
     expect(screen.getByText('Cultural Card')).toBeInTheDocument();
+  });
+});
+
+describe('HomePage random cultural fact', () => {
+  it('renders the random cultural fact when one is returned', async () => {
+    renderPage();
+    expect(await screen.findByText(/köfte traveled to sweden/i)).toBeInTheDocument();
+  });
+
+  it('renders nothing when fetchRandomCulturalFact resolves null', async () => {
+    culturalFactService.fetchRandomCulturalFact.mockResolvedValueOnce(null);
+    renderPage();
+    // Wait for the page baseline to settle — region chips finish loading.
+    await screen.findByRole('button', { name: 'Aegean' });
+    expect(screen.queryByText(/köfte traveled to sweden/i)).not.toBeInTheDocument();
   });
 });

--- a/app/frontend/src/__tests__/Navbar.test.jsx
+++ b/app/frontend/src/__tests__/Navbar.test.jsx
@@ -75,4 +75,10 @@ describe('Navbar', () => {
     const link = screen.getByRole('link', { name: /^profile$/i });
     expect(link).toHaveAttribute('href', '/profile');
   });
+
+  it('renders a Calendar link to /calendar', () => {
+    renderNavbar();
+    const link = screen.getByRole('link', { name: /calendar/i });
+    expect(link).toHaveAttribute('href', '/calendar');
+  });
 });

--- a/app/frontend/src/__tests__/RandomCulturalFact.test.jsx
+++ b/app/frontend/src/__tests__/RandomCulturalFact.test.jsx
@@ -1,0 +1,31 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import RandomCulturalFact from '../components/RandomCulturalFact';
+import * as culturalFactService from '../services/culturalFactService';
+
+jest.mock('../services/culturalFactService');
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('RandomCulturalFact', () => {
+  it('renders the fact text when the service returns a fact', async () => {
+    culturalFactService.fetchRandomCulturalFact.mockResolvedValue({
+      id: 1, text: 'Tarhana is fermented.', source_url: '', heritage_group: null, region: null,
+    });
+    render(<RandomCulturalFact />);
+    expect(await screen.findByText(/tarhana is fermented/i)).toBeInTheDocument();
+  });
+
+  it('renders nothing when the service returns null (no facts)', async () => {
+    culturalFactService.fetchRandomCulturalFact.mockResolvedValue(null);
+    const { container } = render(<RandomCulturalFact />);
+    await waitFor(() => expect(culturalFactService.fetchRandomCulturalFact).toHaveBeenCalled());
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing when the service throws', async () => {
+    culturalFactService.fetchRandomCulturalFact.mockRejectedValue(new Error('boom'));
+    const { container } = render(<RandomCulturalFact />);
+    await waitFor(() => expect(culturalFactService.fetchRandomCulturalFact).toHaveBeenCalled());
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/app/frontend/src/__tests__/RecipeDetailPage.test.jsx
+++ b/app/frontend/src/__tests__/RecipeDetailPage.test.jsx
@@ -293,3 +293,26 @@ describe('RecipeDetailPage', () => {
     });
   });
 });
+
+// — Heritage badge (#500) —
+describe('RecipeDetailPage heritage badge', () => {
+  it('renders the heritage badge when recipe.heritage_group is present', async () => {
+    recipeService.fetchRecipe.mockResolvedValueOnce({
+      ...mockRecipe,
+      heritage_group: { id: 1, name: 'Sarma' },
+    });
+    renderPage();
+    const link = await screen.findByRole('link', { name: /heritage: sarma/i });
+    expect(link).toHaveAttribute('href', '/heritage/1');
+  });
+
+  it('renders no heritage badge when recipe.heritage_group is null', async () => {
+    recipeService.fetchRecipe.mockResolvedValueOnce({
+      ...mockRecipe,
+      heritage_group: null,
+    });
+    renderPage();
+    await screen.findByText('Baklava');
+    expect(screen.queryByText(/heritage:/i)).not.toBeInTheDocument();
+  });
+});

--- a/app/frontend/src/__tests__/RecipeDetailPage.test.jsx
+++ b/app/frontend/src/__tests__/RecipeDetailPage.test.jsx
@@ -8,12 +8,14 @@ import * as searchService from '../services/searchService';
 import * as commentService from '../services/commentService';
 import * as checkOffService from '../services/checkOffService';
 import * as ingredientService from '../services/ingredientService';
+import * as culturalFactService from '../services/culturalFactService';
 
 jest.mock('../services/recipeService');
 jest.mock('../services/searchService');
 jest.mock('../services/commentService');
 jest.mock('../services/checkOffService');
 jest.mock('../services/ingredientService');
+jest.mock('../services/culturalFactService');
 
 const mockRecipe = {
   id: 1,
@@ -53,6 +55,7 @@ beforeEach(() => {
   checkOffService.fetchCheckedIngredients.mockResolvedValue([]);
   checkOffService.toggleCheckedIngredient.mockResolvedValue([]);
   ingredientService.fetchSubstitutes.mockResolvedValue([]);
+  culturalFactService.fetchCulturalFacts.mockResolvedValue([]);
 });
 
 describe('RecipeDetailPage', () => {
@@ -314,5 +317,31 @@ describe('RecipeDetailPage heritage badge', () => {
     renderPage();
     await screen.findByText('Baklava');
     expect(screen.queryByText(/heritage:/i)).not.toBeInTheDocument();
+  });
+});
+
+describe('RecipeDetailPage cultural facts', () => {
+  it('fetches and renders facts when recipe has a heritage_group', async () => {
+    recipeService.fetchRecipe.mockResolvedValueOnce({
+      ...mockRecipe,
+      heritage_group: { id: 5, name: 'Köfte' },
+    });
+    culturalFactService.fetchCulturalFacts.mockResolvedValueOnce([
+      { id: 1, text: 'Köfte spread to Sweden as köttbullar.', source_url: '',
+        heritage_group: { id: 5, name: 'Köfte' }, region: null },
+    ]);
+    renderPage();
+    expect(await screen.findByText(/köfte spread to sweden/i)).toBeInTheDocument();
+    expect(culturalFactService.fetchCulturalFacts).toHaveBeenCalledWith({ heritageGroup: 5 });
+  });
+
+  it('does not call the facts service when recipe has no heritage_group', async () => {
+    recipeService.fetchRecipe.mockResolvedValueOnce({
+      ...mockRecipe,
+      heritage_group: null,
+    });
+    renderPage();
+    await screen.findByText('Baklava');
+    expect(culturalFactService.fetchCulturalFacts).not.toHaveBeenCalled();
   });
 });

--- a/app/frontend/src/__tests__/Routing.test.jsx
+++ b/app/frontend/src/__tests__/Routing.test.jsx
@@ -43,6 +43,21 @@ describe('Public routes (unauthenticated)', () => {
     renderApp('/stories/1');
     expect(screen.getByText(/loading/i)).toBeInTheDocument();
   });
+
+  test('/heritage/1 renders HeritagePage (loading first)', () => {
+    renderApp('/heritage/1');
+    expect(screen.getByText(/loading/i)).toBeInTheDocument();
+  });
+
+  test('/heritage/1/map renders HeritageMapPage (loading first)', () => {
+    renderApp('/heritage/1/map');
+    expect(screen.getByText(/loading/i)).toBeInTheDocument();
+  });
+
+  test('/calendar renders CalendarPage', () => {
+    renderApp('/calendar');
+    expect(screen.getByRole('heading', { name: /cultural food calendar/i })).toBeInTheDocument();
+  });
 });
 
 describe('Protected routes (unauthenticated)', () => {

--- a/app/frontend/src/__tests__/StoryDetailPage.test.jsx
+++ b/app/frontend/src/__tests__/StoryDetailPage.test.jsx
@@ -263,3 +263,26 @@ describe('StoryDetailPage', () => {
     });
   });
 });
+
+// — Heritage badge (#500) —
+describe('StoryDetailPage heritage badge', () => {
+  it('renders the heritage badge when story.heritage_group is present', async () => {
+    storyService.fetchStory.mockResolvedValueOnce({
+      ...mockStory,
+      heritage_group: { id: 4, name: 'Dolmadakia' },
+    });
+    renderPage();
+    const link = await screen.findByRole('link', { name: /heritage: dolmadakia/i });
+    expect(link).toHaveAttribute('href', '/heritage/4');
+  });
+
+  it('renders no heritage badge when story.heritage_group is null', async () => {
+    storyService.fetchStory.mockResolvedValueOnce({
+      ...mockStory,
+      heritage_group: null,
+    });
+    renderPage();
+    await screen.findByText("Grandma's Sunday Kitchen");
+    expect(screen.queryByText(/heritage:/i)).not.toBeInTheDocument();
+  });
+});

--- a/app/frontend/src/__tests__/culturalEventService.test.js
+++ b/app/frontend/src/__tests__/culturalEventService.test.js
@@ -1,0 +1,47 @@
+import { apiClient } from '../services/api';
+import { fetchCulturalEvents } from '../services/culturalEventService';
+
+jest.mock('../services/api', () => ({
+  apiClient: { get: jest.fn() },
+}));
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('fetchCulturalEvents', () => {
+  it('calls GET /api/cultural-events/ with no params when none given', async () => {
+    apiClient.get.mockResolvedValue({ data: [] });
+    await fetchCulturalEvents();
+    expect(apiClient.get).toHaveBeenCalledWith('/api/cultural-events/', { params: {} });
+  });
+
+  it('formats numeric month as a zero-padded two-digit string', async () => {
+    apiClient.get.mockResolvedValue({ data: [] });
+    await fetchCulturalEvents({ month: 3 });
+    expect(apiClient.get).toHaveBeenCalledWith('/api/cultural-events/', { params: { month: '03' } });
+  });
+
+  it('passes month and region together', async () => {
+    apiClient.get.mockResolvedValue({ data: [] });
+    await fetchCulturalEvents({ month: 11, region: 4 });
+    expect(apiClient.get).toHaveBeenCalledWith('/api/cultural-events/', {
+      params: { month: '11', region: 4 },
+    });
+  });
+
+  it('omits undefined month and region', async () => {
+    apiClient.get.mockResolvedValue({ data: [] });
+    await fetchCulturalEvents({ month: undefined, region: undefined });
+    expect(apiClient.get).toHaveBeenCalledWith('/api/cultural-events/', { params: {} });
+  });
+
+  it('unwraps paginated DRF response', async () => {
+    apiClient.get.mockResolvedValue({ data: { results: [{ id: 1 }] } });
+    const result = await fetchCulturalEvents();
+    expect(result).toEqual([{ id: 1 }]);
+  });
+
+  it('propagates errors', async () => {
+    apiClient.get.mockRejectedValue(new Error('fail'));
+    await expect(fetchCulturalEvents()).rejects.toThrow('fail');
+  });
+});

--- a/app/frontend/src/__tests__/culturalFactService.test.js
+++ b/app/frontend/src/__tests__/culturalFactService.test.js
@@ -1,0 +1,61 @@
+import { apiClient } from '../services/api';
+import {
+  fetchCulturalFacts,
+  fetchRandomCulturalFact,
+} from '../services/culturalFactService';
+
+jest.mock('../services/api', () => ({
+  apiClient: { get: jest.fn() },
+}));
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('fetchCulturalFacts', () => {
+  it('calls GET /api/cultural-facts/ with no params when none given', async () => {
+    apiClient.get.mockResolvedValue({ data: [] });
+    await fetchCulturalFacts();
+    expect(apiClient.get).toHaveBeenCalledWith('/api/cultural-facts/', { params: {} });
+  });
+
+  it('passes heritage_group and region filters as params', async () => {
+    apiClient.get.mockResolvedValue({ data: [] });
+    await fetchCulturalFacts({ heritageGroup: 5, region: 2 });
+    expect(apiClient.get).toHaveBeenCalledWith('/api/cultural-facts/', {
+      params: { heritage_group: 5, region: 2 },
+    });
+  });
+
+  it('omits undefined / null filter values', async () => {
+    apiClient.get.mockResolvedValue({ data: [] });
+    await fetchCulturalFacts({ heritageGroup: 5, region: null });
+    expect(apiClient.get).toHaveBeenCalledWith('/api/cultural-facts/', {
+      params: { heritage_group: 5 },
+    });
+  });
+
+  it('unwraps paginated DRF response', async () => {
+    apiClient.get.mockResolvedValue({ data: { results: [{ id: 1 }] } });
+    const result = await fetchCulturalFacts();
+    expect(result).toEqual([{ id: 1 }]);
+  });
+});
+
+describe('fetchRandomCulturalFact', () => {
+  it('calls GET /api/cultural-facts/random/', async () => {
+    apiClient.get.mockResolvedValue({ data: { id: 1, text: 'Hi' } });
+    const result = await fetchRandomCulturalFact();
+    expect(apiClient.get).toHaveBeenCalledWith('/api/cultural-facts/random/');
+    expect(result.text).toBe('Hi');
+  });
+
+  it('returns null on 404 instead of throwing', async () => {
+    apiClient.get.mockRejectedValue({ response: { status: 404 } });
+    const result = await fetchRandomCulturalFact();
+    expect(result).toBeNull();
+  });
+
+  it('propagates non-404 errors', async () => {
+    apiClient.get.mockRejectedValue({ response: { status: 500 } });
+    await expect(fetchRandomCulturalFact()).rejects.toEqual({ response: { status: 500 } });
+  });
+});

--- a/app/frontend/src/__tests__/heritageMidpoint.test.js
+++ b/app/frontend/src/__tests__/heritageMidpoint.test.js
@@ -1,0 +1,52 @@
+import { computeHeritageMidpoint, locatableMembers } from '../utils/heritageMidpoint';
+
+describe('locatableMembers', () => {
+  it('keeps members with numeric lat/lng', () => {
+    const members = [
+      { id: 1, latitude: 41, longitude: 29 },
+      { id: 2, latitude: 38.5, longitude: 27 },
+    ];
+    expect(locatableMembers(members)).toEqual(members);
+  });
+
+  it('drops members with null lat or lng', () => {
+    const members = [
+      { id: 1, latitude: 41, longitude: 29 },
+      { id: 2, latitude: null, longitude: 27 },
+      { id: 3, latitude: 38, longitude: null },
+    ];
+    expect(locatableMembers(members)).toEqual([{ id: 1, latitude: 41, longitude: 29 }]);
+  });
+
+  it('returns an empty array when given no members', () => {
+    expect(locatableMembers([])).toEqual([]);
+  });
+});
+
+describe('computeHeritageMidpoint', () => {
+  it('returns null when there are no locatable members', () => {
+    expect(computeHeritageMidpoint([])).toBeNull();
+    expect(computeHeritageMidpoint([{ latitude: null, longitude: null }])).toBeNull();
+  });
+
+  it('returns the only member when one is locatable', () => {
+    expect(computeHeritageMidpoint([{ latitude: 41, longitude: 29 }])).toEqual([41, 29]);
+  });
+
+  it('averages latitude and longitude across locatable members', () => {
+    const members = [
+      { latitude: 40, longitude: 30 },
+      { latitude: 42, longitude: 28 },
+    ];
+    expect(computeHeritageMidpoint(members)).toEqual([41, 29]);
+  });
+
+  it('ignores members with missing coordinates when averaging', () => {
+    const members = [
+      { latitude: 40, longitude: 30 },
+      { latitude: null, longitude: 0 },
+      { latitude: 42, longitude: 28 },
+    ];
+    expect(computeHeritageMidpoint(members)).toEqual([41, 29]);
+  });
+});

--- a/app/frontend/src/__tests__/heritageService.test.js
+++ b/app/frontend/src/__tests__/heritageService.test.js
@@ -1,0 +1,44 @@
+import { apiClient } from '../services/api';
+import { fetchHeritageGroups, fetchHeritageGroup } from '../services/heritageService';
+
+jest.mock('../services/api', () => ({
+  apiClient: { get: jest.fn() },
+}));
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('fetchHeritageGroups', () => {
+  it('calls GET /api/heritage-groups/', async () => {
+    apiClient.get.mockResolvedValue({ data: [{ id: 1, name: 'Sarma', member_count: 3 }] });
+    const result = await fetchHeritageGroups();
+    expect(apiClient.get).toHaveBeenCalledWith('/api/heritage-groups/');
+    expect(result).toEqual([{ id: 1, name: 'Sarma', member_count: 3 }]);
+  });
+
+  it('unwraps a paginated DRF response', async () => {
+    apiClient.get.mockResolvedValue({ data: { results: [{ id: 2 }] } });
+    const result = await fetchHeritageGroups();
+    expect(result).toEqual([{ id: 2 }]);
+  });
+
+  it('propagates API errors to the caller', async () => {
+    apiClient.get.mockRejectedValue(new Error('Network Error'));
+    await expect(fetchHeritageGroups()).rejects.toThrow('Network Error');
+  });
+});
+
+describe('fetchHeritageGroup', () => {
+  it('calls GET /api/heritage-groups/:id/', async () => {
+    apiClient.get.mockResolvedValue({
+      data: { id: 1, name: 'Sarma', description: '', members: [], journey_steps: [] },
+    });
+    const result = await fetchHeritageGroup(1);
+    expect(apiClient.get).toHaveBeenCalledWith('/api/heritage-groups/1/');
+    expect(result.name).toBe('Sarma');
+  });
+
+  it('propagates API errors to the caller', async () => {
+    apiClient.get.mockRejectedValue(new Error('404'));
+    await expect(fetchHeritageGroup(99)).rejects.toThrow('404');
+  });
+});

--- a/app/frontend/src/components/CulturalFactCard.css
+++ b/app/frontend/src/components/CulturalFactCard.css
@@ -1,0 +1,48 @@
+.cultural-fact-card {
+  background: #FFF8E7;
+  border: 1px solid #E8D27A;
+  border-radius: 12px;
+  padding: 1rem 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+
+.cultural-fact-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.cultural-fact-icon {
+  font-size: 1.2rem;
+  line-height: 1;
+}
+
+.cultural-fact-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: #8C6A1C;
+}
+
+.cultural-fact-text {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.55;
+  color: #3A2613;
+}
+
+.cultural-fact-source {
+  align-self: flex-start;
+  font-size: 0.8rem;
+  color: #8C4A1C;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.cultural-fact-source:hover,
+.cultural-fact-source:focus-visible {
+  text-decoration: underline;
+}

--- a/app/frontend/src/components/CulturalFactCard.jsx
+++ b/app/frontend/src/components/CulturalFactCard.jsx
@@ -1,0 +1,24 @@
+import './CulturalFactCard.css';
+
+export default function CulturalFactCard({ fact }) {
+  if (!fact) return null;
+  return (
+    <article className="cultural-fact-card">
+      <header className="cultural-fact-header">
+        <span className="cultural-fact-icon" aria-hidden="true">💡</span>
+        <span className="cultural-fact-eyebrow">Did You Know?</span>
+      </header>
+      <p className="cultural-fact-text">{fact.text}</p>
+      {fact.source_url && (
+        <a
+          className="cultural-fact-source"
+          href={fact.source_url}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Source ↗
+        </a>
+      )}
+    </article>
+  );
+}

--- a/app/frontend/src/components/HeritageBadge.css
+++ b/app/frontend/src/components/HeritageBadge.css
@@ -1,0 +1,42 @@
+.heritage-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.65rem 1rem;
+  background: linear-gradient(135deg, #FAF1DE 0%, #F2E0BF 100%);
+  border: 1px solid #C4521E;
+  border-radius: 12px;
+  text-decoration: none;
+  color: #4A2208;
+  font-weight: 600;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.heritage-badge:hover,
+.heritage-badge:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 14px rgba(196, 82, 30, 0.18);
+  outline: none;
+}
+
+.heritage-badge-icon {
+  font-size: 1.4rem;
+  line-height: 1;
+}
+
+.heritage-badge-label {
+  display: inline-flex;
+  flex-direction: column;
+  line-height: 1.2;
+}
+
+.heritage-badge-prefix {
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #8C4A1C;
+}
+
+.heritage-badge-name {
+  font-size: 1rem;
+}

--- a/app/frontend/src/components/HeritageBadge.jsx
+++ b/app/frontend/src/components/HeritageBadge.jsx
@@ -1,0 +1,19 @@
+import { Link } from 'react-router-dom';
+import './HeritageBadge.css';
+
+export default function HeritageBadge({ group }) {
+  if (!group) return null;
+  return (
+    <Link
+      to={`/heritage/${group.id}`}
+      className="heritage-badge"
+      aria-label={`Heritage: ${group.name}`}
+    >
+      <span className="heritage-badge-icon" aria-hidden="true">🏛</span>
+      <span className="heritage-badge-label">
+        <span className="heritage-badge-prefix">Heritage</span>
+        <span className="heritage-badge-name">{group.name}</span>
+      </span>
+    </Link>
+  );
+}

--- a/app/frontend/src/components/HeritageJourneySection.css
+++ b/app/frontend/src/components/HeritageJourneySection.css
@@ -1,0 +1,87 @@
+.heritage-journey {
+  margin: 2rem 0;
+}
+
+.heritage-journey-heading {
+  font-size: 1.5rem;
+  margin-bottom: 1rem;
+  color: #4A2208;
+}
+
+.heritage-journey-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  position: relative;
+}
+
+.heritage-journey-list::before {
+  content: '';
+  position: absolute;
+  left: 1.1rem;
+  top: 0.6rem;
+  bottom: 0.6rem;
+  width: 2px;
+  background: linear-gradient(180deg, #C4521E 0%, #FAF1DE 100%);
+  z-index: 0;
+}
+
+.heritage-journey-step {
+  position: relative;
+  display: flex;
+  gap: 1rem;
+  padding: 0.75rem 0;
+}
+
+.heritage-journey-marker {
+  position: relative;
+  z-index: 1;
+  width: 2.2rem;
+  height: 2.2rem;
+  border-radius: 50%;
+  background: #C4521E;
+  color: white;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.heritage-journey-card {
+  background: #FAF7EF;
+  border: 1px solid #EADCBB;
+  border-radius: 10px;
+  padding: 0.75rem 1rem;
+  flex: 1;
+}
+
+.heritage-journey-card-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 0.4rem;
+}
+
+.heritage-journey-location {
+  font-weight: 600;
+  color: #4A2208;
+}
+
+.heritage-journey-era {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #8C4A1C;
+  background: #F2E0BF;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+}
+
+.heritage-journey-story {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  color: #3A2613;
+}

--- a/app/frontend/src/components/HeritageJourneySection.jsx
+++ b/app/frontend/src/components/HeritageJourneySection.jsx
@@ -1,0 +1,31 @@
+import './HeritageJourneySection.css';
+
+export default function HeritageJourneySection({ steps }) {
+  if (!Array.isArray(steps) || steps.length === 0) return null;
+  const sorted = [...steps].sort((a, b) => a.order - b.order);
+  return (
+    <section className="heritage-journey">
+      <h2 className="heritage-journey-heading">Journey</h2>
+      <ol className="heritage-journey-list">
+        {sorted.map((step, index) => (
+          <li key={step.id} className="heritage-journey-step">
+            <div className="heritage-journey-marker" aria-hidden="true">{index + 1}</div>
+            <div className="heritage-journey-card">
+              <div className="heritage-journey-card-head">
+                <span className="heritage-journey-location" data-testid="journey-step-location">
+                  {step.location}
+                </span>
+                {step.era && (
+                  <span className="heritage-journey-era" data-testid="journey-step-era">
+                    {step.era}
+                  </span>
+                )}
+              </div>
+              <p className="heritage-journey-story">{step.story}</p>
+            </div>
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}

--- a/app/frontend/src/components/Navbar.jsx
+++ b/app/frontend/src/components/Navbar.jsx
@@ -56,6 +56,14 @@ export default function Navbar() {
               <p className="navbar-hover-desc">Find cultural food events and experiences near you</p>
             </div>
           </div>
+          <div className="navbar-browse-link-wrap">
+            <NavLink to="/calendar" className="navbar-link">Calendar</NavLink>
+            <div className="navbar-hover-card">
+              <span className="navbar-hover-icon">📅</span>
+              <strong className="navbar-hover-title">Calendar</strong>
+              <p className="navbar-hover-desc">Trace which dishes belong to which seasons, rituals, and feast days</p>
+            </div>
+          </div>
         </div>
         <div className="navbar-links">
           {user ? (

--- a/app/frontend/src/components/RandomCulturalFact.jsx
+++ b/app/frontend/src/components/RandomCulturalFact.jsx
@@ -1,0 +1,18 @@
+import { useEffect, useState } from 'react';
+import CulturalFactCard from './CulturalFactCard';
+import { fetchRandomCulturalFact } from '../services/culturalFactService';
+
+export default function RandomCulturalFact() {
+  const [fact, setFact] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchRandomCulturalFact()
+      .then((data) => { if (!cancelled) setFact(data); })
+      .catch(() => { if (!cancelled) setFact(null); });
+    return () => { cancelled = true; };
+  }, []);
+
+  if (!fact) return null;
+  return <CulturalFactCard fact={fact} />;
+}

--- a/app/frontend/src/pages/CalendarPage.css
+++ b/app/frontend/src/pages/CalendarPage.css
@@ -1,0 +1,188 @@
+.calendar-page {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.calendar-page-header h1 {
+  margin: 0 0 0.25rem;
+  color: #4A2208;
+}
+
+.calendar-page-subtitle {
+  margin: 0;
+  color: #5A3621;
+}
+
+.calendar-filters {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.calendar-filter {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.8rem;
+  color: #5A3621;
+  font-weight: 600;
+}
+
+.calendar-filter select {
+  margin-top: 0.25rem;
+  padding: 0.5rem 0.6rem;
+  border: 1px solid #EADCBB;
+  border-radius: 8px;
+  background: white;
+  min-width: 12rem;
+}
+
+.calendar-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1rem;
+}
+
+.calendar-month {
+  background: #FAF7EF;
+  border: 1px solid #EADCBB;
+  border-radius: 12px;
+  padding: 1rem;
+}
+
+.calendar-month h2 {
+  font-size: 1.05rem;
+  margin: 0 0 0.6rem;
+  color: #4A2208;
+}
+
+.calendar-month ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.calendar-month-empty {
+  color: #8C7757;
+  font-style: italic;
+  font-size: 0.9rem;
+  margin: 0;
+}
+
+.calendar-event-card {
+  width: 100%;
+  text-align: left;
+  background: white;
+  border: 1px solid #EADCBB;
+  border-radius: 8px;
+  padding: 0.55rem 0.7rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  cursor: pointer;
+  transition: border-color 0.15s ease, transform 0.15s ease;
+}
+
+.calendar-event-card:hover,
+.calendar-event-card:focus-visible {
+  border-color: #C4521E;
+  transform: translateY(-1px);
+  outline: none;
+}
+
+.calendar-event-name {
+  font-weight: 600;
+  color: #4A2208;
+}
+
+.calendar-event-region {
+  font-size: 0.8rem;
+  color: #8C4A1C;
+}
+
+.calendar-lunar {
+  background: #FFF8E7;
+  border: 1px dashed #E8D27A;
+  border-radius: 12px;
+  padding: 1rem;
+}
+
+.calendar-lunar h2 {
+  margin: 0 0 0.4rem;
+  color: #8C6A1C;
+}
+
+.calendar-lunar-note {
+  margin: 0 0 0.75rem;
+  font-size: 0.85rem;
+  color: #5A3621;
+}
+
+.calendar-lunar ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.5rem;
+}
+
+.calendar-event-detail {
+  position: relative;
+  background: #FAF7EF;
+  border: 1px solid #EADCBB;
+  border-radius: 12px;
+  padding: 1.25rem;
+}
+
+.calendar-event-detail-close {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.75rem;
+  background: transparent;
+  border: none;
+  font-size: 1.4rem;
+  line-height: 1;
+  cursor: pointer;
+  color: #5A3621;
+}
+
+.calendar-event-detail h2 {
+  margin: 0 0 0.25rem;
+  color: #4A2208;
+}
+
+.calendar-event-detail-rule {
+  font-size: 0.85rem;
+  color: #8C4A1C;
+  margin: 0 0 0.5rem;
+}
+
+.calendar-event-detail-region,
+.calendar-event-detail-description {
+  margin: 0 0 0.5rem;
+  color: #3A2613;
+}
+
+.calendar-event-detail-recipes {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.calendar-event-detail-recipes a {
+  display: inline-block;
+  padding: 0.35rem 0.7rem;
+  background: white;
+  border: 1px solid #EADCBB;
+  border-radius: 999px;
+  color: #4A2208;
+  text-decoration: none;
+  font-size: 0.85rem;
+}

--- a/app/frontend/src/pages/CalendarPage.jsx
+++ b/app/frontend/src/pages/CalendarPage.jsx
@@ -1,8 +1,192 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { fetchCulturalEvents } from '../services/culturalEventService';
+import { fetchRegions } from '../services/searchService';
+import './CalendarPage.css';
+
+const MONTHS = [
+  'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December',
+];
+
+function parseDateRule(rule) {
+  if (typeof rule !== 'string') return { kind: 'unknown' };
+  if (rule.startsWith('fixed:')) {
+    const [mm, dd] = rule.slice('fixed:'.length).split('-');
+    const month = parseInt(mm, 10);
+    return { kind: 'fixed', month, day: parseInt(dd, 10) };
+  }
+  if (rule.startsWith('lunar:')) {
+    return { kind: 'lunar', name: rule.slice('lunar:'.length) };
+  }
+  return { kind: 'unknown' };
+}
+
 export default function CalendarPage() {
+  const [regions, setRegions] = useState([]);
+  const [events, setEvents] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [month, setMonth] = useState('');
+  const [region, setRegion] = useState('');
+  const [selected, setSelected] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchRegions().then((data) => { if (!cancelled) setRegions(data); }).catch(() => {});
+    return () => { cancelled = true; };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    fetchCulturalEvents({ month, region })
+      .then((data) => { if (!cancelled) setEvents(data); })
+      .catch(() => { if (!cancelled) setEvents([]); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [month, region]);
+
+  const grouped = useMemo(() => {
+    const byMonth = Array.from({ length: 12 }, () => []);
+    const lunar = [];
+    for (const event of events) {
+      const parsed = parseDateRule(event.date_rule);
+      if (parsed.kind === 'fixed' && parsed.month >= 1 && parsed.month <= 12) {
+        byMonth[parsed.month - 1].push(event);
+      } else if (parsed.kind === 'lunar') {
+        lunar.push(event);
+      }
+    }
+    return { byMonth, lunar };
+  }, [events]);
+
   return (
-    <main className="page-card">
-      <h1>Cultural Food Calendar</h1>
-      <p>Loading…</p>
+    <main className="page-card calendar-page">
+      <header className="calendar-page-header">
+        <h1>Cultural Food Calendar</h1>
+        <p className="calendar-page-subtitle">
+          Explore which foods belong to which seasons, rituals and celebrations.
+        </p>
+      </header>
+
+      <div className="calendar-filters">
+        <label className="calendar-filter">
+          <span>Month</span>
+          <select value={month} onChange={(e) => setMonth(e.target.value)} aria-label="Month">
+            <option value="">All months</option>
+            {MONTHS.map((label, idx) => {
+              const value = String(idx + 1).padStart(2, '0');
+              return <option key={value} value={value}>{label}</option>;
+            })}
+          </select>
+        </label>
+        <label className="calendar-filter">
+          <span>Region</span>
+          <select value={region} onChange={(e) => setRegion(e.target.value)} aria-label="Region">
+            <option value="">All regions</option>
+            {regions.map((r) => (
+              <option key={r.id} value={r.id}>{r.name}</option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      {loading && <p className="page-status">Loading…</p>}
+
+      <div className="calendar-grid">
+        {MONTHS.map((label, idx) => {
+          const monthEvents = grouped.byMonth[idx];
+          return (
+            <section
+              key={label}
+              className="calendar-month"
+              data-testid={`calendar-month-${idx + 1}`}
+            >
+              <h2>{label}</h2>
+              {monthEvents.length === 0 ? (
+                <p className="calendar-month-empty">No events.</p>
+              ) : (
+                <ul>
+                  {monthEvents.map((event) => (
+                    <li key={event.id}>
+                      <button
+                        type="button"
+                        className="calendar-event-card"
+                        aria-label={`Open ${event.name} details`}
+                        onClick={() => setSelected(event)}
+                      >
+                        <span className="calendar-event-name">{event.name}</span>
+                        {event.region?.name && (
+                          <span className="calendar-event-region">{event.region.name}</span>
+                        )}
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </section>
+          );
+        })}
+      </div>
+
+      {grouped.lunar.length > 0 && (
+        <section className="calendar-lunar" data-testid="calendar-lunar">
+          <h2>Lunar-Anchored Events</h2>
+          <p className="calendar-lunar-note">
+            Lunar dates shift each year; check a current lunar calendar for the exact day.
+          </p>
+          <ul>
+            {grouped.lunar.map((event) => (
+              <li key={event.id}>
+                <button
+                  type="button"
+                  className="calendar-event-card"
+                  aria-label={`Open ${event.name} details`}
+                  onClick={() => setSelected(event)}
+                >
+                  <span className="calendar-event-name">{event.name}</span>
+                  {event.region?.name && (
+                    <span className="calendar-event-region">{event.region.name}</span>
+                  )}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {selected && (
+        <aside className="calendar-event-detail" data-testid="event-detail">
+          <button
+            type="button"
+            className="calendar-event-detail-close"
+            aria-label="Close details"
+            onClick={() => setSelected(null)}
+          >
+            ×
+          </button>
+          <h2>{selected.name}</h2>
+          <p className="calendar-event-detail-rule">{selected.date_rule}</p>
+          {selected.region?.name && (
+            <p className="calendar-event-detail-region">Region: {selected.region.name}</p>
+          )}
+          {selected.description && (
+            <p className="calendar-event-detail-description">{selected.description}</p>
+          )}
+          {selected.recipes?.length > 0 && (
+            <>
+              <h3>Linked Recipes</h3>
+              <ul className="calendar-event-detail-recipes">
+                {selected.recipes.map((recipe) => (
+                  <li key={recipe.id}>
+                    <Link to={`/recipes/${recipe.id}`}>{recipe.title}</Link>
+                  </li>
+                ))}
+              </ul>
+            </>
+          )}
+        </aside>
+      )}
     </main>
   );
 }

--- a/app/frontend/src/pages/CalendarPage.jsx
+++ b/app/frontend/src/pages/CalendarPage.jsx
@@ -1,0 +1,8 @@
+export default function CalendarPage() {
+  return (
+    <main className="page-card">
+      <h1>Cultural Food Calendar</h1>
+      <p>Loading…</p>
+    </main>
+  );
+}

--- a/app/frontend/src/pages/HeritageMapPage.css
+++ b/app/frontend/src/pages/HeritageMapPage.css
@@ -1,0 +1,66 @@
+.heritage-map-page {
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.heritage-map-header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.heritage-map-title-block {
+  display: flex;
+  flex-direction: column;
+}
+
+.heritage-map-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 0.75rem;
+  color: #8C4A1C;
+  font-weight: 600;
+}
+
+.heritage-map-title {
+  font-size: 1.6rem;
+  margin: 0;
+  color: #4A2208;
+}
+
+.heritage-map-wrap {
+  border: 1px solid #EADCBB;
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.heritage-map-leaflet {
+  height: 70vh;
+  min-height: 480px;
+  width: 100%;
+}
+
+.heritage-center-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.6rem;
+  background: #FAF1DE;
+  border: 2px solid #C4521E;
+  border-radius: 50%;
+  cursor: pointer;
+}
+
+.heritage-map-empty {
+  padding: 2rem;
+  text-align: center;
+  color: #5A3621;
+  background: #FAF7EF;
+  border: 1px dashed #EADCBB;
+  border-radius: 12px;
+}

--- a/app/frontend/src/pages/HeritageMapPage.jsx
+++ b/app/frontend/src/pages/HeritageMapPage.jsx
@@ -1,0 +1,110 @@
+import { useEffect, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import { MapContainer, TileLayer, CircleMarker, Marker, Polyline, Tooltip } from 'react-leaflet';
+import L from 'leaflet';
+import 'leaflet/dist/leaflet.css';
+import { fetchHeritageGroup } from '../services/heritageService';
+import { computeHeritageMidpoint, locatableMembers } from '../utils/heritageMidpoint';
+import './HeritageMapPage.css';
+
+const centerIcon = L.divIcon({
+  className: 'heritage-center-icon',
+  html: '<span aria-hidden="true">🏛</span>',
+  iconSize: [36, 36],
+  iconAnchor: [18, 18],
+});
+
+export default function HeritageMapPage() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const [group, setGroup] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchHeritageGroup(id)
+      .then((data) => { if (!cancelled) setGroup(data); })
+      .catch(() => { if (!cancelled) setError('Could not load heritage group.'); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [id]);
+
+  if (loading) return <p className="page-status">Loading…</p>;
+  if (error) return <p className="page-status page-error">{error}</p>;
+  if (!group) return null;
+
+  const located = locatableMembers(group.members);
+  const midpoint = computeHeritageMidpoint(group.members);
+
+  return (
+    <main className="heritage-map-page">
+      <header className="heritage-map-header">
+        <Link to={`/heritage/${group.id}`} className="btn btn-outline btn-sm">
+          ← Back to Heritage Page
+        </Link>
+        <div className="heritage-map-title-block">
+          <span className="heritage-map-eyebrow">🏛 Heritage Map</span>
+          <h1 className="heritage-map-title">{group.name}</h1>
+        </div>
+      </header>
+
+      {midpoint ? (
+        <div className="heritage-map-wrap">
+          <MapContainer
+            center={midpoint}
+            zoom={4}
+            className="heritage-map-leaflet"
+            scrollWheelZoom={false}
+          >
+            <TileLayer
+              url="https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png"
+              attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>'
+            />
+            {located.map((member) => (
+              <Polyline
+                key={`line-${member.content_type}-${member.id}`}
+                positions={[midpoint, [member.latitude, member.longitude]]}
+                pathOptions={{ color: '#C4521E', weight: 2, opacity: 0.65, dashArray: '4 4' }}
+              />
+            ))}
+            <Marker
+              position={midpoint}
+              icon={centerIcon}
+              eventHandlers={{ click: () => navigate(`/heritage/${group.id}`) }}
+            >
+              <Tooltip direction="top" offset={[0, -12]} opacity={0.95}>
+                {group.name}
+              </Tooltip>
+            </Marker>
+            {located.map((member) => (
+              <CircleMarker
+                key={`pin-${member.content_type}-${member.id}`}
+                center={[member.latitude, member.longitude]}
+                radius={10}
+                pathOptions={{
+                  color: '#A3401A',
+                  fillColor: member.content_type === 'recipe' ? '#C4521E' : '#8C4A1C',
+                  fillOpacity: 0.9,
+                  weight: 2,
+                }}
+                eventHandlers={{
+                  click: () =>
+                    navigate(
+                      `/${member.content_type === 'recipe' ? 'recipes' : 'stories'}/${member.id}`,
+                    ),
+                }}
+              >
+                <Tooltip direction="top" offset={[0, -8]} opacity={0.95}>
+                  {member.content_type === 'recipe' ? '🍲 ' : '📖 '}{member.title}
+                </Tooltip>
+              </CircleMarker>
+            ))}
+          </MapContainer>
+        </div>
+      ) : (
+        <p className="heritage-map-empty">No locations to plot for this heritage group yet.</p>
+      )}
+    </main>
+  );
+}

--- a/app/frontend/src/pages/HeritagePage.css
+++ b/app/frontend/src/pages/HeritagePage.css
@@ -1,0 +1,108 @@
+.heritage-page {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.heritage-page-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.heritage-page-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-size: 0.8rem;
+  color: #8C4A1C;
+  font-weight: 600;
+}
+
+.heritage-page-title {
+  font-size: 2.2rem;
+  margin: 0;
+  color: #4A2208;
+}
+
+.heritage-page-description {
+  font-size: 1.05rem;
+  line-height: 1.6;
+  color: #5A3621;
+  margin: 0;
+  max-width: 70ch;
+}
+
+.heritage-page-map-cta {
+  align-self: flex-start;
+  margin-top: 0.6rem;
+}
+
+.heritage-section-heading {
+  font-size: 1.4rem;
+  margin: 0 0 1rem;
+  color: #4A2208;
+}
+
+.heritage-facts-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1rem;
+}
+
+.heritage-members-grid {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.heritage-member-card { display: flex; }
+
+.heritage-member-link {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.9rem 1rem;
+  border: 1px solid #EADCBB;
+  border-radius: 10px;
+  background: #FAF7EF;
+  text-decoration: none;
+  color: #4A2208;
+  width: 100%;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.heritage-member-link:hover,
+.heritage-member-link:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 14px rgba(196, 82, 30, 0.15);
+  outline: none;
+}
+
+.heritage-member-type {
+  font-size: 0.75rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #8C4A1C;
+  font-weight: 600;
+}
+
+.heritage-member-title {
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.heritage-member-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  color: #5A3621;
+}
+
+.heritage-empty {
+  color: #5A3621;
+  font-style: italic;
+}

--- a/app/frontend/src/pages/HeritagePage.jsx
+++ b/app/frontend/src/pages/HeritagePage.jsx
@@ -1,0 +1,88 @@
+import { useEffect, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { fetchHeritageGroup } from '../services/heritageService';
+import { fetchCulturalFacts } from '../services/culturalFactService';
+import HeritageJourneySection from '../components/HeritageJourneySection';
+import CulturalFactCard from '../components/CulturalFactCard';
+import './HeritagePage.css';
+
+export default function HeritagePage() {
+  const { id } = useParams();
+  const [group, setGroup] = useState(null);
+  const [facts, setFacts] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError('');
+    fetchHeritageGroup(id)
+      .then((data) => { if (!cancelled) setGroup(data); })
+      .catch(() => { if (!cancelled) setError('Could not load heritage group.'); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    fetchCulturalFacts({ heritageGroup: id })
+      .then((data) => { if (!cancelled) setFacts(data); })
+      .catch(() => {});
+    return () => { cancelled = true; };
+  }, [id]);
+
+  if (loading) return <p className="page-status">Loading…</p>;
+  if (error) return <p className="page-status page-error">{error}</p>;
+  if (!group) return null;
+
+  return (
+    <main className="page-card heritage-page">
+      <header className="heritage-page-header">
+        <span className="heritage-page-eyebrow">🏛 Heritage Group</span>
+        <h1 className="heritage-page-title">{group.name}</h1>
+        {group.description && (
+          <p className="heritage-page-description">{group.description}</p>
+        )}
+        <Link to={`/heritage/${group.id}/map`} className="btn btn-primary heritage-page-map-cta">
+          Show Heritage Map
+        </Link>
+      </header>
+
+      {facts.length > 0 && (
+        <section className="heritage-facts">
+          <h2 className="heritage-section-heading">Did You Know?</h2>
+          <div className="heritage-facts-grid">
+            {facts.map((fact) => (
+              <CulturalFactCard key={fact.id} fact={fact} />
+            ))}
+          </div>
+        </section>
+      )}
+
+      <HeritageJourneySection steps={group.journey_steps} />
+
+      <section className="heritage-members">
+        <h2 className="heritage-section-heading">Recipes & Stories</h2>
+        {group.members.length === 0 ? (
+          <p className="heritage-empty">This group has no linked recipes or stories yet.</p>
+        ) : (
+          <ul className="heritage-members-grid">
+            {group.members.map((member) => (
+              <li key={`${member.content_type}-${member.id}`} className="heritage-member-card">
+                <Link
+                  to={`/${member.content_type === 'recipe' ? 'recipes' : 'stories'}/${member.id}`}
+                  className="heritage-member-link"
+                >
+                  <span className={`heritage-member-type heritage-member-type-${member.content_type}`}>
+                    {member.content_type === 'recipe' ? '🍲 Recipe' : '📖 Story'}
+                  </span>
+                  <span className="heritage-member-title">{member.title}</span>
+                  <span className="heritage-member-meta">
+                    {member.author && <span>@{member.author}</span>}
+                    {member.region && <span>{member.region}</span>}
+                  </span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/app/frontend/src/pages/HomePage.css
+++ b/app/frontend/src/pages/HomePage.css
@@ -160,3 +160,11 @@
   opacity: 0.45;
   cursor: default;
 }
+
+.home-random-fact {
+  margin-top: 2rem;
+}
+
+.home-random-fact:empty {
+  display: none;
+}

--- a/app/frontend/src/pages/HomePage.jsx
+++ b/app/frontend/src/pages/HomePage.jsx
@@ -5,6 +5,7 @@ import { fetchRegions } from '../services/searchService';
 import { fetchDailyCulturalContent } from '../services/culturalContentService';
 import DailyCulturalSection from '../components/DailyCulturalSection';
 import FloatingCulturalPrompt from '../components/FloatingCulturalPrompt';
+import RandomCulturalFact from '../components/RandomCulturalFact';
 import useKeyboardShortcuts from '../hooks/useKeyboardShortcuts';
 import './HomePage.css';
 
@@ -165,6 +166,9 @@ export default function HomePage() {
       </form>
 
       <DailyCulturalSection items={dailyCards} personalized={isPersonalized} />
+      <aside className="home-random-fact" aria-label="Cultural fact of the moment">
+        <RandomCulturalFact />
+      </aside>
       <FloatingCulturalPrompt regions={regions} />
     </main>
   );

--- a/app/frontend/src/pages/RecipeDetailPage.css
+++ b/app/frontend/src/pages/RecipeDetailPage.css
@@ -357,3 +357,7 @@
   font-size: 0.9rem;
   color: var(--color-text-muted);
 }
+
+.recipe-heritage {
+  margin: 1.5rem 0 0.5rem;
+}

--- a/app/frontend/src/pages/RecipeDetailPage.css
+++ b/app/frontend/src/pages/RecipeDetailPage.css
@@ -361,3 +361,19 @@
 .recipe-heritage {
   margin: 1.5rem 0 0.5rem;
 }
+
+.recipe-cultural-facts {
+  margin: 1.5rem 0;
+}
+
+.recipe-cultural-facts-heading {
+  font-size: 1.25rem;
+  margin: 0 0 0.75rem;
+  color: #4A2208;
+}
+
+.recipe-cultural-facts-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1rem;
+}

--- a/app/frontend/src/pages/RecipeDetailPage.jsx
+++ b/app/frontend/src/pages/RecipeDetailPage.jsx
@@ -6,6 +6,7 @@ import { fetchRegions } from '../services/searchService';
 import { fetchSubstitutes } from '../services/ingredientService';
 import { fetchCheckedIngredients, toggleCheckedIngredient } from '../services/checkOffService';
 import RecipeCommentsSection from '../components/RecipeCommentsSection';
+import HeritageBadge from '../components/HeritageBadge';
 import './RecipeDetailPage.css';
 
 const MATCH_TYPE_LABELS = {
@@ -345,6 +346,12 @@ export default function RecipeDetailPage() {
           </div>
         )}
       </section>
+
+      {recipe.heritage_group && (
+        <section className="recipe-heritage">
+          <HeritageBadge group={recipe.heritage_group} />
+        </section>
+      )}
 
       <RecipeCommentsSection
         recipeId={recipe.id}

--- a/app/frontend/src/pages/RecipeDetailPage.jsx
+++ b/app/frontend/src/pages/RecipeDetailPage.jsx
@@ -7,6 +7,8 @@ import { fetchSubstitutes } from '../services/ingredientService';
 import { fetchCheckedIngredients, toggleCheckedIngredient } from '../services/checkOffService';
 import RecipeCommentsSection from '../components/RecipeCommentsSection';
 import HeritageBadge from '../components/HeritageBadge';
+import CulturalFactCard from '../components/CulturalFactCard';
+import { fetchCulturalFacts } from '../services/culturalFactService';
 import './RecipeDetailPage.css';
 
 const MATCH_TYPE_LABELS = {
@@ -45,6 +47,8 @@ export default function RecipeDetailPage() {
   // #373 — shopping list
   const [showShoppingList, setShowShoppingList] = useState(false);
 
+  const [recipeFacts, setRecipeFacts] = useState([]);
+
   useEffect(() => {
     let cancelled = false;
     fetchRegions().then((r) => { if (!cancelled) setRegions(r); }).catch(() => {});
@@ -63,6 +67,19 @@ export default function RecipeDetailPage() {
       .catch(() => {});
     return () => { cancelled = true; };
   }, [user, id]);
+
+  useEffect(() => {
+    const groupId = recipe?.heritage_group?.id;
+    if (!groupId) {
+      setRecipeFacts([]);
+      return;
+    }
+    let cancelled = false;
+    fetchCulturalFacts({ heritageGroup: groupId })
+      .then((data) => { if (!cancelled) setRecipeFacts(data); })
+      .catch(() => { if (!cancelled) setRecipeFacts([]); });
+    return () => { cancelled = true; };
+  }, [recipe?.heritage_group?.id]);
 
   const toggleCheck = useCallback(async (ingredientId) => {
     if (!user) return;
@@ -350,6 +367,17 @@ export default function RecipeDetailPage() {
       {recipe.heritage_group && (
         <section className="recipe-heritage">
           <HeritageBadge group={recipe.heritage_group} />
+        </section>
+      )}
+
+      {recipeFacts.length > 0 && (
+        <section className="recipe-cultural-facts">
+          <h2 className="recipe-cultural-facts-heading">Did You Know?</h2>
+          <div className="recipe-cultural-facts-list">
+            {recipeFacts.map((fact) => (
+              <CulturalFactCard key={fact.id} fact={fact} />
+            ))}
+          </div>
         </section>
       )}
 

--- a/app/frontend/src/pages/StoryDetailPage.css
+++ b/app/frontend/src/pages/StoryDetailPage.css
@@ -97,3 +97,7 @@
   border-radius: var(--radius-md);
   margin: 1rem 0 1.5rem;
 }
+
+.story-heritage {
+  margin: 1.5rem 0 0.5rem;
+}

--- a/app/frontend/src/pages/StoryDetailPage.jsx
+++ b/app/frontend/src/pages/StoryDetailPage.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useContext, useCallback } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
 import { AuthContext } from '../context/AuthContext';
 import { fetchStory, deleteStory, publishStory, unpublishStory } from '../services/storyService';
+import HeritageBadge from '../components/HeritageBadge';
 import './StoryDetailPage.css';
 
 export default function StoryDetailPage() {
@@ -117,6 +118,12 @@ export default function StoryDetailPage() {
       )}
 
       <p className="story-body">{story.body}</p>
+
+      {story.heritage_group && (
+        <section className="story-heritage">
+          <HeritageBadge group={story.heritage_group} />
+        </section>
+      )}
 
       {story.linked_recipe && (
         <section className="story-linked-recipe">

--- a/app/frontend/src/services/culturalEventService.js
+++ b/app/frontend/src/services/culturalEventService.js
@@ -1,0 +1,13 @@
+import { apiClient } from './api';
+
+export async function fetchCulturalEvents({ month, region } = {}) {
+  const params = {};
+  if (month !== undefined && month !== null && month !== '') {
+    params.month = String(month).padStart(2, '0');
+  }
+  if (region !== undefined && region !== null && region !== '') {
+    params.region = region;
+  }
+  const response = await apiClient.get('/api/cultural-events/', { params });
+  return response.data.results ?? response.data;
+}

--- a/app/frontend/src/services/culturalFactService.js
+++ b/app/frontend/src/services/culturalFactService.js
@@ -1,0 +1,19 @@
+import { apiClient } from './api';
+
+export async function fetchCulturalFacts({ heritageGroup, region } = {}) {
+  const params = {};
+  if (heritageGroup !== undefined && heritageGroup !== null) params.heritage_group = heritageGroup;
+  if (region !== undefined && region !== null) params.region = region;
+  const response = await apiClient.get('/api/cultural-facts/', { params });
+  return response.data.results ?? response.data;
+}
+
+export async function fetchRandomCulturalFact() {
+  try {
+    const response = await apiClient.get('/api/cultural-facts/random/');
+    return response.data;
+  } catch (err) {
+    if (err?.response?.status === 404) return null;
+    throw err;
+  }
+}

--- a/app/frontend/src/services/heritageService.js
+++ b/app/frontend/src/services/heritageService.js
@@ -1,0 +1,11 @@
+import { apiClient } from './api';
+
+export async function fetchHeritageGroups() {
+  const response = await apiClient.get('/api/heritage-groups/');
+  return response.data.results ?? response.data;
+}
+
+export async function fetchHeritageGroup(id) {
+  const response = await apiClient.get(`/api/heritage-groups/${id}/`);
+  return response.data;
+}

--- a/app/frontend/src/utils/heritageMidpoint.js
+++ b/app/frontend/src/utils/heritageMidpoint.js
@@ -1,0 +1,14 @@
+export function locatableMembers(members) {
+  if (!Array.isArray(members)) return [];
+  return members.filter(
+    (m) => typeof m?.latitude === 'number' && typeof m?.longitude === 'number',
+  );
+}
+
+export function computeHeritageMidpoint(members) {
+  const located = locatableMembers(members);
+  if (located.length === 0) return null;
+  const sumLat = located.reduce((acc, m) => acc + m.latitude, 0);
+  const sumLng = located.reduce((acc, m) => acc + m.longitude, 0);
+  return [sumLat / located.length, sumLng / located.length];
+}


### PR DESCRIPTION
## Summary

  Closes Milestone 8 web frontend work for the four ready issues. Backend was already merged on `main` for these (#499, #511, #522, #528 closed); this PR is the matching web layer.

  - **#500 Heritage Badge, Page & Map**
    - `HeritageBadge` component appears on `RecipeDetail` and `StoryDetail` when the API returns a `heritage_group`, links to `/heritage/<id>`
    - `HeritagePage` at `/heritage/:id`: header, "Show Heritage Map" CTA, members grid (recipes + stories mixed), graceful empty/error states
    - `HeritageMapPage` at `/heritage/:id/map`: Leaflet view with the central 🏛 marker at the geographic midpoint of member coordinates, dashed polylines from midpoint to each located
   member, color-coded `CircleMarker` per recipe/story, click-through to detail, "← Back to Heritage Page" link
    - Members without `latitude/longitude` are filtered out of the map; empty state renders when none have coords
    - `computeHeritageMidpoint` / `locatableMembers` extracted as a pure util so the math is unit-tested without Leaflet

  - **#515 Heritage Journey**
    - `HeritageJourneySection` timeline component rendered inside `HeritagePage`
    - Steps sorted by `order` ascending; era badge only when present; prop is never mutated

  - **#517 Cultural Context Cards — "Did You Know?"**
    - `CulturalFactCard` reusable card with `target="_blank"` + `rel="noopener noreferrer"` on source links
    - Facts grid on `HeritagePage` (filtered by heritage group)
    - Facts list on `RecipeDetailPage` when the recipe has a `heritage_group` (no API call for unaffiliated recipes)
    - `RandomCulturalFact` widget on `HomePage` — silently renders nothing on null / 404 / error

  - **#527 Seasonal & Ritual Calendar**
    - `CalendarPage` at `/calendar`: 12-month grid + dedicated "Lunar-Anchored Events" panel for `lunar:*` rules
    - Month + region filters drive a fresh `/api/cultural-events/?month=MM&region=<id>` query
    - Click any event card → side detail panel with description, region, and linked recipes (`Link` to `/recipes/<id>`)
    - New "Calendar" entry in the public navbar between Explore and the user menu

  ### Service / util layer

  - `heritageService.js` — `fetchHeritageGroups`, `fetchHeritageGroup` (DRF pagination unwrap)
  - `culturalFactService.js` — `fetchCulturalFacts({heritageGroup, region})`, `fetchRandomCulturalFact()` returns `null` on 404
  - `culturalEventService.js` — `fetchCulturalEvents({month, region})`, zero-pads numeric month to `MM`
  - `utils/heritageMidpoint.js` — `locatableMembers`, `computeHeritageMidpoint`

  ## Out of scope

  These are tracked separately and intentionally **not** in this PR:

  - **#516 Beyond the Recipe — Cultural Story fields** (depends on backend #521, still open)
  - **#514 Ingredient Migration Routes** (depends on backend #523, still open)
  - **#520 Endangered Heritage Tags** (depends on backend #524, still open)
  - **#464** Zoom-to-region map — no backend sub-issue existed; opened **#662** as the missing backend sub-issue
  - Heritage demo seed data — opened **#663** to give #502 cross-platform testing a reproducible base

  ## Test plan

  - [ ] `npm test` in `app/frontend/` — 496/496 tests pass (17 new test files cover services, utils, components, pages, and integration)
  - [ ] `npm run build` — production build succeeds
  - [ ] Open a recipe whose `heritage_group` is set in the DB — confirm the badge appears below the ingredients section and navigates to `/heritage/<id>`
  - [ ] Open a story whose `heritage_group` is set — same check
  - [ ] Open a recipe with `heritage_group: null` — confirm no badge, no facts section, no `/cultural-facts/` request fired
  - [ ] Navigate to `/heritage/<id>` — verify header, description, "Show Heritage Map" link, journey timeline (when steps exist), facts grid (when facts exist), members grid
  - [ ] Click "Show Heritage Map" — verify central 🏛 marker at midpoint, polylines to each located member, click-through on pins, "← Back to Heritage Page" link
  - [ ] Heritage group where every member has `latitude=null` — verify "No locations to plot" empty state
  - [ ] Visit `/calendar` — verify 12 month panels, lunar panel for `lunar:*` events, month + region filters fire fresh queries
  - [ ] Click an event card — confirm detail panel with description, region, linked recipe links to `/recipes/<id>`
  - [ ] Open the homepage — confirm a random cultural fact card appears below the daily content (or nothing if the backend returns 404)
  - [ ] Navbar shows Calendar entry between Explore and the user menu, links to `/calendar`