### PR TITLE
feat(frontend): My Account page — view and edit onboarding preferences (#728)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,197 @@
+# Genipe — Claude Code Guide
+
+Genipe is a culturally-aware recipe & story sharing platform with three clients: React web frontend, mobile app, and a REST backend.
+
+**Obsidian vault:** `/Users/daglar/Desktop/obsidian notes/voltran notes/voltran/genipe/`
+— authoritative notes on frontend architecture, pages, components, services, patterns, conventions, and open issues. Check it when exploring unfamiliar parts of the frontend.
+
+---
+
+## Repo layout
+
+```
+app/
+  frontend/   React 19 web app (this is the primary focus)
+  backend/    Django REST API
+  mobile/     React Native app
+docs/
+ops/
+```
+
+## My role
+
+Web frontend developer (React). Work is scoped to `app/frontend/`.
+
+---
+
+## Frontend
+
+**Stack:** React 19 · Create React App · React Router v6 · Axios · plain CSS
+
+**Root:** `app/frontend/src/`
+
+```
+src/
+├── App.js                 # routing + layout shell
+├── index.js               # ReactDOM root, wraps BrowserRouter + AuthProvider
+├── styles/global.css      # design tokens (CSS vars)
+├── context/AuthContext.jsx
+├── components/            # reusable UI components
+├── pages/                 # one .jsx + .css per page
+├── services/              # api.js, authService, recipeService, messageService…
+├── mocks/                 # fake data used when REACT_APP_USE_MOCK=true
+└── __tests__/
+```
+
+### Dev commands
+
+```bash
+cd app/frontend && npm start             # localhost:3000
+CI=true npm test                         # all tests, non-interactive
+npm test -- --testPathPattern="PageName" # single test file
+```
+
+### Env
+
+```
+REACT_APP_API_URL=http://localhost:8000
+REACT_APP_USE_MOCK=true    # skip backend entirely
+```
+
+### Design tokens (global.css)
+
+| Variable | Value |
+|---|---|
+| `--color-bg` | `#C4521E` (rust) |
+| `--color-surface` | `#FAF7EF` (cream) |
+| `--color-surface-dark` | `#3D1500` (dark brown) |
+| `--color-primary` | `#C4521E` |
+| `--font-display` | Fraunces (headings) |
+| `--font-body` | DM Sans (body) |
+
+Button classes: `.btn`, `.btn-primary`, `.btn-outline`, `.btn-danger`, `.btn-sm`
+
+### Route map
+
+| Path | Page | Auth required |
+|---|---|---|
+| `/` | HomePage | No |
+| `/login` | LoginPage | No |
+| `/register` | RegisterPage | No |
+| `/search` | SearchPage | No |
+| `/recipes` | RecipeListPage | No |
+| `/recipes/:id` | RecipeDetailPage | No |
+| `/recipes/new` | RecipeCreatePage | Yes |
+| `/recipes/:id/edit` | RecipeEditPage | Yes |
+| `/stories` | StoryListPage | No |
+| `/stories/:id` | StoryDetailPage | No |
+| `/stories/new` | StoryCreatePage | Yes |
+| `/stories/:id/edit` | StoryEditPage | Yes |
+| `/inbox` | InboxPage | Yes |
+| `/inbox/:threadId` | ThreadPage | Yes |
+
+---
+
+## Git conventions
+
+### Commits
+```
+type(scope): short description (#issue-number)
+```
+
+Types: `feat`, `fix`, `refactor`, `style`, `docs`, `chore`
+
+Examples:
+```
+feat(frontend): add inbox list and thread view pages (#340)
+fix(frontend): use named import for apiClient in messageService (#340)
+```
+
+### Branches
+```
+type/area/short-description
+```
+Examples: `feat/frontend/contact-author-messaging`, `fix/frontend/navbar-rendering`
+
+### PRs
+- Branch from `main`, squash and merge, delete branch after merge
+- At least 1 approval required; cannot self-approve
+- No AI attribution in commits or PR descriptions
+
+### PR Description Format (örnek)
+
+```
+Summary
+<Component/Page>: <What was broken and why> + <What was done to fix it>.
+<Component/Page>: <What changed and why>.
+...
+
+Test plan
+ [ ] <Sayfaya git, şunu gör>
+ [ ] <Şu aksiyonu yap, şunu doğrula>
+ [ ] <Regresyon kontrolü>
+```
+
+Örnek:
+```
+Summary
+Explore page: The page was broken because exploreService called a
+non-existent /api/explore/events/ endpoint. Fixed to use the existing
+/api/recommendations/?surface=explore endpoint.
+
+Search filters: Replaced three always-visible filter boxes with
+collapsible accordion panels. Panels show an active-selection count badge.
+
+Test plan
+ [ ] Navigate to /explore — recipes and stories load in two rails
+ [ ] Search for a term, open/close accordion panels, verify badge counts
+ [ ] Open Map page, click regions, verify recipe/story lists load
+```
+
+---
+
+## KURALLAR
+
+- KULLANICIDAN AÇIKÇA ONAY ALMADAN HİÇBİR ZAMAN PR AÇMA
+- COMMIT MESAJLARINDA VEYA PR AÇIKLAMALARINDA CLAUDE'UN YAPTIĞINI BELİRTEN HİÇBİR ŞEY YAZMA
+- KULLANICI TARAFINDAN AÇILAN PR VEYA ISSUE'LARI DOĞRUDAN KAPATMA — bunun yerine PR/issue'ya açıklayıcı bir yorum bırak ve assignee'den kapatmasını iste
+
+---
+
+## Kod kalitesi — PR standartları
+
+Her feature implementasyonunda şu yaklaşımı uygula:
+
+### Bileşen ayrımı
+- Her mantıksal parçayı ayrı component olarak çıkar (tek büyük sayfa dosyasına sığıştırma)
+- Örnek: `HeritageJourneySection.jsx`, `CulturalFactCard.jsx` ayrı bileşenler olmalı
+
+### Servis katmanı
+- Her domain için ayrı servis dosyası: `heritageService.js`, `culturalFactService.js`, `culturalEventService.js`
+- Tek servis dosyasına birden fazla domain sıkıştırma
+
+### Pure utility fonksiyonlar
+- Test edilebilir mantığı (hesaplamalar, dönüşümler) component dışına `utils/` altına al
+- Örnek: `utils/heritageMidpoint.js` — böylece Leaflet olmadan test edilebilir
+
+### Testler — birlikte yaz
+- Kodu yazarken test de yaz, sonraya bırakma
+- Her yeni servis için servis testi (`__tests__/fooService.test.js`)
+- Her yeni component/page için component testi
+- Her yeni util için unit testi
+- `REACT_APP_USE_MOCK=false` olduğunda `apiClient` çağrıldığını doğrula
+
+### Test ortamı
+- `.env.test` dosyası her zaman `REACT_APP_USE_MOCK=false` içermeli (CI'da servis testleri gerçek apiClient path'ini test eder)
+- Yeni `createContext` kullanımlarında `null` yerine safe default value ver (test renderlarında crash önler)
+
+---
+
+## Milestones
+
+| Milestone | Theme | Due |
+|---|---|---|
+| M5 | Cultural & Discovery Features | 2026-05-07 |
+| M6 | Accessibility & Polish | 2026-05-07 |
+| QA | Integration, QA & Demo | 2026-05-14 |
+| TD | Tech Debt & Fixes | 2026-05-24 |

--- a/app/frontend/src/App.js
+++ b/app/frontend/src/App.js
@@ -22,6 +22,7 @@ import ProfilePage from './pages/ProfilePage';
 import MapPage from './pages/MapPage';
 import ExplorePage from './pages/ExplorePage';
 import EventDetailPage from './pages/EventDetailPage';
+import AccountPage from './pages/AccountPage';
 import ModerationPage from './pages/ModerationPage';
 import NotFoundPage from './pages/NotFoundPage';
 
@@ -114,6 +115,10 @@ export default function App() {
           <Route
             path="/profile"
             element={<ProtectedRoute><ProfilePage /></ProtectedRoute>}
+          />
+          <Route
+            path="/account"
+            element={<ProtectedRoute><AccountPage /></ProtectedRoute>}
           />
           <Route
             path="/admin/moderation"

--- a/app/frontend/src/__tests__/AccountPage.test.jsx
+++ b/app/frontend/src/__tests__/AccountPage.test.jsx
@@ -1,0 +1,117 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { AuthContext } from '../context/AuthContext';
+import AccountPage from '../pages/AccountPage';
+import * as authService from '../services/authService';
+
+jest.mock('../services/authService');
+
+const mockUpdateUser = jest.fn();
+
+const baseUser = {
+  id: 1,
+  username: 'alice',
+  cultural_interests: ['Ottoman'],
+  regional_ties: ['Aegean'],
+  religious_preferences: ['Halal'],
+  event_interests: ['Ramadan'],
+};
+
+function renderPage(user = baseUser) {
+  return render(
+    <AuthContext.Provider
+      value={{ user, token: 'tok', login: jest.fn(), logout: jest.fn(), updateUser: mockUpdateUser }}
+    >
+      <MemoryRouter>
+        <AccountPage />
+      </MemoryRouter>
+    </AuthContext.Provider>
+  );
+}
+
+describe('AccountPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    authService.updateMe.mockResolvedValue({ ...baseUser });
+  });
+
+  it('renders saved preferences in view mode', () => {
+    renderPage();
+    expect(screen.getByRole('heading', { name: /my account/i })).toBeInTheDocument();
+    expect(screen.getByText('Ottoman')).toBeInTheDocument();
+    expect(screen.getByText('Aegean')).toBeInTheDocument();
+    expect(screen.getByText('Halal')).toBeInTheDocument();
+    expect(screen.getByText('Ramadan')).toBeInTheDocument();
+  });
+
+  it('shows "None selected" for empty preference lists', () => {
+    const emptyUser = {
+      ...baseUser,
+      cultural_interests: [],
+      regional_ties: [],
+      religious_preferences: [],
+      event_interests: [],
+    };
+    renderPage(emptyUser);
+    const noneLabels = screen.getAllByText('None selected');
+    expect(noneLabels).toHaveLength(4);
+  });
+
+  it('enters edit mode on Edit Preferences click', () => {
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: /edit preferences/i }));
+    expect(screen.getByRole('button', { name: /save changes/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
+  });
+
+  it('cancel returns to view mode without saving', () => {
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: /edit preferences/i }));
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(screen.getByRole('button', { name: /edit preferences/i })).toBeInTheDocument();
+    expect(authService.updateMe).not.toHaveBeenCalled();
+  });
+
+  it('calls updateMe with current draft on Save Changes', async () => {
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: /edit preferences/i }));
+    fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => expect(authService.updateMe).toHaveBeenCalledWith({
+      cultural_interests: ['Ottoman'],
+      regional_ties: ['Aegean'],
+      religious_preferences: ['Halal'],
+      event_interests: ['Ramadan'],
+    }));
+    expect(mockUpdateUser).toHaveBeenCalled();
+  });
+
+  it('returns to view mode after successful save', async () => {
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: /edit preferences/i }));
+    fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => expect(screen.getByRole('button', { name: /edit preferences/i })).toBeInTheDocument());
+  });
+
+  it('shows error message if updateMe fails', async () => {
+    authService.updateMe.mockRejectedValue(new Error('Network error'));
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: /edit preferences/i }));
+    fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => expect(screen.getByText(/could not save preferences/i)).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: /save changes/i })).toBeInTheDocument();
+  });
+
+  it('toggles a chip in edit mode', () => {
+    renderPage();
+    fireEvent.click(screen.getByRole('button', { name: /edit preferences/i }));
+    const anatolianLabel = screen.getByLabelText(/anatolian/i);
+    expect(anatolianLabel).not.toBeChecked();
+    fireEvent.click(anatolianLabel);
+    expect(anatolianLabel).toBeChecked();
+    fireEvent.click(anatolianLabel);
+    expect(anatolianLabel).not.toBeChecked();
+  });
+});

