### PR TITLE
feat(mobile): add zoom in/out controls to map screens (#722)

### DIFF
--- a/app/mobile/src/components/map/MapZoomControls.tsx
+++ b/app/mobile/src/components/map/MapZoomControls.tsx
@@ -1,0 +1,133 @@
+import React, { useCallback } from 'react';
+import { Pressable, StyleSheet, Text, View, type StyleProp, type ViewStyle } from 'react-native';
+import type MapView from 'react-native-maps';
+import { shadows, tokens } from '../../theme';
+
+type Props = {
+  mapRef: React.RefObject<MapView | null>;
+  style?: StyleProp<ViewStyle>;
+};
+
+const MIN_ZOOM = 3;
+const MAX_ZOOM = 18;
+
+function clampZoom(z: number): number {
+  if (Number.isNaN(z)) return MIN_ZOOM;
+  return Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, z));
+}
+
+async function step(mapRef: React.RefObject<MapView | null>, delta: 1 | -1): Promise<void> {
+  const map = mapRef.current;
+  if (!map) return;
+  try {
+    const cam = await map.getCamera();
+    if (cam && typeof cam.zoom === 'number') {
+      // Android path: Camera.zoom is populated.
+      const next = clampZoom(cam.zoom + delta);
+      map.animateCamera({ zoom: next }, { duration: 250 });
+      return;
+    }
+  } catch {
+    // fall through to region-based zoom
+  }
+
+  // iOS fallback: scale region deltas via current map bounds.
+  try {
+    const bounds = await map.getMapBoundaries();
+    const ne = bounds.northEast;
+    const sw = bounds.southWest;
+    const latitudeDelta = Math.abs(ne.latitude - sw.latitude);
+    const longitudeDelta = Math.abs(ne.longitude - sw.longitude);
+    const center = {
+      latitude: (ne.latitude + sw.latitude) / 2,
+      longitude: (ne.longitude + sw.longitude) / 2,
+    };
+    // +1 zoom = halve deltas; −1 zoom = double deltas.
+    const factor = delta === 1 ? 0.5 : 2;
+    // Clamp deltas to keep within rough min/max zoom envelope.
+    const minDelta = 0.0005; // ~zoom 18
+    const maxDelta = 90;     // ~zoom 3
+    const nextLat = Math.min(maxDelta, Math.max(minDelta, latitudeDelta * factor));
+    const nextLng = Math.min(maxDelta, Math.max(minDelta, longitudeDelta * factor));
+    map.animateToRegion(
+      {
+        latitude: center.latitude,
+        longitude: center.longitude,
+        latitudeDelta: nextLat,
+        longitudeDelta: nextLng,
+      },
+      250,
+    );
+  } catch {
+    // give up silently — pinch still works.
+  }
+}
+
+export function MapZoomControls({ mapRef, style }: Props) {
+  const onZoomIn = useCallback(() => {
+    void step(mapRef, 1);
+  }, [mapRef]);
+  const onZoomOut = useCallback(() => {
+    void step(mapRef, -1);
+  }, [mapRef]);
+
+  return (
+    <View style={[styles.card, style]} pointerEvents="box-none">
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="Zoom in"
+        hitSlop={10}
+        onPress={onZoomIn}
+        style={({ pressed }) => [styles.btn, pressed && styles.btnPressed]}
+      >
+        <Text style={styles.glyph}>＋</Text>
+      </Pressable>
+      <View style={styles.divider} />
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="Zoom out"
+        hitSlop={10}
+        onPress={onZoomOut}
+        style={({ pressed }) => [styles.btn, pressed && styles.btnPressed]}
+      >
+        <Text style={styles.glyph}>－</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    position: 'absolute',
+    top: 16,
+    right: 16,
+    backgroundColor: tokens.colors.bg,
+    borderWidth: 1.5,
+    borderColor: tokens.colors.surfaceDark,
+    borderRadius: tokens.radius.lg,
+    overflow: 'hidden',
+    ...shadows.md,
+  },
+  btn: {
+    width: 44,
+    height: 44,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  btnPressed: {
+    opacity: 0.6,
+  },
+  divider: {
+    height: 1,
+    backgroundColor: tokens.colors.surfaceDark,
+    opacity: 0.4,
+  },
+  glyph: {
+    fontSize: 22,
+    fontWeight: '800',
+    color: tokens.colors.text,
+    lineHeight: 24,
+  },
+});
+
+export default MapZoomControls;

--- a/app/mobile/src/screens/HeritageMapScreen.tsx
+++ b/app/mobile/src/screens/HeritageMapScreen.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import MapView, { Callout, Marker, Polyline } from 'react-native-maps';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { MapZoomControls } from '../components/map/MapZoomControls';
 import { ErrorView } from '../components/ui/ErrorView';
 import { LoadingView } from '../components/ui/LoadingView';
 import { fetchHeritageGroup, type HeritageGroupDetail } from '../services/heritageService';
