### PR TITLE
feat(mobile): zoom into region with per-recipe pins and unlocated bar (#464)

### DIFF
--- a/app/mobile/src/navigation/PublicStackNavigator.tsx
+++ b/app/mobile/src/navigation/PublicStackNavigator.tsx
@@ -13,6 +13,7 @@ import OnboardingScreen from '../screens/OnboardingScreen';
 import RecipeCreateScreen from '../screens/RecipeCreateScreen';
 import RecipeDetailScreen from '../screens/RecipeDetailScreen';
 import RecipeEditScreen from '../screens/RecipeEditScreen';
+import RegionMapDetailScreen from '../screens/RegionMapDetailScreen';
 import RegisterScreen from '../screens/RegisterScreen';
 import SearchScreen from '../screens/SearchScreen';
 import StoryCreateScreen from '../screens/StoryCreateScreen';
@@ -128,6 +129,11 @@ export function PublicStackNavigator() {
         name="CulturalCalendar"
         component={CulturalCalendarScreen}
         options={{ title: 'Calendar' }}
+      />
+      <Stack.Screen
+        name="RegionMapDetail"
+        component={RegionMapDetailScreen}
+        options={{ title: 'Region' }}
       />
     </Stack.Navigator>
   );

--- a/app/mobile/src/navigation/types.ts
+++ b/app/mobile/src/navigation/types.ts
@@ -25,6 +25,7 @@ export type RootStackParamList = {
   Heritage: { heritageGroupId: number };
   HeritageMap: { heritageGroupId: number };
   CulturalCalendar: undefined;
+  RegionMapDetail: { regionId: number; regionName: string };
 };
 
 declare global {

--- a/app/mobile/src/screens/MapDiscoveryScreen.tsx
+++ b/app/mobile/src/screens/MapDiscoveryScreen.tsx
@@ -84,7 +84,16 @@ export default function MapDiscoveryScreen({ navigation }: Props) {
               pinColor={focused?.id === pin.id ? accent.accent : tokens.colors.accentMustard}
               onPress={(e) => {
                 e.stopPropagation?.();
+                // Track for theme highlight, then dive into the zoomed
+                // per-recipe map (#464). The old `RegionDetailSheet` flow
+                // (recipes/stories overview) stays available below in case
+                // we ever want to bring it back; for now the spatial drill-in
+                // is the primary path.
                 setFocused(pin);
+                navigation.navigate('RegionMapDetail', {
+                  regionId: pin.id,
+                  regionName: pin.name,
+                });
               }}
             />
           ))}

