### PR TITLE
feat(mobile): endangered heritage badge + sourced notes on recipe detail (#507)

### DIFF
--- a/app/mobile/src/components/heritage/EndangeredHeritageSection.tsx
+++ b/app/mobile/src/components/heritage/EndangeredHeritageSection.tsx
@@ -1,0 +1,180 @@
+import React from 'react';
+import { Linking, Pressable, StyleSheet, Text, View } from 'react-native';
+import { shadows, tokens } from '../../theme';
+
+export type HeritageStatus = 'none' | 'endangered' | 'preserved' | 'revived' | string | null | undefined;
+
+type EndangeredNote = {
+  id: number;
+  text: string;
+  source_url: string;
+};
+
+type Props = {
+  status: HeritageStatus;
+  notes: EndangeredNote[];
+};
+
+type Treatment = {
+  emoji: string;
+  label: string;
+  blurb: string;
+  badgeBg: string;
+  badgeText: string;
+};
+
+const TREATMENT: Record<string, Treatment> = {
+  endangered: {
+    emoji: '⚠️',
+    label: 'ENDANGERED',
+    blurb: 'This recipe is at risk of being lost. Cooks, source it, share it, keep it on the table.',
+    badgeBg: '#DC2626',
+    badgeText: '#FFFFFF',
+  },
+  preserved: {
+    emoji: '🛡',
+    label: 'PRESERVED',
+    blurb: 'A heritage recipe actively kept alive by its community.',
+    badgeBg: tokens.colors.accentGreen,
+    badgeText: tokens.colors.textOnDark,
+  },
+  revived: {
+    emoji: '🌱',
+    label: 'REVIVED',
+    blurb: 'Once nearly lost — now coming back through deliberate revival.',
+    badgeBg: tokens.colors.accentMustard,
+    badgeText: tokens.colors.surfaceDark,
+  },
+};
+
+/** Renders the endangered-heritage badge and sourced notes (#507, #524). Returns
+ * null when there's nothing meaningful to show (status is 'none' or missing
+ * AND no notes are attached). */
+export function EndangeredHeritageSection({ status, notes }: Props) {
+  const treatment = status && status !== 'none' ? TREATMENT[status] : undefined;
+  const hasStatus = !!treatment;
+  const hasNotes = Array.isArray(notes) && notes.length > 0;
+  if (!hasStatus && !hasNotes) return null;
+
+  const onPressSource = (url: string) => {
+    if (!url) return;
+    Linking.openURL(url).catch(() => undefined);
+  };
+
+  return (
+    <View style={styles.section} accessibilityLabel="Endangered heritage status">
+      {hasStatus ? (
+        <View style={[styles.statusCard, { borderColor: treatment.badgeBg }]}>
+          <View style={[styles.badge, { backgroundColor: treatment.badgeBg }]}>
+            <Text style={styles.badgeEmoji}>{treatment.emoji}</Text>
+            <Text style={[styles.badgeLabel, { color: treatment.badgeText }]}>{treatment.label}</Text>
+          </View>
+          <Text style={styles.blurb}>{treatment.blurb}</Text>
+        </View>
+      ) : null}
+
+      {hasNotes ? (
+        <View style={styles.notes}>
+          <Text style={styles.notesHeading}>Sourced notes</Text>
+          {notes.map((note) => (
+            <View key={note.id} style={styles.noteCard}>
+              <Text style={styles.noteText}>{note.text}</Text>
+              {note.source_url ? (
+                <Pressable
+                  onPress={() => onPressSource(note.source_url)}
+                  style={({ pressed }) => [styles.sourcePill, pressed && styles.pressed]}
+                  accessibilityRole="link"
+                  accessibilityLabel="Open source link"
+                  hitSlop={10}
+                >
+                  <Text style={styles.sourcePillText}>Source ↗</Text>
+                </Pressable>
+              ) : null}
+            </View>
+          ))}
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  section: {
+    marginTop: 28,
+    paddingTop: 16,
+    borderTopWidth: 1,
+    borderTopColor: tokens.colors.surfaceDark,
+    gap: 14,
+  },
+  statusCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 14,
+    padding: 14,
+    borderRadius: tokens.radius.lg,
+    backgroundColor: tokens.colors.bg,
+    borderWidth: 2,
+    ...shadows.sm,
+  },
+  badge: {
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: tokens.radius.sm,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  badgeEmoji: { fontSize: 16 },
+  badgeLabel: {
+    fontSize: 12,
+    fontWeight: '900',
+    letterSpacing: 1.2,
+  },
+  blurb: {
+    flex: 1,
+    fontSize: 13,
+    color: tokens.colors.text,
+    lineHeight: 18,
+    fontWeight: '600',
+  },
+  notes: { gap: 10 },
+  notesHeading: {
+    fontSize: 12,
+    fontWeight: '900',
+    color: tokens.colors.textMuted,
+    letterSpacing: 1.2,
+  },
+  noteCard: {
+    padding: 12,
+    borderRadius: tokens.radius.lg,
+    backgroundColor: tokens.colors.bg,
+    borderLeftWidth: 4,
+    borderLeftColor: tokens.colors.surfaceDark,
+    borderTopWidth: 1,
+    borderRightWidth: 1,
+    borderBottomWidth: 1,
+    borderTopColor: tokens.colors.surfaceDark,
+    borderRightColor: tokens.colors.surfaceDark,
+    borderBottomColor: tokens.colors.surfaceDark,
+    gap: 8,
+  },
+  noteText: {
+    fontSize: 13,
+    color: tokens.colors.text,
+    lineHeight: 19,
+  },
+  sourcePill: {
+    alignSelf: 'flex-start',
+    paddingVertical: 4,
+    paddingHorizontal: 10,
+    borderRadius: tokens.radius.pill,
+    backgroundColor: tokens.colors.surfaceDark,
+  },
+  sourcePillText: {
+    fontSize: 11,
+    fontWeight: '800',
+    color: '#FFE066',
+    letterSpacing: 0.3,
+  },
+  pressed: { opacity: 0.85 },
+});

--- a/app/mobile/src/screens/RecipeDetailScreen.tsx
+++ b/app/mobile/src/screens/RecipeDetailScreen.tsx
@@ -10,6 +10,7 @@ import { ErrorView } from '../components/ui/ErrorView';
 import { LoadingView } from '../components/ui/LoadingView';
 import { IngredientSubstitutesSheet } from '../components/recipe/IngredientSubstitutesSheet';
 import { LinkedStoryPreviewCard } from '../components/recipe/LinkedStoryPreviewCard';
+import { EndangeredHeritageSection } from '../components/heritage/EndangeredHeritageSection';
 import { HeritageBadge } from '../components/heritage/HeritageBadge';
 import { RecipeCommentsSection } from '../components/recipe/RecipeCommentsSection';
 import { DidYouKnowSection } from '../components/cultural/DidYouKnowSection';
@@ -480,6 +481,11 @@ export default function RecipeDetailScreen({ route, navigation }: Props) {
               ) : null}
             </View>
           ) : null}
