### PR TITLE
feat(backend): seed HeritageJourneyStep rows for the heritage catalogue (#681)

### DIFF
--- a/app/backend/apps/heritage/tests_journey_seed.py
+++ b/app/backend/apps/heritage/tests_journey_seed.py
@@ -1,0 +1,77 @@
+"""Regression: seed_canonical must populate HeritageJourneyStep rows.
+
+Issue #681 asks for 3 to 5 ordered, narrated journey steps per heritage
+group so the mobile "Journey through time" timeline (#504) has data to
+render. These tests pin the contract: after seed_canonical every group
+has between 3 and 5 steps, the orders are contiguous from 1, and the
+list endpoint returns them in order.
+"""
+from io import StringIO
+
+from django.core.management import call_command
+from django.test import TestCase
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from apps.heritage.models import HeritageGroup, HeritageJourneyStep
+
+
+class HeritageJourneyStepSeedTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        call_command('seed_canonical', stdout=StringIO())
+
+    def setUp(self):
+        self.client = APIClient()
+
+    def test_groups_were_seeded(self):
+        self.assertGreater(HeritageGroup.objects.count(), 0)
+
+    def test_each_group_has_three_to_five_steps(self):
+        for group in HeritageGroup.objects.all():
+            count = group.journey_steps.count()
+            self.assertGreaterEqual(
+                count, 3, f"{group.name} has only {count} journey steps",
+            )
+            self.assertLessEqual(
+                count, 5, f"{group.name} has {count} journey steps (max 5)",
+            )
+
+    def test_step_orders_are_contiguous_from_one(self):
+        for group in HeritageGroup.objects.all():
+            orders = list(
+                group.journey_steps.order_by('order').values_list('order', flat=True)
+            )
+            self.assertEqual(
+                orders, list(range(1, len(orders) + 1)),
+                f"{group.name} has non-contiguous step orders: {orders}",
+            )
+
+    def test_step_story_and_location_are_non_empty(self):
+        for step in HeritageJourneyStep.objects.all():
+            self.assertTrue(step.location.strip(), f"empty location on step {step.id}")
+            self.assertTrue(step.story.strip(), f"empty story on step {step.id}")
+
+    def test_list_endpoint_returns_group_steps_in_order(self):
+        group = HeritageGroup.objects.first()
+        url = reverse('heritage-journey-step-list')
+        response = self.client.get(url, {'heritage_group': group.id})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = (
+            response.data['results']
+            if isinstance(response.data, dict) and 'results' in response.data
+            else response.data
+        )
+        self.assertEqual(
+            [r['heritage_group'] for r in results],
+            [group.id] * len(results),
+        )
+        orders = [r['order'] for r in results]
+        self.assertEqual(orders, sorted(orders))
+        self.assertEqual(orders, list(range(1, len(orders) + 1)))
+
+    def test_reseeding_is_idempotent_on_step_count(self):
+        before = HeritageJourneyStep.objects.count()
+        call_command('seed_canonical', stdout=StringIO())
+        self.assertEqual(HeritageJourneyStep.objects.count(), before)

--- a/app/backend/fixtures/seed_canonical.json
+++ b/app/backend/fixtures/seed_canonical.json
@@ -6929,21 +6929,15 @@
           },
           {
             "order": 4,
-            "location": "Greece and the Balkans",
+            "location": "Greece, the Balkans, and the Levant",
             "era": "Post-Ottoman (19th–20th c.)",
-            "story": "Greek dolmadakia emerged with lemon-egg sauce, while Balkan versions favoured sauerkraut leaves and smoked meat. Each culture embraced the technique as its own ancient tradition."
+            "story": "Greek dolmadakia arrived with a lemon-egg sauce, Balkan cooks turned to sauerkraut leaves and smoked meat, and Lebanese and Syrian kitchens folded in pomegranate molasses and spiced lamb. Each branch came to be claimed as a local invention rather than an Ottoman inheritance."
           },
           {
             "order": 5,
-            "location": "Levant",
-            "era": "Post-Ottoman (19th–20th c.)",
-            "story": "Lebanese and Syrian cooks added pomegranate molasses and spiced lamb, creating a distinctly Levantine branch noted for its tartness and deep colour."
-          },
-          {
-            "order": 6,
             "location": "Sweden",
             "era": "18th century",
-            "story": "King Charles XII returned from Ottoman exile in 1714 bringing the concept of stuffed cabbage leaves. Kåldolmar became a Swedish staple, served with lingonberry jam — a culinary bridge between two distant empires."
+            "story": "King Charles XII returned from Ottoman exile in 1714 with the idea of stuffed cabbage leaves. Kåldolmar became a Swedish staple, served with lingonberry jam, a culinary bridge between two distant empires."
           }
         ],
         "cultural_facts": [
@@ -7002,6 +6996,12 @@
             "location": "Eastern Europe",
             "era": "Medieval (13th–16th c.)",
             "story": "Pierogi emerged in Poland and Ukraine, likely through eastern trade and migration. Potato and cheese fillings replaced meat as the region's signature variation, and the dumpling became embedded in Christmas Eve ritual."
+          },
+          {
+            "order": 5,
+            "location": "Japan",
+            "era": "Modern (20th c.)",
+            "story": "Soldiers and settlers returning from Manchuria after the Second World War carried jiaozi home, where it was reworked into gyoza: thinner skins, a garlic-forward filling, and a crisp pan-fried base. The dumpling had travelled the Silk Road in both directions."
           }
         ],
         "cultural_facts": [
@@ -7047,6 +7047,18 @@
             "location": "Japan",
             "era": "Asuka period (6th–8th c.)",
             "story": "Buddhist monks brought soybean fermentation techniques from China. Japanese craftspeople refined the process into miso, developing regional varieties across the archipelago, from white Kyoto miso to rich red Sendai miso."
+          },
+          {
+            "order": 4,
+            "location": "Indonesia",
+            "era": "Documented 19th c., older in oral tradition",
+            "story": "On Java, soybeans bound by a white mat of Rhizopus mould became tempeh, a dense, sliceable protein eaten daily across the archipelago. It spread through Indonesian home kitchens long before the West learned to call it a superfood."
+          },
+          {
+            "order": 5,
+            "location": "Worldwide",
+            "era": "21st century",
+            "story": "A global fermentation revival put kimchi, miso, kombucha, and sourdough starters on restaurant menus and kitchen counters far from their origins. Old techniques of patience found a new audience hungry for living food."
           }
         ],
         "cultural_facts": [
@@ -7091,6 +7103,18 @@
             "location": "Sweden",
             "era": "18th century",
             "story": "King Charles XII tasted köfte during his Ottoman exile of 1709–1714 and brought the concept home. Swedish cooks replaced bulgur with breadcrumbs, added cream and allspice, and shaped the mixture into smaller balls. Köttbullar entered the national canon alongside kåldolmar."
+          },
+          {
+            "order": 4,
+            "location": "Greece",
+            "era": "Post-Ottoman (19th–20th c.)",
+            "story": "Greek keftedes split from the Ottoman table after independence: bound with bread soaked in wine or ouzo, brightened with mint and oregano, and often fried rather than grilled. The meatball stayed on the Greek table long after the empire that introduced it had gone."
+          },
+          {
+            "order": 5,
+            "location": "The Balkans",
+            "era": "Modern",
+            "story": "Across the former Ottoman Balkans the form survives as ćevapi: small fingers of minced beef and lamb grilled over charcoal and served with flatbread, raw onion, and ajvar. Bosnia, Serbia, and Croatia each insist their version is the original."
           }
         ],
         "cultural_facts": [


### PR DESCRIPTION
## Summary
- Fill out heritage.groups[].journey_steps in seed_canonical.json to 3 to 5 ordered, narrated steps per group
- Add apps/heritage/tests_journey_seed.py verifying per-group step count, contiguous ordering, and the list endpoint

## Test plan
- [x] python -c "import json; json.load(open('app/backend/fixtures/seed_canonical.json'))"
- [x] cd app/backend && python manage.py seed_canonical && python manage.py test apps.heritage.tests_journey_seed
- [x] python manage.py makemigrations --check --dry-run (clean)

## Notes
- Pure data edit; the seed_canonical loader already supported journey_steps. Did not touch cultural_facts (tracked in #664) or other sections.

Closes #681.