@@ -197,6 +198,8 @@ export default function HeritageMapScreen({ route, navigation }: Props) {
           ))}
         </MapView>
 
+        <MapZoomControls mapRef={mapRef} style={styles.zoomControls} />
+
         <View style={styles.legend} pointerEvents="none">
           <Text style={styles.legendTitle}>{group.name}</Text>
           <Text style={styles.legendBody}>
@@ -280,4 +283,5 @@ const styles = StyleSheet.create({
     fontFamily: tokens.typography.display.fontFamily,
   },
   legendBody: { fontSize: 12, color: tokens.colors.textMuted, fontWeight: '700' },
+  zoomControls: { top: 90 },
 });

--- a/app/mobile/src/screens/MapDiscoveryScreen.tsx
+++ b/app/mobile/src/screens/MapDiscoveryScreen.tsx
@@ -1,8 +1,9 @@
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import MapView, { Marker } from 'react-native-maps';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { MapZoomControls } from '../components/map/MapZoomControls';
 import { RegionDetailSheet } from '../components/map/RegionDetailSheet';
 import { ErrorView } from '../components/ui/ErrorView';
 import { LoadingView } from '../components/ui/LoadingView';
@@ -20,6 +21,7 @@ export default function MapDiscoveryScreen({ navigation }: Props) {
   const [error, setError] = useState<string | null>(null);
   const [reloadToken, setReloadToken] = useState(0);
   const { accent, setFocusedRegion } = useTheme();
+  const mapRef = useRef<MapView | null>(null);
 
   useEffect(() => {
     setFocusedRegion(focused?.name ?? null);
@@ -70,6 +72,7 @@ export default function MapDiscoveryScreen({ navigation }: Props) {
     <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
       <View style={styles.fill}>
         <MapView
+          ref={mapRef}
           style={styles.map}
           initialRegion={INITIAL_MAP_REGION}
           onPress={() => setFocused(null)}
@@ -89,6 +92,8 @@ export default function MapDiscoveryScreen({ navigation }: Props) {
             />
           ))}
         </MapView>
+
+        <MapZoomControls mapRef={mapRef} />
 
         {!focused ? (
           <View style={styles.hintWrap} pointerEvents="none">


### PR DESCRIPTION
Closes #722.

## Summary

Pinch-zoom on `react-native-maps` works but isn't discoverable. This PR adds an explicit floating `＋` / `－` control overlaid on every map view in the app.

## What changed

- New component `src/components/map/MapZoomControls.tsx`
  - Accepts a `mapRef: React.RefObject<MapView | null>` prop.
  - Two stacked `Pressable`s in a single rounded card (cream `bg`, `surfaceDark` border, `md` shadow). Positioned absolutely top-right by default; consumer can override via `style`.
  - On press: calls `mapRef.current.getCamera()`. On Android, `Camera.zoom` is populated, so it animates the camera by `±1` clamped to `[3, 18]`. On iOS (no `zoom` on the camera object), falls back to `getMapBoundaries()` + `animateToRegion(...)` with halved/doubled `latitudeDelta` / `longitudeDelta`, clamped to a sane envelope.
  - Accessibility: `accessibilityRole="button"`, labels `"Zoom in"` / `"Zoom out"`, `hitSlop={10}`.
- Wired into the two map screens that exist today:
  - `MapDiscoveryScreen` — added a `mapRef`, attached it to the `MapView`, and rendered `<MapZoomControls>` inside the fill view.
  - `HeritageMapScreen` — already had a `mapRef`; placed the controls at `top: 90` so they sit directly below the existing legend card.

`RegionMapDetailScreen` from the issue description doesn't exist in this codebase, so there was nothing to wire there.

## Notes

- No new dependencies.
- Pinch / double-tap zoom is untouched (`zoomEnabled` / `scrollEnabled` not set).
- Only stable palette tokens used: `bg`, `surfaceDark`, `text` (no `primary*` per #617).
- `npx tsc --noEmit` passes.

## Test plan

- [ ] Open the Map tab → controls appear top-right of the map.
- [ ] Tap `＋` → camera animates one zoom step in.
- [ ] Tap `－` → camera animates one zoom step out.
- [ ] Spam-tap `＋` past street level → no crash, motion stops at the max clamp.
- [ ] Spam-tap `－` past world view → no crash, motion stops at the min clamp.
- [ ] Pinch-zoom still works normally alongside the buttons.
- [ ] Open a Heritage group map → controls appear under the legend card.
- [ ] VoiceOver / TalkBack: each button announces "Zoom in" / "Zoom out".