+
+          <EndangeredHeritageSection
+            status={recipe.heritage_status}
+            notes={recipe.endangered_notes ?? []}
+          />
 
           <DidYouKnowSection facts={culturalFacts} />
 

--- a/app/mobile/src/types/recipe.ts
+++ b/app/mobile/src/types/recipe.ts
@@ -27,4 +27,13 @@ export type RecipeDetail = {
   rank_reason?: string | null;
   /** Heritage group surfaced by backend serializer when the recipe is grouped. */
   heritage_group?: { id: number; name: string } | null;
+  /** Endangered-heritage status (#507/#524): one of 'none' | 'endangered' | 'preserved' | 'revived'. */
+  heritage_status?: 'none' | 'endangered' | 'preserved' | 'revived' | string | null;
+  /** Sourced notes attached to a recipe's endangered-heritage status. */
+  endangered_notes?: Array<{
+    id: number;
+    text: string;
+    source_url: string;
+    created_at?: string;
+  }>;
 };


### PR DESCRIPTION
## Summary
Closes #507 (mobile portion). Surfaces the `Recipe.heritage_status` enum (#524) and the attached `endangered_notes` on the recipe detail screen. Recipes flagged endangered / preserved / revived now show a coloured status badge with a one-line "what this means" blurb and a stack of sourced notes (each linkable to its citation).

## Files
- **New** `components/heritage/EndangeredHeritageSection.tsx` — single section that handles the badge + notes list. Three status treatments:
  - **ENDANGERED** — red `#DC2626` badge with ⚠️, blurb urging cooks to source it
  - **PRESERVED** — green `accentGreen` badge with 🛡, blurb on active community keeping
  - **REVIVED** — mustard badge with 🌱, blurb on deliberate revival
  - Returns `null` when status is `'none'` (or an unknown value) AND no notes exist, so it's invisible on regular recipes.
- `types/recipe.ts` — added `heritage_status` (`'none' | 'endangered' | 'preserved' | 'revived'`) and `endangered_notes` array (`{id, text, source_url, created_at?}`).
- `screens/RecipeDetailScreen.tsx` — renders `<EndangeredHeritageSection>` between the shopping list / `<DidYouKnowSection>` and the comments. Reads both new fields directly off the `recipe` object the backend already serializes.

## Note design
Each note is a small card with a thick dark left edge (quote/citation feel), the prose text, and an optional Source pill (dark fill + mustard `#FFE066` text) that opens the source URL via `Linking.openURL`. Notes without a `source_url` hide the pill cleanly.

## Test
- `npx tsc --noEmit` clean
- **API contract** verified end-to-end:
  - Recipe #1 → `heritage_status: 'endangered'`, 2 notes both with source URLs
  - Recipe #3 → `heritage_status: 'preserved'`, 0 notes
  - Recipe #2 → `heritage_status: 'none'`, 0 notes (default)
  - Recipe #5 (seeded for QA) → `heritage_status: 'revived'`, 1 note with no source URL
- **Render decision tree** simulated across 6 cases including defensive ones (null status, unknown status string, notes-only). All hide / show as designed; no crash paths.
- Live: opened recipe #1 → red ⚠️ ENDANGERED badge + 2 sourced notes, Source pills opened the URLs. Opened recipe #3 → green 🛡 PRESERVED badge, no notes section. Opened a normal recipe → section invisible.

## Out of scope / followups
- **Authoring UI**: no way to set `heritage_status` or add `endangered_notes` from the mobile edit form yet. Curators set them via Django admin / direct seed; can become a follow-up when scoped.
- **Backend write endpoint for notes**: `EndangeredNoteSerializer` exists but no router endpoint registered. Filing nothing; can become a future ticket when authoring UI lands.

Closes #507 (mobile)