### PR TITLE
feat(backend): seed lat/lng + bbox for regions and recipes (#721, #678, #657)

### DIFF
--- a/app/backend/apps/recipes/management/commands/seed_region_geo.py
+++ b/app/backend/apps/recipes/management/commands/seed_region_geo.py
@@ -1,0 +1,133 @@
+"""Idempotent seeder for Region geo data and per-recipe map coordinates.
+
+Closes the gap behind the blank map pages (#721, #678, #657): Region rows
+ship with nullable latitude/longitude and bbox_* fields, and seed_canonical
+creates regions from recipe data without populating any of them, so
+GET /api/map/regions/ (which defaults to geo_only=true) returns an empty
+list and the web /map and mobile map screens render nothing.
+
+This command runs *after* seed_canonical. It does not touch
+seed_canonical.py / seed_canonical.json; it patches existing rows directly:
+
+  1. For every Region whose name is in fixtures/region_geo.json, set the six
+     geo fields (latitude, longitude, bbox_north, bbox_south, bbox_east,
+     bbox_west). Fixture keys with no matching region, and regions absent
+     from the fixture, are skipped with a warning.
+  2. For every Recipe whose region now has a bounding box, set the recipe's
+     latitude/longitude to a deterministic point inside that bbox (the RNG
+     is seeded with the recipe id, so reruns produce the same point).
+     Recipes whose id is divisible by 7 are intentionally left without
+     coordinates so the "Without a location" path (#464) stays exercised.
+
+Idempotent: rerunning re-applies the same values.
+"""
+import json
+import random
+from decimal import Decimal
+from pathlib import Path
+
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+
+from apps.recipes.models import Recipe, Region
+
+
+# Recipes whose id is divisible by this are intentionally left without
+# coordinates (the "Without a location" bucket). Keeps the share of located
+# recipes around 85%, comfortably above the 70% acceptance bar in #721.
+UNLOCATED_RECIPE_ID_MODULUS = 7
+
+GEO_FIELDS = ('latitude', 'longitude', 'bbox_north', 'bbox_south', 'bbox_east', 'bbox_west')
+
+FIXTURE_PATH = Path(settings.BASE_DIR) / 'fixtures' / 'region_geo.json'
+
+
+def _fixture_path():
+    """Locate fixtures/region_geo.json relative to the backend project root."""
+    if FIXTURE_PATH.exists():
+        return FIXTURE_PATH
+    # Fallback: walk up from this file to find a sibling fixtures/ directory.
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        candidate = parent / 'fixtures' / 'region_geo.json'
+        if candidate.exists():
+            return candidate
+    raise CommandError(f'region_geo fixture not found (looked at {FIXTURE_PATH})')
+
+
+def _point_in_bbox(region, rng):
+    """A deterministic point inside the region's bounding box.
+
+    Quantized to 6 decimal places to match Recipe.latitude/longitude
+    (DecimalField, max_digits=9, decimal_places=6).
+    """
+    lat = rng.uniform(region.bbox_south, region.bbox_north)
+    lng = rng.uniform(region.bbox_west, region.bbox_east)
+    q = Decimal('0.000001')
+    return Decimal(repr(lat)).quantize(q), Decimal(repr(lng)).quantize(q)
+
+
+class Command(BaseCommand):
+    help = (
+        'Seed Region latitude/longitude/bbox from fixtures/region_geo.json and '
+        'assign each Recipe a stable point inside its region bbox. Recipes whose '
+        f'id is divisible by {UNLOCATED_RECIPE_ID_MODULUS} are intentionally left '
+        'without coordinates. Idempotent; run after seed_canonical.'
+    )
+
+    def handle(self, *args, **options):
+        with _fixture_path().open(encoding='utf-8') as fh:
+            fixture = json.load(fh)
+
+        regions_seeded = self._seed_regions(fixture)
+        recipes_seeded, recipes_unlocated = self._seed_recipes()
+
+        self.stdout.write(self.style.SUCCESS(
+            f'Seeded geo for {regions_seeded} regions, {recipes_seeded} recipes '
+            f'({recipes_unlocated} recipes left without coordinates).'
+        ))
+
+    def _seed_regions(self, fixture):
+        existing = {r.name: r for r in Region.objects.all()}
+        seeded = 0
+        for name, geo in fixture.items():
+            region = existing.get(name)
+            if region is None:
+                self.stdout.write(self.style.WARNING(
+                    f'  fixture region {name!r} has no matching Region row; skipping'
+                ))
+                continue
+            for field in GEO_FIELDS:
+                setattr(region, field, geo[field])
+            region.save(update_fields=list(GEO_FIELDS))
+            seeded += 1
+        for name in existing:
+            if name not in fixture:
+                self.stdout.write(self.style.WARNING(
+                    f'  region {name!r} is not in the geo fixture; left without coordinates'
+                ))
+        return seeded
+
+    def _seed_recipes(self):
+        seeded = 0
+        unlocated = 0
+        for recipe in Recipe.objects.select_related('region').iterator():
+            region = recipe.region
+            has_bbox = region is not None and None not in (
+                region.bbox_north, region.bbox_south, region.bbox_east, region.bbox_west,
+            )
+            if recipe.id % UNLOCATED_RECIPE_ID_MODULUS == 0 or not has_bbox:
+                if recipe.latitude is not None or recipe.longitude is not None:
+                    recipe.latitude = None
+                    recipe.longitude = None
+                    recipe.save(update_fields=['latitude', 'longitude'])
+                unlocated += 1
+                continue
+            rng = random.Random(recipe.id)
+            lat, lng = _point_in_bbox(region, rng)
+            if recipe.latitude != lat or recipe.longitude != lng:
+                recipe.latitude = lat
+                recipe.longitude = lng
+                recipe.save(update_fields=['latitude', 'longitude'])
+            seeded += 1
+        return seeded, unlocated

--- a/app/backend/apps/recipes/tests_geo_seed.py
+++ b/app/backend/apps/recipes/tests_geo_seed.py
@@ -1,0 +1,100 @@
+"""Tests for the seed_region_geo management command (#721, #678, #657).
+
+Runs seed_canonical then seed_region_geo and verifies that regions get
+center coordinates and a valid bounding box, that the map index endpoint
+stops returning an empty list, and that a few recipes are intentionally
+left without coordinates so the "Without a location" UI path stays exercised.
+"""
+from io import StringIO
+
+from django.core.management import call_command
+from django.test import TestCase
+from rest_framework.test import APIClient
+
+from apps.recipes.models import Recipe, Region
+
+
+# Regions that must always end up with coordinates after the seed runs.
+MAJOR_REGIONS = [
+    'Aegean', 'Anatolian', 'Black Sea', 'Marmara', 'Mediterranean',
+    'Southeastern Anatolia', 'Levantine', 'Persian', 'Arabian', 'Balkan',
+    'Indian', 'Japanese', 'Chinese', 'Korean', 'French', 'Italian',
+    'Iberian', 'Nordic', 'British Isles', 'North African',
+]
+
+
+class SeedRegionGeoCommandTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        call_command('seed_canonical', stdout=StringIO())
+        call_command('seed_region_geo', stdout=StringIO())
+
+    def test_major_regions_have_center_coordinates(self):
+        for name in MAJOR_REGIONS:
+            region = Region.objects.filter(name=name).first()
+            self.assertIsNotNone(region, f'expected region {name!r} to be seeded')
+            self.assertIsNotNone(region.latitude, f'{name} latitude is null')
+            self.assertIsNotNone(region.longitude, f'{name} longitude is null')
+
+    def test_seeded_regions_have_a_valid_bounding_box(self):
+        seeded = Region.objects.exclude(latitude__isnull=True).exclude(longitude__isnull=True)
+        self.assertGreaterEqual(seeded.count(), len(MAJOR_REGIONS))
+        for region in seeded:
+            self.assertIsNotNone(region.bbox_north, f'{region.name} bbox_north is null')
+            self.assertIsNotNone(region.bbox_south, f'{region.name} bbox_south is null')
+            self.assertIsNotNone(region.bbox_east, f'{region.name} bbox_east is null')
+            self.assertIsNotNone(region.bbox_west, f'{region.name} bbox_west is null')
+            self.assertGreater(region.bbox_north, region.bbox_south,
+                               f'{region.name} bbox north must be greater than south')
+            self.assertGreater(region.bbox_east, region.bbox_west,
+                               f'{region.name} bbox east must be greater than west')
+            # Center should sit inside its own bounding box.
+            self.assertLessEqual(region.bbox_south, region.latitude)
+            self.assertGreaterEqual(region.bbox_north, region.latitude)
+
+    def test_map_regions_endpoint_returns_geo_rows(self):
+        client = APIClient()
+        response = client.get('/api/map/regions/')
+        self.assertEqual(response.status_code, 200)
+        self.assertGreater(len(response.data), 0, 'map index should not be empty after seeding')
+        for row in response.data:
+            self.assertIsNotNone(row['latitude'])
+            self.assertIsNotNone(row['longitude'])
+
+    def test_recipes_get_coordinates_but_a_handful_stay_null(self):
+        with_coords = Recipe.objects.exclude(latitude__isnull=True).exclude(longitude__isnull=True)
+        without_coords = Recipe.objects.filter(latitude__isnull=True, longitude__isnull=True)
+        self.assertGreater(with_coords.count(), 0, 'expected at least one located recipe')
+        self.assertGreater(without_coords.count(), 0, 'expected at least one unlocated recipe')
+        # The intentional gap is recipes whose id is divisible by 7.
+        for recipe in without_coords:
+            self.assertEqual(recipe.id % 7, 0)
+        # And at least 70% of recipes should be located (issue acceptance bar).
+        total = Recipe.objects.count()
+        self.assertGreaterEqual(with_coords.count() / total, 0.7)
+
+    def test_recipe_coordinates_lie_inside_their_region_bbox(self):
+        for recipe in Recipe.objects.exclude(latitude__isnull=True).select_related('region'):
+            region = recipe.region
+            self.assertIsNotNone(region)
+            self.assertGreaterEqual(float(recipe.latitude), region.bbox_south)
+            self.assertLessEqual(float(recipe.latitude), region.bbox_north)
+            self.assertGreaterEqual(float(recipe.longitude), region.bbox_west)
+            self.assertLessEqual(float(recipe.longitude), region.bbox_east)
+
+    def test_rerun_is_idempotent(self):
+        first_region = {
+            (r.name, r.latitude, r.longitude, r.bbox_north, r.bbox_south, r.bbox_east, r.bbox_west)
+            for r in Region.objects.all()
+        }
+        first_recipe = {(r.id, r.latitude, r.longitude) for r in Recipe.objects.all()}
+
+        call_command('seed_region_geo', stdout=StringIO())
+
+        second_region = {
+            (r.name, r.latitude, r.longitude, r.bbox_north, r.bbox_south, r.bbox_east, r.bbox_west)
+            for r in Region.objects.all()
+        }
+        second_recipe = {(r.id, r.latitude, r.longitude) for r in Recipe.objects.all()}
+        self.assertEqual(first_region, second_region)
+        self.assertEqual(first_recipe, second_recipe)

--- a/app/backend/fixtures/region_geo.json
+++ b/app/backend/fixtures/region_geo.json
@@ -1,0 +1,474 @@
+{
+  "Aegean": {
+    "latitude": 38.4192,
+    "longitude": 27.1287,
+    "bbox_north": 39.5,
+    "bbox_south": 37.0,
+    "bbox_east": 28.5,
+    "bbox_west": 26.0
+  },
+  "Anatolian": {
+    "latitude": 39.0,
+    "longitude": 35.5,
+    "bbox_north": 42.5,
+    "bbox_south": 35.5,
+    "bbox_east": 39.0,
+    "bbox_west": 32.0
+  },
+  "Black Sea": {
+    "latitude": 41.5,
+    "longitude": 35.0,
+    "bbox_north": 44.0,
+    "bbox_south": 39.0,
+    "bbox_east": 37.5,
+    "bbox_west": 32.5
+  },
+  "Marmara": {
+    "latitude": 40.8,
+    "longitude": 28.5,
+    "bbox_north": 42.3,
+    "bbox_south": 39.3,
+    "bbox_east": 30.0,
+    "bbox_west": 27.0
+  },
+  "Mediterranean": {
+    "latitude": 35.0,
+    "longitude": 18.0,
+    "bbox_north": 41.0,
+    "bbox_south": 29.0,
+    "bbox_east": 24.0,
+    "bbox_west": 12.0
+  },
+  "Southeastern Anatolia": {
+    "latitude": 37.1,
+    "longitude": 38.8,
+    "bbox_north": 39.1,
+    "bbox_south": 35.1,
+    "bbox_east": 40.8,
+    "bbox_west": 36.8
+  },
+  "Levantine": {
+    "latitude": 33.8547,
+    "longitude": 35.8623,
+    "bbox_north": 36.8547,
+    "bbox_south": 30.8547,
+    "bbox_east": 38.8623,
+    "bbox_west": 32.8623
+  },
+  "Persian": {
+    "latitude": 32.4279,
+    "longitude": 53.688,
+    "bbox_north": 38.4279,
+    "bbox_south": 26.4279,
+    "bbox_east": 59.688,
+    "bbox_west": 47.688
+  },
+  "Arabian": {
+    "latitude": 24.0,
+    "longitude": 45.0,
+    "bbox_north": 32.0,
+    "bbox_south": 16.0,
+    "bbox_east": 53.0,
+    "bbox_west": 37.0
+  },
+  "Balkan": {
+    "latitude": 42.0,
+    "longitude": 22.0,
+    "bbox_north": 46.0,
+    "bbox_south": 38.0,
+    "bbox_east": 26.0,
+    "bbox_west": 18.0
+  },
+  "Caucasian": {
+    "latitude": 42.0,
+    "longitude": 44.0,
+    "bbox_north": 45.0,
+    "bbox_south": 39.0,
+    "bbox_east": 47.0,
+    "bbox_west": 41.0
+  },
+  "Indian": {
+    "latitude": 20.5937,
+    "longitude": 78.9629,
+    "bbox_north": 28.5937,
+    "bbox_south": 12.5937,
+    "bbox_east": 86.9629,
+    "bbox_west": 70.9629
+  },
+  "Japanese": {
+    "latitude": 36.2048,
+    "longitude": 138.2529,
+    "bbox_north": 42.2048,
+    "bbox_south": 30.2048,
+    "bbox_east": 144.2529,
+    "bbox_west": 132.2529
+  },
+  "Chinese": {
+    "latitude": 35.8617,
+    "longitude": 104.1954,
+    "bbox_north": 45.8617,
+    "bbox_south": 25.8617,
+    "bbox_east": 114.1954,
+    "bbox_west": 94.1954
+  },
+  "Korean": {
+    "latitude": 36.5651,
+    "longitude": 127.9785,
+    "bbox_north": 39.0651,
+    "bbox_south": 34.0651,
+    "bbox_east": 130.4785,
+    "bbox_west": 125.4785
+  },
+  "French": {
+    "latitude": 46.2276,
+    "longitude": 2.2137,
+    "bbox_north": 50.2276,
+    "bbox_south": 42.2276,
+    "bbox_east": 6.2137,
+    "bbox_west": -1.7863
+  },
+  "Italian": {
+    "latitude": 41.8719,
+    "longitude": 12.5674,
+    "bbox_north": 45.8719,
+    "bbox_south": 37.8719,
+    "bbox_east": 16.5674,
+    "bbox_west": 8.5674
+  },
+  "Iberian": {
+    "latitude": 40.4637,
+    "longitude": -3.7492,
+    "bbox_north": 45.4637,
+    "bbox_south": 35.4637,
+    "bbox_east": 1.2508,
+    "bbox_west": -8.7492
+  },
+  "Nordic": {
+    "latitude": 60.472,
+    "longitude": 8.4689,
+    "bbox_north": 68.472,
+    "bbox_south": 52.472,
+    "bbox_east": 16.4689,
+    "bbox_west": 0.4689
+  },
+  "Central European": {
+    "latitude": 49.0,
+    "longitude": 16.0,
+    "bbox_north": 53.0,
+    "bbox_south": 45.0,
+    "bbox_east": 20.0,
+    "bbox_west": 12.0
+  },
+  "Eastern European": {
+    "latitude": 50.0,
+    "longitude": 30.0,
+    "bbox_north": 56.0,
+    "bbox_south": 44.0,
+    "bbox_east": 36.0,
+    "bbox_west": 24.0
+  },
+  "British Isles": {
+    "latitude": 54.6,
+    "longitude": -3.0,
+    "bbox_north": 58.6,
+    "bbox_south": 50.6,
+    "bbox_east": 1.0,
+    "bbox_west": -7.0
+  },
+  "North African": {
+    "latitude": 28.0339,
+    "longitude": 1.6596,
+    "bbox_north": 38.0339,
+    "bbox_south": 18.0339,
+    "bbox_east": 11.6596,
+    "bbox_west": -8.3404
+  },
+  "West African": {
+    "latitude": 10.0,
+    "longitude": -3.0,
+    "bbox_north": 18.0,
+    "bbox_south": 2.0,
+    "bbox_east": 5.0,
+    "bbox_west": -11.0
+  },
+  "East African": {
+    "latitude": 2.0,
+    "longitude": 38.0,
+    "bbox_north": 10.0,
+    "bbox_south": -6.0,
+    "bbox_east": 46.0,
+    "bbox_west": 30.0
+  },
+  "Caribbean": {
+    "latitude": 21.4691,
+    "longitude": -78.6569,
+    "bbox_north": 27.4691,
+    "bbox_south": 15.4691,
+    "bbox_east": -72.6569,
+    "bbox_west": -84.6569
+  },
+  "Central American": {
+    "latitude": 14.0,
+    "longitude": -88.0,
+    "bbox_north": 19.0,
+    "bbox_south": 9.0,
+    "bbox_east": -83.0,
+    "bbox_west": -93.0
+  },
+  "North American": {
+    "latitude": 40.0,
+    "longitude": -100.0,
+    "bbox_north": 55.0,
+    "bbox_south": 25.0,
+    "bbox_east": -85.0,
+    "bbox_west": -115.0
+  },
+  "South American": {
+    "latitude": -15.0,
+    "longitude": -60.0,
+    "bbox_north": 0.0,
+    "bbox_south": -30.0,
+    "bbox_east": -45.0,
+    "bbox_west": -75.0
+  },
+  "Southeast Asian": {
+    "latitude": 5.0,
+    "longitude": 110.0,
+    "bbox_north": 15.0,
+    "bbox_south": -5.0,
+    "bbox_east": 120.0,
+    "bbox_west": 100.0
+  },
+  "Central Asian": {
+    "latitude": 45.0,
+    "longitude": 65.0,
+    "bbox_north": 53.0,
+    "bbox_south": 37.0,
+    "bbox_east": 73.0,
+    "bbox_west": 57.0
+  },
+  "Oceanian": {
+    "latitude": -25.0,
+    "longitude": 140.0,
+    "bbox_north": -10.0,
+    "bbox_south": -40.0,
+    "bbox_east": 155.0,
+    "bbox_west": 125.0
+  },
+  "Argentina": {
+    "latitude": -38.4161,
+    "longitude": -63.6167,
+    "bbox_north": -30.4161,
+    "bbox_south": -46.4161,
+    "bbox_east": -55.6167,
+    "bbox_west": -71.6167
+  },
+  "Australia": {
+    "latitude": -25.2744,
+    "longitude": 133.7751,
+    "bbox_north": -13.2744,
+    "bbox_south": -37.2744,
+    "bbox_east": 145.7751,
+    "bbox_west": 121.7751
+  },
+  "Brazil": {
+    "latitude": -14.235,
+    "longitude": -51.9253,
+    "bbox_north": -2.235,
+    "bbox_south": -26.235,
+    "bbox_east": -39.9253,
+    "bbox_west": -63.9253
+  },
+  "China": {
+    "latitude": 35.8617,
+    "longitude": 104.1954,
+    "bbox_north": 45.8617,
+    "bbox_south": 25.8617,
+    "bbox_east": 114.1954,
+    "bbox_west": 94.1954
+  },
+  "El Salvador": {
+    "latitude": 13.7942,
+    "longitude": -88.8965,
+    "bbox_north": 15.2942,
+    "bbox_south": 12.2942,
+    "bbox_east": -87.3965,
+    "bbox_west": -90.3965
+  },
+  "Ethiopia": {
+    "latitude": 9.145,
+    "longitude": 40.4897,
+    "bbox_north": 14.145,
+    "bbox_south": 4.145,
+    "bbox_east": 45.4897,
+    "bbox_west": 35.4897
+  },
+  "France": {
+    "latitude": 46.2276,
+    "longitude": 2.2137,
+    "bbox_north": 50.2276,
+    "bbox_south": 42.2276,
+    "bbox_east": 6.2137,
+    "bbox_west": -1.7863
+  },
+  "Germany": {
+    "latitude": 51.1657,
+    "longitude": 10.4515,
+    "bbox_north": 55.1657,
+    "bbox_south": 47.1657,
+    "bbox_east": 14.4515,
+    "bbox_west": 6.4515
+  },
+  "Ghana": {
+    "latitude": 7.9465,
+    "longitude": -1.0232,
+    "bbox_north": 10.9465,
+    "bbox_south": 4.9465,
+    "bbox_east": 1.9768,
+    "bbox_west": -4.0232
+  },
+  "Greece": {
+    "latitude": 39.0742,
+    "longitude": 23.0,
+    "bbox_north": 42.5742,
+    "bbox_south": 35.5742,
+    "bbox_east": 26.5,
+    "bbox_west": 19.5
+  },
+  "Hungary": {
+    "latitude": 47.1625,
+    "longitude": 19.5033,
+    "bbox_north": 49.6625,
+    "bbox_south": 44.6625,
+    "bbox_east": 22.0033,
+    "bbox_west": 17.0033
+  },
+  "Jamaica": {
+    "latitude": 18.1096,
+    "longitude": -77.2975,
+    "bbox_north": 19.6096,
+    "bbox_south": 16.6096,
+    "bbox_east": -75.7975,
+    "bbox_west": -78.7975
+  },
+  "Kyrgyzstan": {
+    "latitude": 41.2044,
+    "longitude": 74.7661,
+    "bbox_north": 44.2044,
+    "bbox_south": 38.2044,
+    "bbox_east": 77.7661,
+    "bbox_west": 71.7661
+  },
+  "Morocco": {
+    "latitude": 31.7917,
+    "longitude": -7.0926,
+    "bbox_north": 36.7917,
+    "bbox_south": 26.7917,
+    "bbox_east": -2.0926,
+    "bbox_west": -12.0926
+  },
+  "Nigeria": {
+    "latitude": 9.082,
+    "longitude": 8.6753,
+    "bbox_north": 14.082,
+    "bbox_south": 4.082,
+    "bbox_east": 13.6753,
+    "bbox_west": 3.6753
+  },
+  "Peru": {
+    "latitude": -9.19,
+    "longitude": -75.0152,
+    "bbox_north": -2.19,
+    "bbox_south": -16.19,
+    "bbox_east": -68.0152,
+    "bbox_west": -82.0152
+  },
+  "Poland": {
+    "latitude": 51.9194,
+    "longitude": 19.1451,
+    "bbox_north": 55.4194,
+    "bbox_south": 48.4194,
+    "bbox_east": 22.6451,
+    "bbox_west": 15.6451
+  },
+  "Portugal": {
+    "latitude": 39.3999,
+    "longitude": -8.2245,
+    "bbox_north": 41.8999,
+    "bbox_south": 36.8999,
+    "bbox_east": -5.7245,
+    "bbox_west": -10.7245
+  },
+  "Russia": {
+    "latitude": 61.524,
+    "longitude": 90.0,
+    "bbox_north": 81.524,
+    "bbox_south": 41.524,
+    "bbox_east": 110.0,
+    "bbox_west": 70.0
+  },
+  "Saudi Arabia": {
+    "latitude": 23.8859,
+    "longitude": 45.0792,
+    "bbox_north": 30.8859,
+    "bbox_south": 16.8859,
+    "bbox_east": 52.0792,
+    "bbox_west": 38.0792
+  },
+  "South Korea": {
+    "latitude": 35.9078,
+    "longitude": 127.7669,
+    "bbox_north": 37.9078,
+    "bbox_south": 33.9078,
+    "bbox_east": 129.7669,
+    "bbox_west": 125.7669
+  },
+  "Spain": {
+    "latitude": 40.4637,
+    "longitude": -3.7492,
+    "bbox_north": 45.4637,
+    "bbox_south": 35.4637,
+    "bbox_east": 1.2508,
+    "bbox_west": -8.7492
+  },
+  "Thailand": {
+    "latitude": 15.87,
+    "longitude": 100.9925,
+    "bbox_north": 20.87,
+    "bbox_south": 10.87,
+    "bbox_east": 105.9925,
+    "bbox_west": 95.9925
+  },
+  "Trinidad and Tobago": {
+    "latitude": 10.6918,
+    "longitude": -61.2225,
+    "bbox_north": 11.6918,
+    "bbox_south": 9.6918,
+    "bbox_east": -60.2225,
+    "bbox_west": -62.2225
+  },
+  "United Kingdom": {
+    "latitude": 54.0,
+    "longitude": -2.5,
+    "bbox_north": 58.0,
+    "bbox_south": 50.0,
+    "bbox_east": 1.5,
+    "bbox_west": -6.5
+  },
+  "Uzbekistan": {
+    "latitude": 41.3775,
+    "longitude": 64.5853,
+    "bbox_north": 45.3775,
+    "bbox_south": 37.3775,
+    "bbox_east": 68.5853,
+    "bbox_west": 60.5853
+  },
+  "Vietnam": {
+    "latitude": 14.0583,
+    "longitude": 108.2772,
+    "bbox_north": 20.0583,
+    "bbox_south": 8.0583,
+    "bbox_east": 114.2772,
+    "bbox_west": 102.2772
+  }
+}


### PR DESCRIPTION
## Summary
- Add fixtures/region_geo.json mapping every seeded region to centroid + bbox
- Add seed_region_geo management command: patches Region geo fields, assigns each Recipe a stable point inside its region bbox, intentionally leaves a few recipes without coords
- Add apps/recipes/tests_geo_seed.py verifying regions get coords and GET /api/map/regions/ is non-empty

## Test plan
- [x] cd app/backend && python manage.py seed_canonical && python manage.py seed_region_geo
- [x] python manage.py test apps.recipes.tests_geo_seed
- [x] python manage.py makemigrations --check --dry-run (clean, no model changes)

## Notes
- Standalone command, run after seed_canonical. Did not touch seed_canonical.py/json to stay clear of parallel seed work.
- Closes #678 (the blank-map bug) and #657 (region coords) as well, both are subsumed by this.

Closes #721, closes #678, closes #657.