### PR TITLE
feat(frontend): floating chat tray — X.com-style docked tab with inline messaging (#716)

### DIFF
--- a/app/frontend/.env.test
+++ b/app/frontend/.env.test
@@ -1,0 +1,2 @@
+REACT_APP_API_URL=http://localhost:8000
+REACT_APP_USE_MOCK=false

--- a/app/frontend/Dockerfile
+++ b/app/frontend/Dockerfile
@@ -11,6 +11,8 @@ COPY . .
 
 ARG REACT_APP_API_URL=http://localhost
 ENV REACT_APP_API_URL=$REACT_APP_API_URL
+ARG REACT_APP_USE_MOCK=false
+ENV REACT_APP_USE_MOCK=$REACT_APP_USE_MOCK
 RUN npm run build
 
 # ---- Stage 2: serve ----

--- a/app/frontend/src/App.js
+++ b/app/frontend/src/App.js
@@ -1,6 +1,7 @@
 import { Routes, Route, useLocation } from 'react-router-dom';
 import Navbar from './components/Navbar';
 import SkipLink from './components/SkipLink';
+import ChatTray from './components/ChatTray';
 import ProtectedRoute from './components/ProtectedRoute';
 import GridMotion from './components/GridMotion';
 import HomePage from './pages/HomePage';
@@ -71,6 +72,7 @@ export default function App() {
         </>
       )}
       <Navbar />
+      <ChatTray />
       <div className="page-wrapper" id="main-content">
         <Routes>
           <Route path="/" element={<HomePage />} />

--- a/app/frontend/src/__tests__/ChatContext.test.jsx
+++ b/app/frontend/src/__tests__/ChatContext.test.jsx
@@ -1,0 +1,89 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { useContext } from 'react';
+import { ChatContext, ChatProvider } from '../context/ChatContext';
+import { AuthContext } from '../context/AuthContext';
+import * as messageService from '../services/messageService';
+
+jest.mock('../services/messageService');
+jest.useFakeTimers();
+
+const mockThreads = [
+  { id: 1, otherUser: { id: 2, username: 'alice' }, lastMessage: null, unreadCount: 3 },
+  { id: 2, otherUser: { id: 3, username: 'bob' }, lastMessage: null, unreadCount: 0 },
+];
+
+function Spy() {
+  const ctx = useContext(ChatContext);
+  return (
+    <div>
+      <span data-testid="count">{ctx.threads.length}</span>
+      <span data-testid="unread">{ctx.totalUnread}</span>
+      <span data-testid="loading">{String(ctx.loading)}</span>
+      <button onClick={() => ctx.markRead(1)}>markRead</button>
+      <button onClick={() => ctx.refresh()}>refresh</button>
+    </div>
+  );
+}
+
+function renderWithUser(user) {
+  return render(
+    <AuthContext.Provider value={{ user, token: user ? 'tok' : null, login: jest.fn(), logout: jest.fn(), updateUser: jest.fn() }}>
+      <ChatProvider>
+        <Spy />
+      </ChatProvider>
+    </AuthContext.Provider>
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  messageService.fetchThreads.mockResolvedValue(mockThreads);
+  messageService.markThreadRead.mockResolvedValue({});
+});
+
+describe('ChatContext', () => {
+  it('starts with empty threads when user is null', () => {
+    renderWithUser(null);
+    expect(screen.getByTestId('count').textContent).toBe('0');
+    expect(messageService.fetchThreads).not.toHaveBeenCalled();
+  });
+
+  it('fetches threads on mount when user is set', async () => {
+    renderWithUser({ id: 1, username: 'me' });
+    await waitFor(() => expect(screen.getByTestId('count').textContent).toBe('2'));
+    expect(messageService.fetchThreads).toHaveBeenCalledTimes(1);
+  });
+
+  it('computes totalUnread from threads', async () => {
+    renderWithUser({ id: 1, username: 'me' });
+    await waitFor(() => expect(screen.getByTestId('unread').textContent).toBe('3'));
+  });
+
+  it('polls again after 30s', async () => {
+    renderWithUser({ id: 1, username: 'me' });
+    await waitFor(() => expect(messageService.fetchThreads).toHaveBeenCalledTimes(1));
+    act(() => jest.advanceTimersByTime(30000));
+    await waitFor(() => expect(messageService.fetchThreads).toHaveBeenCalledTimes(2));
+  });
+
+  it('markRead zeroes unreadCount locally and calls markThreadRead service', async () => {
+    renderWithUser({ id: 1, username: 'me' });
+    await waitFor(() => expect(screen.getByTestId('unread').textContent).toBe('3'));
+    act(() => screen.getByText('markRead').click());
+    await waitFor(() => expect(screen.getByTestId('unread').textContent).toBe('0'));
+    expect(messageService.markThreadRead).toHaveBeenCalledWith(1);
+  });
+
+  it('clears threads when user becomes null', async () => {
+    const { rerender } = renderWithUser({ id: 1, username: 'me' });
+    await waitFor(() => expect(screen.getByTestId('count').textContent).toBe('2'));
+    rerender(
+      <AuthContext.Provider value={{ user: null, token: null, login: jest.fn(), logout: jest.fn(), updateUser: jest.fn() }}>
+        <ChatProvider>
+          <Spy />
+        </ChatProvider>
+      </AuthContext.Provider>
+    );
+    expect(screen.getByTestId('count').textContent).toBe('0');
+  });
+});