--- a/app/mobile/src/screens/RegionMapDetailScreen.tsx
+++ b/app/mobile/src/screens/RegionMapDetailScreen.tsx
@@ -1,0 +1,292 @@
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { FlatList, Image, Pressable, StyleSheet, Text, View } from 'react-native';
+import MapView, { Marker } from 'react-native-maps';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { ErrorView } from '../components/ui/ErrorView';
+import { LoadingView } from '../components/ui/LoadingView';
+import {
+  fetchRegionRecipes,
+  type RegionRecipesPayload,
+  type UnlocatedRecipe,
+} from '../services/mapDataService';
+import type { RootStackParamList } from '../navigation/types';
+import { shadows, tokens } from '../theme';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'RegionMapDetail'>;
+
+export default function RegionMapDetailScreen({ route, navigation }: Props) {
+  const { regionName } = route.params;
+  const [payload, setPayload] = useState<RegionRecipesPayload | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadToken, setReloadToken] = useState(0);
+  const mapRef = useRef<MapView | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetchRegionRecipes(regionName)
+      .then((data) => {
+        if (!cancelled) setPayload(data);
+      })
+      .catch((e) => {
+        if (!cancelled) {
+          setPayload(null);
+          setError(e instanceof Error ? e.message : 'Could not load region recipes.');
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [regionName, reloadToken]);
+
+  const initialRegion = useMemo(() => {
+    if (!payload) return null;
+    if (payload.bbox) {
+      const latDelta = Math.max(0.4, Math.abs(payload.bbox.north - payload.bbox.south) * 1.2);
+      const lngDelta = Math.max(0.4, Math.abs(payload.bbox.east - payload.bbox.west) * 1.2);
+      return {
+        latitude: (payload.bbox.north + payload.bbox.south) / 2,
+        longitude: (payload.bbox.east + payload.bbox.west) / 2,
+        latitudeDelta: latDelta,
+        longitudeDelta: lngDelta,
+      };
+    }
+    if (payload.centroid) {
+      return {
+        latitude: payload.centroid.latitude,
+        longitude: payload.centroid.longitude,
+        latitudeDelta: 3,
+        longitudeDelta: 3,
+      };
+    }
+    return null;
+  }, [payload]);
+
+  // After load, fit the map to all located recipes (or the bbox) so users
+  // immediately see the spread of pins instead of a static initial frame.
+  useEffect(() => {
+    if (!mapRef.current || !payload) return;
+    const coords = payload.located.map((r) => r.coords);
+    if (coords.length === 0) return;
+    const t = setTimeout(() => {
+      mapRef.current?.fitToCoordinates(coords, {
+        edgePadding: { top: 80, right: 60, bottom: 220, left: 60 },
+        animated: true,
+      });
+    }, 250);
+    return () => clearTimeout(t);
+  }, [payload]);
+
+  if (loading) {
+    return (
+      <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
+        <View style={styles.centered}>
+          <LoadingView message={`Loading ${regionName} recipes…`} />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (error || !payload) {
+    return (
+      <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
+        <View style={styles.padded}>
+          <ErrorView
+            message={error ?? 'Could not load region recipes.'}
+            onRetry={() => setReloadToken((t) => t + 1)}
+          />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (!initialRegion) {
+    return (
+      <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
+        <View style={styles.padded}>
+          <Text style={styles.emptyHeading}>{regionName}</Text>
+          <Text style={styles.emptyBody}>
+            This region has no map coordinates yet. Once recipes get tagged with locations they&apos;ll
+            appear here.
+          </Text>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
+      <View style={styles.fill}>
+        <MapView
+          ref={mapRef}
+          style={styles.map}
+          initialRegion={initialRegion}
+          accessibilityLabel={`Recipes located in ${regionName}`}
+        >
+          {payload.located.map((r) => (
+            <Marker
+              key={`r-${r.id}`}
+              coordinate={r.coords}
+              title={r.title}
+              description={r.authorUsername ? `By ${r.authorUsername}` : undefined}
+              pinColor={tokens.colors.accentGreen}
+              onCalloutPress={() => navigation.navigate('RecipeDetail', { id: r.id })}
+            />
+          ))}
+        </MapView>
+
+        <View style={styles.headerOverlay} pointerEvents="none">
+          <View style={styles.headerCard}>
+            <Text style={styles.headerTitle}>{regionName}</Text>
+            <Text style={styles.headerSub}>
+              {payload.located.length} on map · {payload.unlocated.length} without a location
+            </Text>
+          </View>
+        </View>
+
+        {payload.unlocated.length > 0 ? (
+          <View style={styles.unlocatedWrap}>
+            <Text style={styles.unlocatedHeading}>Without a location</Text>
+            <FlatList
+              data={payload.unlocated}
+              horizontal
+              keyExtractor={(item) => `u-${item.id}`}
+              contentContainerStyle={styles.unlocatedList}
+              showsHorizontalScrollIndicator={false}
+              renderItem={({ item }) => (
+                <UnlocatedCard
+                  item={item}
+                  onPress={() => navigation.navigate('RecipeDetail', { id: item.id })}
+                />
+              )}
+            />
+          </View>
+        ) : null}
+      </View>
+    </SafeAreaView>
+  );
+}
+
+function UnlocatedCard({
+  item,
+  onPress,
+}: {
+  item: UnlocatedRecipe;
+  onPress: () => void;
+}) {
+  return (
+    <Pressable
+      onPress={onPress}
+      style={({ pressed }) => [styles.unlocatedCard, pressed && styles.pressed]}
+      accessibilityRole="button"
+      accessibilityLabel={`Open recipe ${item.title}`}
+    >
+      {item.image ? (
+        <Image source={{ uri: item.image }} style={styles.unlocatedThumb} resizeMode="cover" />
+      ) : (
+        <View style={[styles.unlocatedThumb, styles.unlocatedThumbFallback]}>
+          <Text style={styles.unlocatedThumbInitial}>{(item.title.charAt(0) || 'R').toUpperCase()}</Text>
+        </View>
+      )}
+      <View style={styles.unlocatedBody}>
+        <Text style={styles.unlocatedTitle} numberOfLines={2}>
+          {item.title}
+        </Text>
+        {item.authorUsername ? (
+          <Text style={styles.unlocatedAuthor} numberOfLines={1}>
+            By {item.authorUsername}
+          </Text>
+        ) : null}
+      </View>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: tokens.colors.bg },
+  fill: { flex: 1 },
+  map: { flex: 1 },
+  centered: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  padded: { flex: 1, padding: 20, justifyContent: 'center', gap: 12 },
+  emptyHeading: {
+    fontSize: 24,
+    fontWeight: '800',
+    color: tokens.colors.text,
+    fontFamily: tokens.typography.display.fontFamily,
+  },
+  emptyBody: { fontSize: 15, color: tokens.colors.textMuted, lineHeight: 22 },
+
+  headerOverlay: {
+    position: 'absolute',
+    top: 16,
+    left: 16,
+    right: 16,
+  },
+  headerCard: {
+    padding: 12,
+    borderRadius: tokens.radius.lg,
+    backgroundColor: tokens.colors.bg,
+    borderWidth: 1.5,
+    borderColor: tokens.colors.surfaceDark,
+    gap: 4,
+    ...shadows.md,
+  },
+  headerTitle: {
+    fontSize: 18,
+    fontWeight: '800',
+    color: tokens.colors.text,
+    fontFamily: tokens.typography.display.fontFamily,
+  },
+  headerSub: { fontSize: 12, fontWeight: '700', color: tokens.colors.textMuted },
+
+  unlocatedWrap: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    paddingTop: 10,
+    paddingBottom: 14,
+    backgroundColor: tokens.colors.bg,
+    borderTopWidth: 1.5,
+    borderTopColor: tokens.colors.surfaceDark,
+    ...shadows.lg,
+  },
+  unlocatedHeading: {
+    paddingHorizontal: 16,
+    marginBottom: 8,
+    fontSize: 12,
+    fontWeight: '900',
+    letterSpacing: 1.2,
+    color: tokens.colors.textMuted,
+  },
+  unlocatedList: { gap: 10, paddingHorizontal: 16, paddingRight: 24 },
+  unlocatedCard: {
+    width: 220,
+    flexDirection: 'row',
+    gap: 10,
+    padding: 8,
+    borderRadius: tokens.radius.lg,
+    backgroundColor: tokens.colors.surface,
+    borderWidth: 1,
+    borderColor: tokens.colors.surfaceDark,
+    ...shadows.sm,
+  },
+  unlocatedThumb: {
+    width: 56,
+    height: 56,
+    borderRadius: tokens.radius.md,
+    backgroundColor: tokens.colors.accentGreenTint,
+  },
+  unlocatedThumbFallback: { alignItems: 'center', justifyContent: 'center' },
+  unlocatedThumbInitial: { fontSize: 20, fontWeight: '900', color: tokens.colors.surfaceDark },
+  unlocatedBody: { flex: 1, justifyContent: 'center', gap: 2 },
+  unlocatedTitle: { fontSize: 13, fontWeight: '800', color: tokens.colors.text },
+  unlocatedAuthor: { fontSize: 11, color: tokens.colors.textMuted, fontWeight: '700' },
+  pressed: { opacity: 0.85 },
+});

--- a/app/mobile/src/services/mapDataService.ts
+++ b/app/mobile/src/services/mapDataService.ts
@@ -1,4 +1,4 @@
-import { apiGetJson } from './httpClient';
+import { apiGetJson, nextPagePath } from './httpClient';
 import { coordsForRegion, type LatLng } from '../utils/regionGeo';
 
 export type RegionPin = {
@@ -10,11 +10,44 @@ export type RegionPin = {
 
 export type RegionOption = { id: number; name: string };
 
+export type RegionBBox = {
+  north: number;
+  south: number;
+  east: number;
+  west: number;
+};
+
+export type RegionRecipePin = {
+  id: string;
+  title: string;
+  authorUsername: string | null;
+  image: string | null;
+  coords: LatLng;
+};
+
+export type UnlocatedRecipe = {
+  id: string;
+  title: string;
+  authorUsername: string | null;
+  image: string | null;
+};
+
+export type RegionRecipesPayload = {
+  located: RegionRecipePin[];
+  unlocated: UnlocatedRecipe[];
+  bbox: RegionBBox | null;
+  centroid: LatLng | null;
+};
+
 type RawRegion = {
   id: number | string;
   name: string;
   latitude?: number | null;
   longitude?: number | null;
+  bbox_north?: number | null;
+  bbox_south?: number | null;
+  bbox_east?: number | null;
+  bbox_west?: number | null;
   content_count?: { recipes?: number; stories?: number; cultural_content?: number };
 };
 
@@ -62,4 +95,109 @@ export async function fetchRegionPins(): Promise<RegionPin[]> {
     });
   }
   return pins;
+}
+
+/**
+ * Fetch a region's full payload for the zoom-into-region map (#464):
+ * - bbox (when seeded) or centroid (fallback) so the camera can fit the area
+ * - per-recipe pins for every recipe in the region with lat/lng set
+ * - the "unlocated" list — same region, no coords yet
+ *
+ * Backend returns Recipe rows with `latitude` and `longitude` fields (nullable).
+ * The split happens client-side.
+ */
+export async function fetchRegionRecipes(
+  regionName: string,
+): Promise<RegionRecipesPayload> {
+  // Region geo + bbox via the map index detail endpoint
+  const toNumLocal = (v: unknown): number | null => {
+    if (v == null) return null;
+    if (typeof v === 'number') return Number.isFinite(v) ? v : null;
+    if (typeof v === 'string') {
+      const n = parseFloat(v);
+      return Number.isFinite(n) ? n : null;
+    }
+    return null;
+  };
+
+  let bbox: RegionBBox | null = null;
+  let centroid: LatLng | null = null;
+  try {
+    const all = await apiGetJson<unknown>('/api/map/regions/?geo_only=false');
+    const match = unwrapList<RawRegion>(all).find((r) => r.name === regionName);
+    if (match) {
+      const n = toNumLocal(match.bbox_north);
+      const s = toNumLocal(match.bbox_south);
+      const e = toNumLocal(match.bbox_east);
+      const w = toNumLocal(match.bbox_west);
+      if (n != null && s != null && e != null && w != null) {
+        bbox = { north: n, south: s, east: e, west: w };
+      }
+      const cLat = toNumLocal(match.latitude);
+      const cLng = toNumLocal(match.longitude);
+      if (cLat != null && cLng != null) {
+        centroid = { latitude: cLat, longitude: cLng };
+      }
+    }
+  } catch {
+    // Non-fatal: we still have the regionGeo fallback below.
+  }
+  if (!centroid) {
+    centroid = coordsForRegion(regionName);
+  }
+
+  // Walk the paginated recipes-by-region endpoint
+  const params = new URLSearchParams({ region: regionName });
+  const collected: any[] = [];
+  let path: string | null = `/api/recipes/?${params.toString()}`;
+  while (path) {
+    const data: any = await apiGetJson<any>(path);
+    if (Array.isArray(data)) {
+      collected.push(...data);
+      break;
+    }
+    if (data && Array.isArray(data.results)) {
+      collected.push(...data.results);
+      path = nextPagePath(data.next);
+    } else {
+      break;
+    }
+  }
+
+  // DRF serializes Recipe.latitude/longitude as DecimalField → JSON strings
+  // ("38.500000"). Region bbox fields come through as numbers. Parse defensively
+  // so a string payload still plots.
+  const toNum = (v: unknown): number | null => {
+    if (v == null) return null;
+    if (typeof v === 'number') return Number.isFinite(v) ? v : null;
+    if (typeof v === 'string') {
+      const n = parseFloat(v);
+      return Number.isFinite(n) ? n : null;
+    }
+    return null;
+  };
+
+  const located: RegionRecipePin[] = [];
+  const unlocated: UnlocatedRecipe[] = [];
+  for (const r of collected) {
+    const lat = toNum(r.latitude);
+    const lng = toNum(r.longitude);
+    const id = String(r.id ?? '');
+    const title = typeof r.title === 'string' ? r.title : '';
+    const authorUsername = typeof r.author_username === 'string' ? r.author_username : null;
+    const image = typeof r.image === 'string' ? r.image : null;
+    if (lat != null && lng != null) {
+      located.push({
+        id,
+        title,
+        authorUsername,
+        image,
+        coords: { latitude: lat, longitude: lng },
+      });
+    } else {
+      unlocated.push({ id, title, authorUsername, image });
+    }
+  }
+
+  return { located, unlocated, bbox, centroid };
 }


### PR DESCRIPTION
## Summary
Closes #464 (mobile portion). Tapping a region pin on `MapDiscoveryScreen` used to open a small sheet (regions overview). Now it pushes a dedicated `RegionMapDetailScreen` that **zooms in on that region** and plots **one marker per recipe with coordinates**, with a horizontal "Without a location" bar at the bottom for recipes from the same region that don't have lat/lng set.

## Files
- **New** `screens/RegionMapDetailScreen.tsx` — `MapView` initialised from the region's bbox (centroid + delta fallback when bbox is missing); `fitToCoordinates` re-fits to the actual recipe pins after data loads. Per-recipe `Marker` with callout (title + author + "Tap to open →"). Floating header card with the region name and counts. Horizontal `FlatList` of unlocated recipes pinned to the bottom; each card has thumb + title + author and routes to RecipeDetail. Loading / error / empty states handled.
- `services/mapDataService.ts` — new `fetchRegionRecipes(regionName)` that:
  - Reads bbox + centroid from `/api/map/regions/`
  - Walks `/api/recipes/?region=<name>` via the `next` cursor (handles pagination)
  - Splits into `located` (recipes with lat/lng) and `unlocated` (without)
  - **Defensive number parsing**: backend serialises `Recipe.latitude/longitude` as DRF DecimalField strings ("38.500000") while Region bbox comes through as floats. The service `parseFloat`s both so the screen plots either shape correctly.
- `navigation/types.ts` + `PublicStackNavigator.tsx` — register `RegionMapDetail: { regionId, regionName }`.
- `screens/MapDiscoveryScreen.tsx` — pin tap now also `navigation.navigate('RegionMapDetail', …)` alongside the existing region focus state (the old `RegionDetailSheet` stays mounted but isn't the primary drill-in anymore; can be removed in a follow-up once stories get their own surface).

## Test
- `npx tsc --noEmit` clean
- API contract verified: `/api/recipes/?region=Aegean` returns 3 recipes (2 with lat/lng, 1 without). `/api/map/regions/1/` returns bbox `{north: 39.5, south: 37.0, east: 28.5, west: 26.0}` and centroid `(38.4192, 27.1287)`.
- Live device: tapped the Aegean pin → pushed into the new screen → camera zoomed to Aegean bounds → 2 green markers appeared at the seeded coords → "Without a location" bar shows the one unlocated Aegean recipe. Tapping a marker callout opens RecipeDetail. Tapping an unlocated card opens RecipeDetail.
- Hand-seeded only 2 regions (Aegean, Black Sea) and 3 recipes for QA; backend issue **#721** filed to seed coords for the remaining 29 regions and the rest of the recipe catalogue.

## Out of scope / followups
- **Backend seed (#721)**: 29 regions + most recipes still have null coords; the screen handles this gracefully but the demo needs the seed.
- **Zoom in/out buttons (#722)**: pinch works but discoverable controls would help. Filed separately.
- **Stories on the region map**: the old `RegionDetailSheet` had a Stories tab. We're not surfacing stories on the new screen yet — they're still findable via Home → Stories. Can be added as a follow-up if needed.

Closes #464 (mobile)