### PR TITLE
feat(mobile): wire MapZoomControls into RegionMapDetailScreen (follow-up to #722 / #464)

### DIFF
--- a/app/mobile/src/screens/RegionMapDetailScreen.tsx
+++ b/app/mobile/src/screens/RegionMapDetailScreen.tsx
@@ -5,6 +5,7 @@ import MapView, { Marker } from 'react-native-maps';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { ErrorView } from '../components/ui/ErrorView';
 import { LoadingView } from '../components/ui/LoadingView';
+import { MapZoomControls } from '../components/map/MapZoomControls';
 import {
   fetchRegionRecipes,
   type RegionRecipesPayload,
@@ -141,6 +142,8 @@ export default function RegionMapDetailScreen({ route, navigation }: Props) {
           ))}
         </MapView>
 
+        <MapZoomControls mapRef={mapRef} style={styles.zoomControls} />
+
         <View style={styles.headerOverlay} pointerEvents="none">
           <View style={styles.headerCard}>
             <Text style={styles.headerTitle}>{regionName}</Text>
@@ -228,6 +231,9 @@ const styles = StyleSheet.create({
     left: 16,
     right: 16,
   },
+  /** Stacked below the header card (which sits at top:16) so the zoom
+   * controls don't overlap the region name. */
+  zoomControls: { top: 90 },
   headerCard: {
     padding: 12,
     borderRadius: tokens.radius.lg,


### PR DESCRIPTION
## Summary
Small follow-up promised in PR #725. `MapZoomControls` (#722) landed but only got wired into `MapDiscoveryScreen` and `HeritageMapScreen` — `RegionMapDetailScreen` was added in #723 (PR #723) which wasn't on `main` at the time. Now that both are on `main`, this PR adds the same controls to RegionMapDetailScreen.

## File
- `screens/RegionMapDetailScreen.tsx` — import `MapZoomControls`, render `<MapZoomControls mapRef={mapRef} style={styles.zoomControls} />` between the MapView and the header overlay. The `zoomControls` style positions it at `top: 90` so it sits below the existing region-name header card (which lives at `top: 16`).

## Test
- `npx tsc --noEmit` clean.
- Visual: open a region pin from MapDiscovery → RegionMapDetailScreen → zoom in/out buttons appear below the floating header card; +/- animate the camera one zoom step at a time, with the same `[3, 18]` clamps as the other screens.

Closes (follow-up to) #722 and #464.