--- a/app/frontend/src/__tests__/ChatTray.test.jsx
+++ b/app/frontend/src/__tests__/ChatTray.test.jsx
@@ -1,0 +1,180 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { AuthContext } from '../context/AuthContext';
+import { ChatContext } from '../context/ChatContext';
+import ChatTray from '../components/ChatTray';
+import * as messageService from '../services/messageService';
+
+jest.mock('../services/messageService');
+
+const mockMarkRead = jest.fn();
+
+const baseThreads = [
+  {
+    id: 1,
+    otherUser: { id: 2, username: 'alice' },
+    lastMessage: { body: 'Hey!', createdAt: new Date().toISOString() },
+    unreadCount: 2,
+  },
+];
+
+function renderTray({ user = { id: 1, username: 'me' }, threads = baseThreads, totalUnread = 2 } = {}) {
+  return render(
+    <MemoryRouter>
+      <AuthContext.Provider value={{ user, token: user ? 'tok' : null, login: jest.fn(), logout: jest.fn(), updateUser: jest.fn() }}>
+        <ChatContext.Provider value={{ threads, totalUnread, loading: false, markRead: mockMarkRead, refresh: jest.fn() }}>
+          <ChatTray />
+        </ChatContext.Provider>
+      </AuthContext.Provider>
+    </MemoryRouter>
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  messageService.fetchMessages.mockResolvedValue([]);
+  messageService.sendMessage.mockResolvedValue({ id: 99, body: 'hi', sender: { id: 1 }, createdAt: new Date().toISOString() });
+  window.HTMLElement.prototype.scrollIntoView = jest.fn();
+});
+
+describe('ChatTray', () => {
+  it('renders nothing when user is null', () => {
+    const { container } = renderTray({ user: null });
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the Messages tab when user is logged in', () => {
+    renderTray();
+    expect(screen.getByRole('button', { name: /messages/i })).toBeInTheDocument();
+  });
+
+  it('shows unread badge when totalUnread > 0', () => {
+    renderTray({ totalUnread: 5 });
+    expect(screen.getByText('5')).toBeInTheDocument();
+  });
+
+  it('does not show badge when totalUnread is 0', () => {
+    renderTray({ totalUnread: 0 });
+    expect(screen.queryByText('0')).not.toBeInTheDocument();
+  });
+
+  it('opens the panel on toggle click', () => {
+    renderTray();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /messages/i }));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('closes the panel on second toggle click', () => {
+    renderTray();
+    fireEvent.click(screen.getByRole('button', { name: /messages/i }));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /messages/i }));
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('closes the panel on click-outside', () => {
+    renderTray();
+    fireEvent.click(screen.getByRole('button', { name: /messages/i }));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    fireEvent.mouseDown(document.body);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('shows thread list with username and unread count in open panel', () => {
+    renderTray();
+    fireEvent.click(screen.getByRole('button', { name: /messages/i }));
+    expect(screen.getByText('@alice')).toBeInTheDocument();
+    expect(document.querySelector('.chat-tray-unread')).toBeInTheDocument();
+  });
+
+  it('calls markRead when a thread is clicked', () => {
+    renderTray();
+    fireEvent.click(screen.getByRole('button', { name: /messages/i }));
+    fireEvent.click(screen.getByText('@alice'));
+    expect(mockMarkRead).toHaveBeenCalledWith(1);
+  });
+
+  it('shows "No conversations yet." when threads are empty', () => {
+    renderTray({ threads: [], totalUnread: 0 });
+    fireEvent.click(screen.getByRole('button', { name: /messages/i }));
+    expect(screen.getByText('No conversations yet.')).toBeInTheDocument();
+  });
+});
+
+describe('relativeTime and isRecentlyActive helpers', () => {
+  beforeEach(() => {
+    jest.spyOn(Date, 'now').mockReturnValue(new Date('2026-01-01T12:00:00Z').getTime());
+  });
+  afterEach(() => jest.restoreAllMocks());
+
+  it('shows seconds for recent timestamps', () => {
+    renderTray({
+      threads: [{
+        id: 1,
+        otherUser: { id: 2, username: 'alice' },
+        lastMessage: { body: 'Hey', createdAt: new Date('2026-01-01T11:59:30Z').toISOString() },
+        unreadCount: 0,
+      }],
+      totalUnread: 0,
+    });
+    fireEvent.click(screen.getByRole('button', { name: /messages/i }));
+    expect(screen.getByText('30s')).toBeInTheDocument();
+  });
+
+  it('shows minutes for older timestamps', () => {
+    renderTray({
+      threads: [{
+        id: 1,
+        otherUser: { id: 2, username: 'alice' },
+        lastMessage: { body: 'Hey', createdAt: new Date('2026-01-01T11:55:00Z').toISOString() },
+        unreadCount: 0,
+      }],
+      totalUnread: 0,
+    });
+    fireEvent.click(screen.getByRole('button', { name: /messages/i }));
+    expect(screen.getByText('5m')).toBeInTheDocument();
+  });
+
+  it('clamps negative diff to 0s for future timestamps', () => {
+    renderTray({
+      threads: [{
+        id: 1,
+        otherUser: { id: 2, username: 'alice' },
+        lastMessage: { body: 'Hey', createdAt: new Date('2026-01-01T12:00:05Z').toISOString() },
+        unreadCount: 0,
+      }],
+      totalUnread: 0,
+    });
+    fireEvent.click(screen.getByRole('button', { name: /messages/i }));
+    expect(screen.getByText('0s')).toBeInTheDocument();
+  });
+
+  it('shows green dot for threads active within 5 minutes', () => {
+    renderTray({
+      threads: [{
+        id: 1,
+        otherUser: { id: 2, username: 'alice' },
+        lastMessage: { body: 'Hey', createdAt: new Date('2026-01-01T11:57:00Z').toISOString() },
+        unreadCount: 0,
+      }],
+      totalUnread: 0,
+    });
+    fireEvent.click(screen.getByRole('button', { name: /messages/i }));
+    expect(document.querySelector('.chat-tray-online')).toBeInTheDocument();
+  });
+
+  it('no green dot for threads older than 5 minutes', () => {
+    renderTray({
+      threads: [{
+        id: 1,
+        otherUser: { id: 2, username: 'alice' },
+        lastMessage: { body: 'Hey', createdAt: new Date('2026-01-01T11:54:00Z').toISOString() },
+        unreadCount: 0,
+      }],
+      totalUnread: 0,
+    });
+    fireEvent.click(screen.getByRole('button', { name: /messages/i }));
+    expect(document.querySelector('.chat-tray-online')).not.toBeInTheDocument();
+  });
+});

--- a/app/frontend/src/components/ChatTray.css
+++ b/app/frontend/src/components/ChatTray.css
@@ -6,8 +6,8 @@
   z-index: 900;
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
-  width: fit-content;
+  align-items: stretch;
+  width: 300px;
 }
 
 /* ── Tab bar (always visible) ────────────────────────────────── */