--- a/app/frontend/src/components/Navbar.jsx
+++ b/app/frontend/src/components/Navbar.jsx
@@ -84,6 +84,13 @@ export default function Navbar() {
                       Profile
                     </Link>
                     <Link
+                      to="/account"
+                      className="navbar-dropdown-item"
+                      onClick={() => setMenuOpen(false)}
+                    >
+                      My Account
+                    </Link>
+                    <Link
                       to="/recipes/new"
                       className="navbar-dropdown-item"
                       onClick={() => setMenuOpen(false)}

--- a/app/frontend/src/pages/AccountPage.css
+++ b/app/frontend/src/pages/AccountPage.css
@@ -1,0 +1,90 @@
+.account-page {
+  max-width: 640px;
+}
+
+.account-page-header {
+  margin-bottom: 2rem;
+}
+
+.account-page-header h1 {
+  font-family: var(--font-display);
+  font-size: 2rem;
+  color: var(--color-text);
+  margin: 0 0 0.25rem;
+}
+
+.account-page-sub {
+  color: var(--color-text-muted);
+  font-size: 0.95rem;
+  margin: 0;
+}
+
+.account-section {
+  margin-bottom: 1.75rem;
+}
+
+.account-section-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-text);
+  margin: 0 0 0.6rem;
+}
+
+.account-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.account-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.3rem 0.75rem;
+  border-radius: 999px;
+  border: 1.5px solid var(--color-border);
+  background: var(--color-surface);
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+  user-select: none;
+}
+
+.account-chip input[type="checkbox"] {
+  display: none;
+}
+
+.account-chip:hover {
+  border-color: var(--color-primary);
+}
+
+.account-chip-active {
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+  color: #fff;
+}
+
+.account-chip-readonly {
+  cursor: default;
+  background: var(--color-surface-alt, #f2ede3);
+  border-color: var(--color-border);
+  color: var(--color-text);
+}
+
+.account-empty {
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+  font-style: italic;
+}
+
+.account-error {
+  color: #c53030;
+  font-size: 0.88rem;
+  margin: 0.5rem 0;
+}
+
+.account-actions {
+  display: flex;
+  gap: 0.75rem;
+  margin-top: 2rem;
+}

--- a/app/frontend/src/pages/AccountPage.jsx
+++ b/app/frontend/src/pages/AccountPage.jsx
@@ -1,0 +1,164 @@
+import { useContext, useEffect, useRef, useState } from 'react';
+import { AuthContext } from '../context/AuthContext';
+import { extractApiError } from '../services/api';
+import { updateMe } from '../services/authService';
+import './AccountPage.css';
+
+const SECTIONS = [
+  {
+    key: 'cultural_interests',
+    title: 'Cultural Interests',
+    options: ['Ottoman', 'Anatolian', 'Balkan', 'Levantine', 'Mediterranean', 'Central Asian'],
+  },
+  {
+    key: 'regional_ties',
+    title: 'Regional Ties',
+    options: ['Aegean', 'Marmara', 'Central Anatolia', 'Black Sea', 'Mediterranean', 'Southeastern Anatolia'],
+  },
+  {
+    key: 'religious_preferences',
+    title: 'Dietary / Religious Preferences',
+    options: ['Halal', 'Kosher', 'Vegetarian', 'Vegan', 'Pescetarian', 'No Preference'],
+  },
+  {
+    key: 'event_interests',
+    title: 'Event Interests',
+    options: ['Ramadan', 'Eid', 'Weddings', 'Family Gatherings', 'Religious Holidays', 'Weeknight Meals'],
+  },
+];
+
+function normalizeList(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function emptyPrefs() {
+  return Object.fromEntries(SECTIONS.map((s) => [s.key, []]));
+}
+
+export default function AccountPage() {
+  const { user, updateUser } = useContext(AuthContext);
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(emptyPrefs);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+  const initialized = useRef(false);
+
+  useEffect(() => {
+    if (user && !initialized.current) {
+      initialized.current = true;
+      setDraft({
+        cultural_interests: normalizeList(user.cultural_interests),
+        regional_ties: normalizeList(user.regional_ties),
+        religious_preferences: normalizeList(user.religious_preferences),
+        event_interests: normalizeList(user.event_interests),
+      });
+    }
+  }, [user]);
+
+  function handleEdit() {
+    setDraft({
+      cultural_interests: normalizeList(user?.cultural_interests),
+      regional_ties: normalizeList(user?.regional_ties),
+      religious_preferences: normalizeList(user?.religious_preferences),
+      event_interests: normalizeList(user?.event_interests),
+    });
+    setError('');
+    setEditing(true);
+  }
+
+  function handleCancel() {
+    setEditing(false);
+    setError('');
+  }
+
+  function toggleOption(key, option) {
+    setDraft((prev) => {
+      const current = prev[key];
+      return {
+        ...prev,
+        [key]: current.includes(option) ? current.filter((o) => o !== option) : [...current, option],
+      };
+    });
+  }
+
+  async function handleSave() {
+    setSaving(true);
+    setError('');
+    try {
+      const updated = await updateMe(draft);
+      updateUser(updated);
+      setEditing(false);
+    } catch (err) {
+      setError(extractApiError(err, 'Could not save preferences.'));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <main className="page-card account-page">
+      <div className="account-page-header">
+        <h1>My Account</h1>
+        <p className="account-page-sub">Manage your cultural preferences.</p>
+      </div>
+
+      {SECTIONS.map((section) => {
+        const saved = normalizeList(user?.[section.key]);
+        return (
+          <section key={section.key} className="account-section">
+            <h2 className="account-section-title">{section.title}</h2>
+            {editing ? (
+              <div className="account-chips">
+                {section.options.map((opt) => {
+                  const active = draft[section.key].includes(opt);
+                  return (
+                    <label
+                      key={opt}
+                      className={`account-chip${active ? ' account-chip-active' : ''}`}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={active}
+                        onChange={() => toggleOption(section.key, opt)}
+                      />
+                      <span>{opt}</span>
+                    </label>
+                  );
+                })}
+              </div>
+            ) : (
+              <div className="account-chips">
+                {saved.length === 0 ? (
+                  <span className="account-empty">None selected</span>
+                ) : (
+                  saved.map((opt) => (
+                    <span key={opt} className="account-chip account-chip-readonly">{opt}</span>
+                  ))
+                )}
+              </div>
+            )}
+          </section>
+        );
+      })}
+
+      {error && <p className="account-error">{error}</p>}
+
+      <div className="account-actions">
+        {editing ? (
+          <>
+            <button type="button" className="btn btn-outline" onClick={handleCancel} disabled={saving}>
+              Cancel
+            </button>
+            <button type="button" className="btn btn-primary" onClick={handleSave} disabled={saving}>
+              {saving ? 'Saving…' : 'Save Changes'}
+            </button>
+          </>
+        ) : (
+          <button type="button" className="btn btn-primary" onClick={handleEdit}>
+            Edit Preferences
+          </button>
+        )}
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary

AccountPage: Added `/account` route with a new My Account page where logged-in users can view and edit the four onboarding preferences they selected during sign-up (cultural interests, regional ties, dietary/religious preferences, event interests). View mode displays saved chips; edit mode allows toggling options and saving via `PATCH /api/users/me/`.

Navbar: Added a "My Account" link to the user dropdown, between Profile and New Recipe.

## Test plan
 [ ] Log in, open user dropdown — "My Account" link is visible
 [ ] Navigate to /account — four preference sections render with saved values
 [ ] Click "Edit Preferences" — chips become toggleable checkboxes
 [ ] Toggle a chip on/off, click "Save Changes" — preferences update and view mode returns
 [ ] Click "Edit Preferences" then "Cancel" — no changes saved, view mode returns
 [ ] Navigate to /account while logged out — redirected to login
 [ ] `CI=true npm test -- --testPathPattern="AccountPage"` — 8 tests pass