@@ -15,7 +15,7 @@
   display: flex;
   align-items: center;
   gap: 0.55rem;
-  width: fit-content;
+  width: 100%;
   height: 44px;
   padding: 0 1rem;
   background: var(--color-surface-dark, #3d1500);
@@ -40,6 +40,7 @@
 .chat-tray-label {
   font-size: 0.88rem;
   font-weight: 600;
+  flex: 1;
   text-align: left;
 }
 
@@ -75,7 +76,7 @@
 
 /* ── Panel ───────────────────────────────────────────────────── */
 .chat-tray-panel {
-  width: 300px;
+  width: 100%;
   background: var(--color-surface, #FAF7EF);
   border: 1px solid var(--color-border);
   border-bottom: none;

--- a/app/frontend/src/components/ChatTray.css
+++ b/app/frontend/src/components/ChatTray.css
@@ -1,45 +1,50 @@
+/* ── Container ───────────────────────────────────────────────── */
 .chat-tray {
   position: fixed;
-  bottom: 1.5rem;
+  bottom: 0;
   left: 1.5rem;
   z-index: 900;
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
+  align-items: stretch;
+  width: 300px;
 }
 
-/* Toggle button */
-.chat-tray-toggle {
-  width: 52px;
-  height: 52px;
-  border-radius: 50%;
+/* ── Tab bar (always visible) ────────────────────────────────── */
+.chat-tray-tab {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  width: 100%;
+  height: 44px;
+  padding: 0 1rem;
   background: var(--color-surface-dark, #3d1500);
   color: #f5e6c8;
   border: none;
+  border-radius: 10px 10px 0 0;
   cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  box-shadow: 0 4px 16px rgba(0,0,0,0.25);
-  position: relative;
-  transition: background 0.15s, transform 0.12s;
+  transition: background 0.15s;
   flex-shrink: 0;
 }
 
-.chat-tray-toggle:hover {
+.chat-tray-tab:hover {
   background: #5a2200;
-  transform: scale(1.06);
 }
 
 .chat-tray-icon {
-  width: 24px;
-  height: 24px;
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+}
+
+.chat-tray-label {
+  font-size: 0.88rem;
+  font-weight: 600;
+  flex: 1;
+  text-align: left;
 }
 
 .chat-tray-badge {
-  position: absolute;
-  top: -4px;
-  right: -4px;
   background: #e53e3e;
   color: #fff;
   font-size: 0.68rem;
@@ -51,52 +56,40 @@
   align-items: center;
   justify-content: center;
   padding: 0 4px;
-  border: 2px solid var(--color-surface, #FAF7EF);
-  line-height: 1;
+  flex-shrink: 0;
 }
 
-/* Panel */
+.chat-tray-chevron {
+  width: 8px;
+  height: 8px;
+  border-right: 2px solid #f5e6c8;
+  border-bottom: 2px solid #f5e6c8;
+  transform: rotate(-135deg);
+  transition: transform 0.2s;
+  flex-shrink: 0;
+  margin-left: 2px;
+}
+
+.chat-tray-chevron.open {
+  transform: rotate(45deg);
+}
+
+/* ── Panel ───────────────────────────────────────────────────── */
 .chat-tray-panel {
-  position: absolute;
-  bottom: calc(100% + 10px);
-  left: 0;
-  width: 320px;
+  width: 100%;
   background: var(--color-surface, #FAF7EF);
   border: 1px solid var(--color-border);
-  border-radius: 14px;
-  box-shadow: 0 8px 32px rgba(0,0,0,0.15);
-  overflow: hidden;
+  border-bottom: none;
+  border-radius: 10px 10px 0 0;
+  box-shadow: 0 -4px 24px rgba(0,0,0,0.12);
   display: flex;
   flex-direction: column;
+  overflow: hidden;
 }
 
-.chat-tray-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 0.8rem 1rem;
-  border-bottom: 1px solid var(--color-border);
-  background: var(--color-surface-alt, #f2ede3);
-}
-
-.chat-tray-title {
-  font-size: 0.9rem;
-  font-weight: 700;
-  color: var(--color-text);
-}
-
-.chat-tray-view-all {
-  font-size: 0.8rem;
-  color: var(--color-primary);
-  text-decoration: none;
-}
-
-.chat-tray-view-all:hover {
-  text-decoration: underline;
-}
-
+/* ── Thread list ─────────────────────────────────────────────── */
 .chat-tray-list {
-  max-height: 380px;
+  max-height: 340px;
   overflow-y: auto;
 }
 
@@ -108,13 +101,12 @@
   margin: 0;
 }
 
-/* Thread row */
 .chat-tray-thread {
   display: flex;
-  align-items: flex-start;
-  gap: 0.75rem;
+  align-items: center;
+  gap: 0.7rem;
   width: 100%;
-  padding: 0.7rem 1rem;
+  padding: 0.65rem 1rem;
   background: none;
   border: none;
   border-bottom: 1px solid var(--color-border);
@@ -137,15 +129,15 @@
 }
 
 .chat-tray-avatar {
-  width: 36px;
-  height: 36px;
+  width: 34px;
+  height: 34px;
   border-radius: 50%;
   background: var(--color-primary);
   color: #fff;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 0.95rem;
+  font-size: 0.9rem;
   font-weight: 700;
 }
 
@@ -153,8 +145,8 @@
   position: absolute;
   bottom: 1px;
   right: 1px;
-  width: 10px;
-  height: 10px;
+  width: 9px;
+  height: 9px;
   border-radius: 50%;
   background: #38a169;
   border: 2px solid var(--color-surface, #FAF7EF);
@@ -163,20 +155,18 @@
 .chat-tray-thread-body {
   flex: 1;
   min-width: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.2rem;
 }
 
 .chat-tray-thread-top {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
-  gap: 0.4rem;
+  gap: 0.3rem;
+  margin-bottom: 0.15rem;
 }
 
-.chat-tray-username {
-  font-size: 0.88rem;
+.chat-tray-uname {
+  font-size: 0.85rem;
   font-weight: 600;
   color: var(--color-text);
   white-space: nowrap;
@@ -185,7 +175,7 @@
 }
 
 .chat-tray-time {
-  font-size: 0.75rem;
+  font-size: 0.72rem;
   color: var(--color-text-muted);
   flex-shrink: 0;
 }
@@ -194,11 +184,11 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 0.4rem;
+  gap: 0.3rem;
 }
 
 .chat-tray-preview {
-  font-size: 0.82rem;
+  font-size: 0.78rem;
   color: var(--color-text-muted);
   white-space: nowrap;
   overflow: hidden;
@@ -206,27 +196,185 @@
   flex: 1;
 }
 
-.chat-tray-unread-badge {
+.chat-tray-unread {
   flex-shrink: 0;
   background: var(--color-primary);
   color: #fff;
-  font-size: 0.68rem;
+  font-size: 0.65rem;
   font-weight: 700;
-  min-width: 18px;
-  height: 18px;
+  min-width: 16px;
+  height: 16px;
   border-radius: 999px;
   display: flex;
   align-items: center;
   justify-content: center;
+  padding: 0 3px;
+}
+
+.chat-tray-footer {
+  padding: 0.6rem 1rem;
+  border-top: 1px solid var(--color-border);
+  text-align: center;
+}
+
+.chat-tray-viewall {
+  font-size: 0.8rem;
+  color: var(--color-primary);
+  text-decoration: none;
+}
+
+.chat-tray-viewall:hover {
+  text-decoration: underline;
+}
+
+/* ── Mini chat (conversation view) ──────────────────────────── */
+.chat-conv {
+  display: flex;
+  flex-direction: column;
+  height: 380px;
+}
+
+.chat-conv-header {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.6rem 0.9rem;
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-surface-alt, #f2ede3);
+  flex-shrink: 0;
+}
+
+.chat-conv-back {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1rem;
+  color: var(--color-text-muted);
+  padding: 0;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.chat-conv-back:hover {
+  color: var(--color-text);
+}
+
+.chat-conv-username {
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.chat-conv-messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0.75rem 0.9rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.chat-conv-empty {
+  font-size: 0.82rem;
+  color: var(--color-text-muted);
+  text-align: center;
+  margin: auto;
+}
+
+.chat-msg {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  max-width: 80%;
+}
+
+.chat-msg-me {
+  align-self: flex-end;
+  align-items: flex-end;
+}
+
+.chat-msg-body {
+  background: var(--color-surface-alt, #f2ede3);
+  border: 1px solid var(--color-border);
+  border-radius: 12px 12px 12px 4px;
+  padding: 0.4rem 0.65rem;
+  font-size: 0.85rem;
+  line-height: 1.45;
+  color: var(--color-text);
+  word-break: break-word;
+}
+
+.chat-msg-me .chat-msg-body {
+  background: var(--color-primary);
+  color: #fff;
+  border-color: var(--color-primary);
+  border-radius: 12px 12px 4px 12px;
+}
+
+.chat-msg-time {
+  font-size: 0.68rem;
+  color: var(--color-text-muted);
+  margin-top: 2px;
   padding: 0 4px;
 }
 
+.chat-conv-input-row {
+  display: flex;
+  align-items: flex-end;
+  gap: 0.4rem;
+  padding: 0.5rem 0.7rem;
+  border-top: 1px solid var(--color-border);
+  flex-shrink: 0;
+}
+
+.chat-conv-input {
+  flex: 1;
+  resize: none;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 0.4rem 0.6rem;
+  font-size: 0.85rem;
+  font-family: inherit;
+  background: var(--color-surface);
+  color: var(--color-text);
+  line-height: 1.4;
+  max-height: 80px;
+  overflow-y: auto;
+}
+
+.chat-conv-input:focus {
+  outline: none;
+  border-color: var(--color-primary);
+}
+
+.chat-conv-send {
+  background: var(--color-primary);
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  font-size: 1rem;
+  flex-shrink: 0;
+  transition: opacity 0.15s;
+}
+
+.chat-conv-send:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* ── Mobile ──────────────────────────────────────────────────── */
 @media (max-width: 480px) {
   .chat-tray {
-    bottom: 1rem;
-    left: 1rem;
+    left: 0;
+    width: 100vw;
   }
-  .chat-tray-panel {
-    width: calc(100vw - 2rem);
+  .chat-tray-tab {
+    border-radius: 0;
   }
 }

--- a/app/frontend/src/components/ChatTray.css
+++ b/app/frontend/src/components/ChatTray.css
@@ -1,0 +1,232 @@
+.chat-tray {
+  position: fixed;
+  bottom: 1.5rem;
+  left: 1.5rem;
+  z-index: 900;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+/* Toggle button */
+.chat-tray-toggle {
+  width: 52px;
+  height: 52px;
+  border-radius: 50%;
+  background: var(--color-surface-dark, #3d1500);
+  color: #f5e6c8;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.25);
+  position: relative;
+  transition: background 0.15s, transform 0.12s;
+  flex-shrink: 0;
+}
+
+.chat-tray-toggle:hover {
+  background: #5a2200;
+  transform: scale(1.06);
+}
+
+.chat-tray-icon {
+  width: 24px;
+  height: 24px;
+}
+
+.chat-tray-badge {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  background: #e53e3e;
+  color: #fff;
+  font-size: 0.68rem;
+  font-weight: 700;
+  min-width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 4px;
+  border: 2px solid var(--color-surface, #FAF7EF);
+  line-height: 1;
+}
+
+/* Panel */
+.chat-tray-panel {
+  position: absolute;
+  bottom: calc(100% + 10px);
+  left: 0;
+  width: 320px;
+  background: var(--color-surface, #FAF7EF);
+  border: 1px solid var(--color-border);
+  border-radius: 14px;
+  box-shadow: 0 8px 32px rgba(0,0,0,0.15);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.chat-tray-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.8rem 1rem;
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-surface-alt, #f2ede3);
+}
+
+.chat-tray-title {
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: var(--color-text);
+}
+
+.chat-tray-view-all {
+  font-size: 0.8rem;
+  color: var(--color-primary);
+  text-decoration: none;
+}
+
+.chat-tray-view-all:hover {
+  text-decoration: underline;
+}
+
+.chat-tray-list {
+  max-height: 380px;
+  overflow-y: auto;
+}
+
+.chat-tray-status {
+  padding: 1.2rem 1rem;
+  font-size: 0.88rem;
+  color: var(--color-text-muted);
+  text-align: center;
+  margin: 0;
+}
+
+/* Thread row */
+.chat-tray-thread {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  width: 100%;
+  padding: 0.7rem 1rem;
+  background: none;
+  border: none;
+  border-bottom: 1px solid var(--color-border);
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.12s;
+}
+
+.chat-tray-thread:last-child {
+  border-bottom: none;
+}
+
+.chat-tray-thread:hover {
+  background: rgba(196, 82, 30, 0.06);
+}
+
+.chat-tray-avatar-wrap {
+  position: relative;
+  flex-shrink: 0;
+}
+
+.chat-tray-avatar {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: var(--color-primary);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
+.chat-tray-online {
+  position: absolute;
+  bottom: 1px;
+  right: 1px;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #38a169;
+  border: 2px solid var(--color-surface, #FAF7EF);
+}
+
+.chat-tray-thread-body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.chat-tray-thread-top {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.4rem;
+}
+
+.chat-tray-username {
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: var(--color-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.chat-tray-time {
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  flex-shrink: 0;
+}
+
+.chat-tray-thread-bottom {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.4rem;
+}
+
+.chat-tray-preview {
+  font-size: 0.82rem;
+  color: var(--color-text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+}
+
+.chat-tray-unread-badge {
+  flex-shrink: 0;
+  background: var(--color-primary);
+  color: #fff;
+  font-size: 0.68rem;
+  font-weight: 700;
+  min-width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 4px;
+}
+
+@media (max-width: 480px) {
+  .chat-tray {
+    bottom: 1rem;
+    left: 1rem;
+  }
+  .chat-tray-panel {
+    width: calc(100vw - 2rem);
+  }
+}

--- a/app/frontend/src/components/ChatTray.css
+++ b/app/frontend/src/components/ChatTray.css
@@ -6,8 +6,8 @@
   z-index: 900;
   display: flex;
   flex-direction: column;
-  align-items: stretch;
-  width: 300px;
+  align-items: flex-start;
+  width: fit-content;
 }
 
 /* ── Tab bar (always visible) ────────────────────────────────── */
@@ -15,7 +15,7 @@
   display: flex;
   align-items: center;
   gap: 0.55rem;
-  width: 100%;
+  width: fit-content;
   height: 44px;
   padding: 0 1rem;
   background: var(--color-surface-dark, #3d1500);
@@ -40,7 +40,6 @@
 .chat-tray-label {
   font-size: 0.88rem;
   font-weight: 600;
-  flex: 1;
   text-align: left;
 }
 
@@ -76,7 +75,7 @@
 
 /* ── Panel ───────────────────────────────────────────────────── */
 .chat-tray-panel {
-  width: 100%;
+  width: 300px;
   background: var(--color-surface, #FAF7EF);
   border: 1px solid var(--color-border);
   border-bottom: none;

--- a/app/frontend/src/components/ChatTray.jsx
+++ b/app/frontend/src/components/ChatTray.jsx
@@ -2,12 +2,12 @@ import { useContext, useState, useEffect, useRef, useCallback } from 'react';
 import { Link } from 'react-router-dom';
 import { ChatContext } from '../context/ChatContext';
 import { AuthContext } from '../context/AuthContext';
-import { fetchMessages, sendMessage, markThreadRead } from '../services/messageService';
+import { fetchMessages, sendMessage } from '../services/messageService';
 import './ChatTray.css';
 
 function relativeTime(isoString) {
   if (!isoString) return '';
-  const diff = Math.floor((Date.now() - new Date(isoString).getTime()) / 1000);
+  const diff = Math.max(0, Math.floor((Date.now() - new Date(isoString).getTime()) / 1000));
   if (diff < 60) return `${diff}s`;
   if (diff < 3600) return `${Math.floor(diff / 60)}m`;
   if (diff < 86400) return `${Math.floor(diff / 3600)}h`;
@@ -27,7 +27,6 @@ function ChatConversation({ thread, currentUser, onBack }) {
   const bottomRef = useRef(null);
 
   useEffect(() => {
-    markThreadRead(thread.id).catch(() => {});
     fetchMessages(thread.id)
       .then(setMessages)
       .catch(() => {});
@@ -37,15 +36,7 @@ function ChatConversation({ thread, currentUser, onBack }) {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages]);
 
-  const handleKeyDown = useCallback((e) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
-      e.preventDefault();
-      handleSend();
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [body]);
-
-  async function handleSend() {
+  const handleSend = useCallback(async () => {
     const trimmed = body.trim();
     if (!trimmed || sending) return;
     setSending(true);
@@ -58,7 +49,14 @@ function ChatConversation({ thread, currentUser, onBack }) {
     } finally {
       setSending(false);
     }
-  }
+  }, [body, sending, thread.id]);
+
+  const handleKeyDown = useCallback((e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  }, [handleSend]);
 
   return (
     <div className="chat-conv">

--- a/app/frontend/src/components/ChatTray.jsx
+++ b/app/frontend/src/components/ChatTray.jsx
@@ -1,0 +1,124 @@
+import { useContext, useState, useEffect, useRef } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { ChatContext } from '../context/ChatContext';
+import { AuthContext } from '../context/AuthContext';
+import './ChatTray.css';
+
+function relativeTime(isoString) {
+  if (!isoString) return '';
+  const diff = Math.floor((Date.now() - new Date(isoString).getTime()) / 1000);
+  if (diff < 60) return `${diff}s`;
+  if (diff < 3600) return `${Math.floor(diff / 60)}m`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h`;
+  return `${Math.floor(diff / 86400)}d`;
+}
+
+function isRecentlyActive(isoString) {
+  if (!isoString) return false;
+  return Date.now() - new Date(isoString).getTime() < 5 * 60 * 1000;
+}
+
+export default function ChatTray() {
+  const { user } = useContext(AuthContext);
+  const { threads, totalUnread, loading } = useContext(ChatContext);
+  const { markRead } = useContext(ChatContext);
+  const [open, setOpen] = useState(false);
+  const trayRef = useRef(null);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    function handleClickOutside(e) {
+      if (trayRef.current && !trayRef.current.contains(e.target)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  if (!user) return null;
+
+  const sorted = [...threads].sort((a, b) => {
+    const aTime = a.lastMessage?.createdAt ? new Date(a.lastMessage.createdAt).getTime() : 0;
+    const bTime = b.lastMessage?.createdAt ? new Date(b.lastMessage.createdAt).getTime() : 0;
+    return bTime - aTime;
+  });
+
+  function handleThreadClick(thread) {
+    markRead(thread.id);
+    setOpen(false);
+    navigate(`/inbox/${thread.id}`);
+  }
+
+  return (
+    <div className="chat-tray" ref={trayRef}>
+      {open && (
+        <div className="chat-tray-panel" role="dialog" aria-label="Messages">
+          <div className="chat-tray-header">
+            <span className="chat-tray-title">Messages</span>
+            <Link to="/inbox" className="chat-tray-view-all" onClick={() => setOpen(false)}>
+              View all →
+            </Link>
+          </div>
+
+          <div className="chat-tray-list">
+            {loading && threads.length === 0 && (
+              <p className="chat-tray-status">Loading…</p>
+            )}
+            {!loading && sorted.length === 0 && (
+              <p className="chat-tray-status">No conversations yet.</p>
+            )}
+            {sorted.map((thread) => {
+              const active = isRecentlyActive(thread.lastMessage?.createdAt);
+              const preview = thread.lastMessage?.body
+                ? thread.lastMessage.body.slice(0, 42) + (thread.lastMessage.body.length > 42 ? '…' : '')
+                : 'No messages yet';
+              return (
+                <button
+                  key={thread.id}
+                  type="button"
+                  className="chat-tray-thread"
+                  onClick={() => handleThreadClick(thread)}
+                >
+                  <div className="chat-tray-avatar-wrap">
+                    <span className="chat-tray-avatar">
+                      {thread.otherUser?.username?.[0]?.toUpperCase() ?? '?'}
+                    </span>
+                    {active && <span className="chat-tray-online" aria-label="Recently active" />}
+                  </div>
+                  <div className="chat-tray-thread-body">
+                    <div className="chat-tray-thread-top">
+                      <span className="chat-tray-username">@{thread.otherUser?.username}</span>
+                      <span className="chat-tray-time">{relativeTime(thread.lastMessage?.createdAt)}</span>
+                    </div>
+                    <div className="chat-tray-thread-bottom">
+                      <span className="chat-tray-preview">{preview}</span>
+                      {thread.unreadCount > 0 && (
+                        <span className="chat-tray-unread-badge">{thread.unreadCount}</span>
+                      )}
+                    </div>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      <button
+        type="button"
+        className="chat-tray-toggle"
+        onClick={() => setOpen((o) => !o)}
+        aria-label={`Messages${totalUnread > 0 ? `, ${totalUnread} unread` : ''}`}
+        aria-expanded={open}
+      >
+        <svg className="chat-tray-icon" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+          <path d="M20 2H4a2 2 0 0 0-2 2v18l4-4h14a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2z" />
+        </svg>
+        {totalUnread > 0 && (
+          <span className="chat-tray-badge">{totalUnread > 99 ? '99+' : totalUnread}</span>
+        )}
+      </button>
+    </div>
+  );
+}

--- a/app/frontend/src/components/ChatTray.jsx
+++ b/app/frontend/src/components/ChatTray.jsx
@@ -1,7 +1,8 @@
-import { useContext, useState, useEffect, useRef } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { useContext, useState, useEffect, useRef, useCallback } from 'react';
+import { Link } from 'react-router-dom';
 import { ChatContext } from '../context/ChatContext';
 import { AuthContext } from '../context/AuthContext';
+import { fetchMessages, sendMessage, markThreadRead } from '../services/messageService';
 import './ChatTray.css';
 
 function relativeTime(isoString) {
@@ -18,13 +19,103 @@ function isRecentlyActive(isoString) {
   return Date.now() - new Date(isoString).getTime() < 5 * 60 * 1000;
 }
 
+// ─── Mini chat view ───────────────────────────────────────────────────────────
+function ChatConversation({ thread, currentUser, onBack }) {
+  const [messages, setMessages] = useState([]);
+  const [body, setBody] = useState('');
+  const [sending, setSending] = useState(false);
+  const bottomRef = useRef(null);
+
+  useEffect(() => {
+    markThreadRead(thread.id).catch(() => {});
+    fetchMessages(thread.id)
+      .then(setMessages)
+      .catch(() => {});
+  }, [thread.id]);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
+  const handleKeyDown = useCallback((e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [body]);
+
+  async function handleSend() {
+    const trimmed = body.trim();
+    if (!trimmed || sending) return;
+    setSending(true);
+    setBody('');
+    try {
+      const msg = await sendMessage(thread.id, trimmed);
+      setMessages((prev) => [...prev, msg]);
+    } catch {
+      setBody(trimmed);
+    } finally {
+      setSending(false);
+    }
+  }
+
+  return (
+    <div className="chat-conv">
+      <div className="chat-conv-header">
+        <button type="button" className="chat-conv-back" onClick={onBack} aria-label="Back">
+          ←
+        </button>
+        <span className="chat-conv-username">@{thread.otherUser?.username}</span>
+      </div>
+
+      <div className="chat-conv-messages">
+        {messages.length === 0 && (
+          <p className="chat-conv-empty">No messages yet.</p>
+        )}
+        {messages.map((msg) => {
+          const isMe = msg.sender?.id === currentUser?.id;
+          return (
+            <div key={msg.id} className={`chat-msg${isMe ? ' chat-msg-me' : ''}`}>
+              <span className="chat-msg-body">{msg.body}</span>
+              <span className="chat-msg-time">{relativeTime(msg.createdAt)}</span>
+            </div>
+          );
+        })}
+        <div ref={bottomRef} />
+      </div>
+
+      <div className="chat-conv-input-row">
+        <textarea
+          className="chat-conv-input"
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="Message…"
+          rows={1}
+          disabled={sending}
+        />
+        <button
+          type="button"
+          className="chat-conv-send"
+          onClick={handleSend}
+          disabled={!body.trim() || sending}
+          aria-label="Send"
+        >
+          →
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ─── Main tray ────────────────────────────────────────────────────────────────
 export default function ChatTray() {
   const { user } = useContext(AuthContext);
-  const { threads, totalUnread, loading } = useContext(ChatContext);
-  const { markRead } = useContext(ChatContext);
+  const { threads, totalUnread, loading, markRead } = useContext(ChatContext);
   const [open, setOpen] = useState(false);
+  const [activeThread, setActiveThread] = useState(null);
   const trayRef = useRef(null);
-  const navigate = useNavigate();
 
   useEffect(() => {
     function handleClickOutside(e) {
@@ -39,86 +130,106 @@ export default function ChatTray() {
   if (!user) return null;
 
   const sorted = [...threads].sort((a, b) => {
-    const aTime = a.lastMessage?.createdAt ? new Date(a.lastMessage.createdAt).getTime() : 0;
-    const bTime = b.lastMessage?.createdAt ? new Date(b.lastMessage.createdAt).getTime() : 0;
-    return bTime - aTime;
+    const aT = a.lastMessage?.createdAt ? new Date(a.lastMessage.createdAt).getTime() : 0;
+    const bT = b.lastMessage?.createdAt ? new Date(b.lastMessage.createdAt).getTime() : 0;
+    return bT - aT;
   });
 
   function handleThreadClick(thread) {
     markRead(thread.id);
-    setOpen(false);
-    navigate(`/inbox/${thread.id}`);
+    setActiveThread(thread);
+  }
+
+  function handleToggle() {
+    setOpen((o) => {
+      if (o) setActiveThread(null);
+      return !o;
+    });
   }
 
   return (
     <div className="chat-tray" ref={trayRef}>
+
+      {/* Panel — yukarı açılır */}
       {open && (
         <div className="chat-tray-panel" role="dialog" aria-label="Messages">
-          <div className="chat-tray-header">
-            <span className="chat-tray-title">Messages</span>
-            <Link to="/inbox" className="chat-tray-view-all" onClick={() => setOpen(false)}>
-              View all →
-            </Link>
-          </div>
-
-          <div className="chat-tray-list">
-            {loading && threads.length === 0 && (
-              <p className="chat-tray-status">Loading…</p>
-            )}
-            {!loading && sorted.length === 0 && (
-              <p className="chat-tray-status">No conversations yet.</p>
-            )}
-            {sorted.map((thread) => {
-              const active = isRecentlyActive(thread.lastMessage?.createdAt);
-              const preview = thread.lastMessage?.body
-                ? thread.lastMessage.body.slice(0, 42) + (thread.lastMessage.body.length > 42 ? '…' : '')
-                : 'No messages yet';
-              return (
-                <button
-                  key={thread.id}
-                  type="button"
-                  className="chat-tray-thread"
-                  onClick={() => handleThreadClick(thread)}
-                >
-                  <div className="chat-tray-avatar-wrap">
-                    <span className="chat-tray-avatar">
-                      {thread.otherUser?.username?.[0]?.toUpperCase() ?? '?'}
-                    </span>
-                    {active && <span className="chat-tray-online" aria-label="Recently active" />}
-                  </div>
-                  <div className="chat-tray-thread-body">
-                    <div className="chat-tray-thread-top">
-                      <span className="chat-tray-username">@{thread.otherUser?.username}</span>
-                      <span className="chat-tray-time">{relativeTime(thread.lastMessage?.createdAt)}</span>
-                    </div>
-                    <div className="chat-tray-thread-bottom">
-                      <span className="chat-tray-preview">{preview}</span>
-                      {thread.unreadCount > 0 && (
-                        <span className="chat-tray-unread-badge">{thread.unreadCount}</span>
-                      )}
-                    </div>
-                  </div>
-                </button>
-              );
-            })}
-          </div>
+          {activeThread ? (
+            <ChatConversation
+              thread={activeThread}
+              currentUser={user}
+              onBack={() => setActiveThread(null)}
+            />
+          ) : (
+            <>
+              <div className="chat-tray-list">
+                {loading && sorted.length === 0 && (
+                  <p className="chat-tray-status">Loading…</p>
+                )}
+                {!loading && sorted.length === 0 && (
+                  <p className="chat-tray-status">No conversations yet.</p>
+                )}
+                {sorted.map((thread) => {
+                  const active = isRecentlyActive(thread.lastMessage?.createdAt);
+                  const preview = thread.lastMessage?.body
+                    ? thread.lastMessage.body.slice(0, 40) + (thread.lastMessage.body.length > 40 ? '…' : '')
+                    : 'No messages yet';
+                  return (
+                    <button
+                      key={thread.id}
+                      type="button"
+                      className="chat-tray-thread"
+                      onClick={() => handleThreadClick(thread)}
+                    >
+                      <div className="chat-tray-avatar-wrap">
+                        <span className="chat-tray-avatar">
+                          {thread.otherUser?.username?.[0]?.toUpperCase() ?? '?'}
+                        </span>
+                        {active && <span className="chat-tray-online" />}
+                      </div>
+                      <div className="chat-tray-thread-body">
+                        <div className="chat-tray-thread-top">
+                          <span className="chat-tray-uname">@{thread.otherUser?.username}</span>
+                          <span className="chat-tray-time">{relativeTime(thread.lastMessage?.createdAt)}</span>
+                        </div>
+                        <div className="chat-tray-thread-bottom">
+                          <span className="chat-tray-preview">{preview}</span>
+                          {thread.unreadCount > 0 && (
+                            <span className="chat-tray-unread">{thread.unreadCount}</span>
+                          )}
+                        </div>
+                      </div>
+                    </button>
+                  );
+                })}
+              </div>
+              <div className="chat-tray-footer">
+                <Link to="/inbox" className="chat-tray-viewall" onClick={() => setOpen(false)}>
+                  View all messages →
+                </Link>
+              </div>
+            </>
+          )}
         </div>
       )}
 
+      {/* Tab bar — her zaman görünür */}
       <button
         type="button"
-        className="chat-tray-toggle"
-        onClick={() => setOpen((o) => !o)}
-        aria-label={`Messages${totalUnread > 0 ? `, ${totalUnread} unread` : ''}`}
+        className="chat-tray-tab"
+        onClick={handleToggle}
         aria-expanded={open}
+        aria-label={`Messages${totalUnread > 0 ? `, ${totalUnread} unread` : ''}`}
       >
         <svg className="chat-tray-icon" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
           <path d="M20 2H4a2 2 0 0 0-2 2v18l4-4h14a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2z" />
         </svg>
+        <span className="chat-tray-label">Messages</span>
         {totalUnread > 0 && (
           <span className="chat-tray-badge">{totalUnread > 99 ? '99+' : totalUnread}</span>
         )}
+        <span className={`chat-tray-chevron${open ? ' open' : ''}`} aria-hidden="true" />
       </button>
+
     </div>
   );
 }

--- a/app/frontend/src/components/Navbar.jsx
+++ b/app/frontend/src/components/Navbar.jsx
@@ -112,13 +112,6 @@ export default function Navbar() {
                     >
                       New Story
                     </Link>
-                    <Link
-                      to="/inbox"
-                      className="navbar-dropdown-item"
-                      onClick={() => setMenuOpen(false)}
-                    >
-                      Inbox
-                    </Link>
                     <div className="navbar-dropdown-divider" />
                     <button
                       className="navbar-dropdown-item navbar-dropdown-logout"

--- a/app/frontend/src/context/ChatContext.jsx
+++ b/app/frontend/src/context/ChatContext.jsx
@@ -2,7 +2,13 @@ import { createContext, useContext, useEffect, useState, useCallback, useRef } f
 import { AuthContext } from './AuthContext';
 import { fetchThreads, markThreadRead } from '../services/messageService';
 
-export const ChatContext = createContext(null);
+export const ChatContext = createContext({
+  threads: [],
+  totalUnread: 0,
+  loading: false,
+  markRead: () => {},
+  refresh: () => {},
+});
 
 export function ChatProvider({ children }) {
   const { user } = useContext(AuthContext);

--- a/app/frontend/src/context/ChatContext.jsx
+++ b/app/frontend/src/context/ChatContext.jsx
@@ -1,0 +1,49 @@
+import { createContext, useContext, useEffect, useState, useCallback, useRef } from 'react';
+import { AuthContext } from './AuthContext';
+import { fetchThreads, markThreadRead } from '../services/messageService';
+
+export const ChatContext = createContext(null);
+
+export function ChatProvider({ children }) {
+  const { user } = useContext(AuthContext);
+  const [threads, setThreads] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const intervalRef = useRef(null);
+
+  const totalUnread = threads.reduce((sum, t) => sum + (t.unreadCount || 0), 0);
+
+  const refresh = useCallback(() => {
+    if (!user) return;
+    fetchThreads()
+      .then(setThreads)
+      .catch(() => {});
+  }, [user]);
+
+  useEffect(() => {
+    if (!user) {
+      setThreads([]);
+      return;
+    }
+    setLoading(true);
+    fetchThreads()
+      .then(setThreads)
+      .catch(() => {})
+      .finally(() => setLoading(false));
+
+    intervalRef.current = setInterval(refresh, 30000);
+    return () => clearInterval(intervalRef.current);
+  }, [user, refresh]);
+
+  function markRead(threadId) {
+    setThreads((prev) =>
+      prev.map((t) => t.id === threadId ? { ...t, unreadCount: 0 } : t)
+    );
+    markThreadRead(threadId).catch(() => {});
+  }
+
+  return (
+    <ChatContext.Provider value={{ threads, totalUnread, loading, markRead, refresh }}>
+      {children}
+    </ChatContext.Provider>
+  );
+}

--- a/app/frontend/src/index.js
+++ b/app/frontend/src/index.js
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { AuthProvider } from './context/AuthContext';
 import { NotificationProvider } from './context/NotificationContext';
+import { ChatProvider } from './context/ChatContext';
 import App from './App';
 import './index.css';
 
@@ -12,7 +13,9 @@ root.render(
     <BrowserRouter>
       <AuthProvider>
         <NotificationProvider>
-          <App />
+          <ChatProvider>
+            <App />
+          </ChatProvider>
         </NotificationProvider>
       </AuthProvider>
     </BrowserRouter>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,7 @@ services:
       context: ./app/frontend
       args:
         REACT_APP_API_URL: ${REACT_APP_API_URL:-http://localhost}
+        REACT_APP_USE_MOCK: "false"
     ports:
       - "80:80"
     volumes:


### PR DESCRIPTION
## Summary

- **Chat tray**: Fixed to the bottom-left corner, always visible as a compact tab bar (💬 Messages + unread badge + chevron). Only shown when logged in.
- **Thread list**: Clicking the tab opens a panel upward showing recent conversations sorted by last message. Each row shows avatar, username, last message preview, relative time, unread count, and a green dot if the last message was within 5 minutes.
- **Inline mini chat**: Clicking a thread opens a mini chat window directly in the tray — no navigation to `/inbox`. Shows message history, send input (Enter to send / Shift+Enter for newline), and a back button to return to the thread list.
- **ChatContext**: Fetches threads on mount and polls every 30 seconds for new messages.
- **Navbar**: Removed "Inbox" from the dropdown — the chat tray replaces it.

## Test plan
- [ ] Login → compact "💬 Messages" tab visible at bottom-left
- [ ] Logout → tab disappears
- [ ] Click tab → thread list opens upward; click again → closes
- [ ] Unread messages → red badge on tab and on the thread row
- [ ] Click a thread → mini chat opens inside the tray, messages load
- [ ] Send a message → appears in the chat immediately
- [ ] Back button → returns to thread list
- [ ] "View all messages →" → navigates to `/inbox`
- [ ] Click outside the panel → closes
- [ ] Navbar dropdown no longer shows "Inbox"