### PR TITLE
feat(backend): seed cultural facts catalogue for Did You Know cards (#664)

### DIFF
--- a/app/backend/apps/heritage/management/commands/seed_cultural_facts.py
+++ b/app/backend/apps/heritage/management/commands/seed_cultural_facts.py
@@ -1,0 +1,92 @@
+"""Idempotent seeder for region-tied "Did You Know?" cultural facts (#664).
+
+The CulturalFact model already ships with a handful of facts nested under
+the four heritage groups (seeded via seed_canonical). What was missing is
+facts tied to a Region, which the mobile "Did You Know?" cards and the web
+parity work query per recipe region. Without them the section silently
+hides on demo recipes and the recipes look bare.
+
+This command reads fixtures/cultural_facts.json (an array of
+{region, text, source_url?} objects) and creates one CulturalFact per
+entry with the region resolved by name and heritage_group left null,
+since the four group-tied facts already exist and region coverage is the
+gap.
+
+Idempotent: a fact is keyed by (region, text), so rerunning does not
+duplicate; a changed source_url on an existing fact is written back.
+Unknown region names are warned about and skipped rather than crashing,
+so the command stays safe if a region has not been seeded yet.
+
+Facts are short, plain-English food and culture trivia (origins,
+etymology, rituals, ingredients). They are curated, not exhaustive.
+"""
+import json
+from pathlib import Path
+
+from django.core.management.base import BaseCommand
+
+from apps.heritage.models import CulturalFact
+from apps.recipes.models import Region
+
+
+DEFAULT_FIXTURE = Path(__file__).resolve().parents[4] / 'fixtures' / 'cultural_facts.json'
+
+
+class Command(BaseCommand):
+    help = 'Seed region-tied "Did You Know?" cultural facts from fixtures/cultural_facts.json (idempotent).'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--fixture',
+            dest='fixture',
+            default=None,
+            help='Path to fixture JSON (default: fixtures/cultural_facts.json).',
+        )
+
+    def handle(self, *args, **options):
+        fixture_path = Path(options['fixture']) if options['fixture'] else DEFAULT_FIXTURE
+        with open(fixture_path, encoding='utf-8') as fh:
+            entries = json.load(fh)
+
+        region_by_name = {region.name: region for region in Region.objects.all()}
+
+        created = 0
+        updated = 0
+        unchanged = 0
+        skipped = 0
+        missing_regions = set()
+
+        for entry in entries:
+            region_name = entry['region']
+            text = entry['text'].strip()
+            source_url = (entry.get('source_url') or '').strip()
+
+            region = region_by_name.get(region_name)
+            if region is None:
+                missing_regions.add(region_name)
+                skipped += 1
+                continue
+
+            fact = CulturalFact.objects.filter(region=region, text=text).first()
+            if fact is None:
+                CulturalFact.objects.create(
+                    region=region,
+                    heritage_group=None,
+                    text=text,
+                    source_url=source_url,
+                )
+                created += 1
+            elif fact.source_url != source_url:
+                fact.source_url = source_url
+                fact.save(update_fields=['source_url', 'updated_at'])
+                updated += 1
+            else:
+                unchanged += 1
+
+        for name in sorted(missing_regions):
+            self.stdout.write(self.style.WARNING(f'Region not found, skipped its facts: {name}'))
+
+        self.stdout.write(self.style.SUCCESS(
+            f'Seeded {created} region cultural facts '
+            f'({updated} updated, {unchanged} unchanged, {skipped} skipped).'
+        ))

--- a/app/backend/apps/heritage/tests_facts_seed.py
+++ b/app/backend/apps/heritage/tests_facts_seed.py
@@ -1,0 +1,114 @@
+"""Tests for the region cultural facts seeder and the facts endpoint (#664).
+
+Covers that `seed_cultural_facts` populates a healthy number of
+region-tied CulturalFact rows, that coverage spreads across regions, that
+it is idempotent and skips unknown regions, and that the public
+/api/cultural-facts/ endpoint serves them (filtering by ?region= and the
+/random/ action).
+"""
+from io import StringIO
+
+from django.core.management import call_command
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from apps.recipes.models import Region
+
+from .models import CulturalFact
+
+
+# Bounds chosen well under what the fixture currently ships (~93 facts
+# across 31 regions) so these tests do not have to move every time a fact
+# is added or removed.
+MIN_REGION_FACTS = 60
+MIN_REGIONS_COVERED = 25
+
+
+def _seed():
+    """Seed regions and group facts (seed_canonical) then the region facts."""
+    call_command('seed_canonical', stdout=StringIO(), stderr=StringIO())
+    out = StringIO()
+    call_command('seed_cultural_facts', stdout=out, stderr=StringIO())
+    return out.getvalue()
+
+
+class RegionCulturalFactsSeededTests(APITestCase):
+    """Behaviour once the full seed has run."""
+
+    @classmethod
+    def setUpTestData(cls):
+        _seed()
+
+    def test_seeds_a_healthy_number_of_region_facts(self):
+        count = CulturalFact.objects.filter(region__isnull=False).count()
+        self.assertGreaterEqual(count, MIN_REGION_FACTS)
+
+    def test_region_facts_have_no_heritage_group(self):
+        # The seeder creates region-tied facts with heritage_group left null.
+        region_only = CulturalFact.objects.filter(
+            region__isnull=False, heritage_group__isnull=True,
+        )
+        self.assertGreaterEqual(region_only.count(), MIN_REGION_FACTS)
+
+    def test_coverage_spreads_across_regions(self):
+        covered = set(
+            CulturalFact.objects.filter(region__isnull=False)
+            .values_list('region_id', flat=True)
+        )
+        self.assertGreaterEqual(len(covered), MIN_REGIONS_COVERED)
+        # Every region that got a fact has at least one.
+        for region in Region.objects.filter(cultural_facts__isnull=False).distinct():
+            self.assertGreaterEqual(region.cultural_facts.count(), 1)
+
+    def test_endpoint_filters_by_region(self):
+        region = Region.objects.filter(cultural_facts__isnull=False).first()
+        expected_ids = set(
+            CulturalFact.objects.filter(region=region).values_list('id', flat=True)
+        )
+        resp = self.client.get(reverse('cultural-fact-list'), {'region': region.id})
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        returned_ids = {item['id'] for item in resp.data}
+        self.assertEqual(returned_ids, expected_ids)
+        self.assertGreaterEqual(len(returned_ids), 1)
+        for item in resp.data:
+            # The serializer nests region as {'id': ..., 'name': ...}.
+            self.assertEqual(item['region']['id'], region.id)
+
+    def test_random_endpoint_returns_a_fact(self):
+        resp = self.client.get(reverse('cultural-fact-random'))
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertIn('text', resp.data)
+        self.assertTrue(resp.data['text'])
+
+
+class RegionCulturalFactsSeederBehaviorTests(APITestCase):
+    """Idempotency, graceful skipping, and the empty-database case."""
+
+    def test_seeder_is_idempotent(self):
+        _seed()
+        before = CulturalFact.objects.count()
+        out = StringIO()
+        call_command('seed_cultural_facts', stdout=out, stderr=StringIO())
+        self.assertEqual(CulturalFact.objects.count(), before)
+        self.assertIn('Seeded 0 region cultural facts', out.getvalue())
+
+    def test_seeder_skips_unknown_regions_without_crashing(self):
+        # Remove a region that the fixture has facts for, then seed: the
+        # command must warn and move on instead of raising.
+        call_command('seed_canonical', stdout=StringIO(), stderr=StringIO())
+        Region.objects.filter(name='Aegean').delete()
+        out = StringIO()
+        call_command('seed_cultural_facts', stdout=out, stderr=StringIO())
+        self.assertIn('Region not found, skipped its facts: Aegean', out.getvalue())
+        self.assertFalse(CulturalFact.objects.filter(region__name='Aegean').exists())
+        # Other regions are still seeded normally.
+        self.assertGreaterEqual(
+            CulturalFact.objects.filter(region__isnull=False).count(), MIN_REGION_FACTS,
+        )
+
+    def test_random_endpoint_404_when_empty(self):
+        # A fresh test database has regions (migration-seeded) but no facts.
+        self.assertEqual(CulturalFact.objects.count(), 0)
+        resp = self.client.get(reverse('cultural-fact-random'))
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)

--- a/app/backend/fixtures/cultural_facts.json
+++ b/app/backend/fixtures/cultural_facts.json
@@ -1,0 +1,417 @@
+[
+  {
+    "region": "Aegean",
+    "text": "Aegean cooking leans so hard on olive oil that a whole class of dishes is simply called zeytinyaglilar, meaning the ones with olive oil, and they are traditionally served at room temperature rather than hot."
+  },
+  {
+    "region": "Aegean",
+    "text": "The region's herb saute, ot kavurmasi, uses foraged greens like nettle, mallow, and poppy leaves that change with the season, a habit older than any written recipe in the area."
+  },
+  {
+    "region": "Aegean",
+    "text": "The coast around Cesme is known for mastic, a fragrant resin tapped from a low shrub that flavors everything from ice cream to puddings and even chewing gum.",
+    "source_url": "https://en.wikipedia.org/wiki/Mastic_(plant_resin)"
+  },
+  {
+    "region": "Anatolian",
+    "text": "The wheat country of central Anatolia gave the world bulgur, parboiled and dried cracked wheat that keeps for months without refrigeration, a practical answer to long highland winters.",
+    "source_url": "https://en.wikipedia.org/wiki/Bulgur"
+  },
+  {
+    "region": "Anatolian",
+    "text": "The clay pot stew testi kebabi is cooked sealed inside a pot that the server cracks open at the table, a bit of theater that started in the Cappadocia region."
+  },
+  {
+    "region": "Anatolian",
+    "text": "Many Anatolian villages still bake the thin flatbread yufka in large batches and stack it dry, sprinkling it with a little water to soften it again when it is needed."
+  },
+  {
+    "region": "Black Sea",
+    "text": "Anchovy, called hamsi, is so central to Black Sea cooking that locals joke you can even make dessert from it, and there really is a traditional hamsi cornbread."
+  },
+  {
+    "region": "Black Sea",
+    "text": "Corn took over as the staple grain along the Black Sea coast after it arrived from the Americas, which is why cornbread and corn flour soups dominate there rather than wheat."
+  },
+  {
+    "region": "Black Sea",
+    "text": "The region's stretchy cheese dish, muhlama or kuymak, melts a young cheese into butter and cornmeal until it pulls into long threads off the spoon."
+  },
+  {
+    "region": "Marmara",
+    "text": "Istanbul's street staple balik ekmek, grilled fish in bread, traces back to fishermen selling their catch cooked right on their boats along the Golden Horn."
+  },
+  {
+    "region": "Marmara",
+    "text": "Turkish delight, or lokum, was popularized by a confectioner named Bekir Efendi in eighteenth century Istanbul, and his shop in the old city still operates today.",
+    "source_url": "https://en.wikipedia.org/wiki/Turkish_delight"
+  },
+  {
+    "region": "Marmara",
+    "text": "Simit, the sesame crusted ring bread sold from red carts, appears in Ottoman palace kitchen records from the fifteen hundreds, so the snack is at least five centuries old."
+  },
+  {
+    "region": "Mediterranean",
+    "text": "The Mediterranean diet as a nutrition idea was named after the eating habits of nineteen sixties Crete and southern Italy, not invented by chefs but observed by researchers.",
+    "source_url": "https://en.wikipedia.org/wiki/Mediterranean_diet"
+  },
+  {
+    "region": "Mediterranean",
+    "text": "Olive trees in the Mediterranean basin can live for over a thousand years, and some groves still being harvested were planted before the fall of Rome."
+  },
+  {
+    "region": "Mediterranean",
+    "text": "Preserving the summer harvest in oil, salt, or vinegar shaped the Mediterranean pantry, which is where capers, salt cured anchovies, and sun dried tomatoes come from."
+  },
+  {
+    "region": "Southeastern Anatolia",
+    "text": "Gaziantep is so serious about food that UNESCO named it a City of Gastronomy in twenty fifteen, partly for its dozens of distinct baklava and kebab styles.",
+    "source_url": "https://en.wikipedia.org/wiki/Gaziantep"
+  },
+  {
+    "region": "Southeastern Anatolia",
+    "text": "The region's baklava is traditionally made with Antep pistachios and clarified butter, and skilled bakers roll the dough thin enough to read a newspaper through it."
+  },
+  {
+    "region": "Southeastern Anatolia",
+    "text": "Isot, the dark smoky dried pepper of Urfa, gets its deep color from being sun dried by day and then sweated under cloth by night."
+  },
+  {
+    "region": "Levantine",
+    "text": "Mezze culture, the spread of many small dishes eaten slowly, is a Levantine signature, and a generous table can carry thirty or more plates before the main course arrives.",
+    "source_url": "https://en.wikipedia.org/wiki/Meze"
+  },
+  {
+    "region": "Levantine",
+    "text": "Za'atar, both the wild herb and the blend mixed with sumac and sesame, is eaten so often at breakfast that some families say it helps children stay sharp at school."
+  },
+  {
+    "region": "Levantine",
+    "text": "Kibbeh, pounded bulgur and meat shaped by hand, is treated as a test of skill, and in parts of the Levant a cook's reputation can rest on how thin the shell is."
+  },
+  {
+    "region": "Persian",
+    "text": "Persian rice is judged by its tahdig, the crisp golden crust at the bottom of the pot, which is often the first thing reached for at the table.",
+    "source_url": "https://en.wikipedia.org/wiki/Tahdig"
+  },
+  {
+    "region": "Persian",
+    "text": "The sweet and sour balance of Persian stews comes from fruit and herbs, like the walnut and pomegranate sauce fesenjan that slow cooks for hours."
+  },
+  {
+    "region": "Persian",
+    "text": "Saffron, the dried stigmas of a crocus, has been grown on the Iranian plateau for thousands of years, and a single kilo takes well over a hundred thousand hand picked flowers."
+  },
+  {
+    "region": "Arabian",
+    "text": "The Gulf rice and meat dish kabsa, also called machboos, carries black lime, or loomi, dried limes that give it a distinctive sour, slightly bitter depth.",
+    "source_url": "https://en.wikipedia.org/wiki/Kabsa"
+  },
+  {
+    "region": "Arabian",
+    "text": "Arabic coffee, qahwa, is traditionally spiced with cardamom and served in small handleless cups, and refilling a guest's cup until they shake it is a rule of hospitality."
+  },
+  {
+    "region": "Arabian",
+    "text": "Dates have been a desert staple for millennia, and a single palm can be used not just for fruit but for sap, fronds, and timber."
+  },
+  {
+    "region": "Balkan",
+    "text": "Many Balkan kitchens share the same dishes under different names, so the layered pastry burek or borek can spark friendly arguments over who made it first."
+  },
+  {
+    "region": "Balkan",
+    "text": "Ajvar, a roasted red pepper relish, is made in large family batches in autumn, and the smell of peppers charring outdoors is a seasonal marker across the region.",
+    "source_url": "https://en.wikipedia.org/wiki/Ajvar"
+  },
+  {
+    "region": "Balkan",
+    "text": "Kajmak, a rich clotted cream skimmed from simmering milk, sits on Balkan tables next to bread and grilled meat much the way butter does elsewhere."
+  },
+  {
+    "region": "Caucasian",
+    "text": "Georgian khachapuri, cheese filled bread, has a version from Adjara shaped like a boat with a runny egg yolk in the middle that is meant to be swirled into the hot cheese.",
+    "source_url": "https://en.wikipedia.org/wiki/Khachapuri"
+  },
+  {
+    "region": "Caucasian",
+    "text": "The Caucasus is one of the oldest wine making regions on earth, and Georgians still ferment wine in buried clay vessels called qvevri, a method now on UNESCO's heritage list."
+  },
+  {
+    "region": "Caucasian",
+    "text": "Walnuts thread through Caucasian cooking, ground into sauces for chicken, beans, and vegetables, sometimes thinned with the tart juice of unripe grapes."
+  },
+  {
+    "region": "Indian",
+    "text": "India's spice trade was so valuable that it helped draw European ships across the world, and black pepper from the Malabar Coast was once nicknamed black gold."
+  },
+  {
+    "region": "Indian",
+    "text": "The tandoor, a clay oven sunk into the ground or set in a barrel, can hit temperatures high enough to bake a flatbread in under a minute.",
+    "source_url": "https://en.wikipedia.org/wiki/Tandoor"
+  },
+  {
+    "region": "Indian",
+    "text": "Many Indian meals are still eaten by hand from a thali, a round platter holding small bowls so the eater can mix flavors in any order they like."
+  },
+  {
+    "region": "Japanese",
+    "text": "Umami, the savory fifth taste, was identified by a Japanese chemist in nineteen oh eight while he was studying why kombu seaweed broth tasted so satisfying.",
+    "source_url": "https://en.wikipedia.org/wiki/Umami"
+  },
+  {
+    "region": "Japanese",
+    "text": "Sushi began as a way to preserve fish by packing it in fermenting rice, and the quick fresh version eaten today is a relatively recent Tokyo invention."
+  },
+  {
+    "region": "Japanese",
+    "text": "Japanese cooks treat the knife as a serious tool, and traditional blades are forged by some of the same craft lineages that once made samurai swords."
+  },
+  {
+    "region": "Chinese",
+    "text": "The wok's rounded shape and the roaring flame under it create wok hei, a smoky aroma that home stoves struggle to match."
+  },
+  {
+    "region": "Chinese",
+    "text": "Tofu has been made in China for around two thousand years, reportedly discovered by accident when soy milk curdled after meeting a mineral salt.",
+    "source_url": "https://en.wikipedia.org/wiki/Tofu"
+  },
+  {
+    "region": "Chinese",
+    "text": "Chinese banquets often end with a whole fish, partly because the word for fish sounds like the word for surplus and so the dish quietly wishes everyone abundance."
+  },
+  {
+    "region": "Korean",
+    "text": "Kimchi making was traditionally a community event called gimjang, with families burying jars of fermented cabbage underground to last the winter, a practice now recognized by UNESCO.",
+    "source_url": "https://en.wikipedia.org/wiki/Kimchi"
+  },
+  {
+    "region": "Korean",
+    "text": "Korean barbecue grills meat right at the table, and the wrapping of each bite in a lettuce leaf with rice, garlic, and paste is called ssam, which means wrapped."
+  },
+  {
+    "region": "Korean",
+    "text": "The bright red of much Korean food comes from gochugaru, sun dried chili flakes, which only became common after chili peppers reached the peninsula a few centuries ago."
+  },
+  {
+    "region": "French",
+    "text": "France's appellation system, which legally ties foods like Champagne and Roquefort to specific places, took shape in the early twentieth century and influenced how the world labels regional food."
+  },
+  {
+    "region": "French",
+    "text": "The mother sauces taught in French kitchens were codified in the nineteenth and twentieth centuries, turning sauce making into a teachable system rather than a closely held secret."
+  },
+  {
+    "region": "French",
+    "text": "The baguette's shape and crust are bound by French rules, and in twenty twenty two UNESCO added the craft of the baguette to its list of cultural heritage.",
+    "source_url": "https://en.wikipedia.org/wiki/Baguette"
+  },
+  {
+    "region": "Italian",
+    "text": "Italy has hundreds of named pasta shapes, and many exist because a particular sauce clings better to a particular ridge, twist, or hollow."
+  },
+  {
+    "region": "Italian",
+    "text": "Parmigiano Reggiano can only be made in a small zone of northern Italy, aged at least a year, and each wheel is inspected and branded before it earns the name.",
+    "source_url": "https://en.wikipedia.org/wiki/Parmigiano-Reggiano"
+  },
+  {
+    "region": "Italian",
+    "text": "Pizza Margherita is said to have been built in eighteen eighty nine to honor a visiting queen, with tomato, mozzarella, and basil echoing the colors of the Italian flag."
+  },
+  {
+    "region": "Iberian",
+    "text": "Spain's tapas tradition may have started with a slice of bread or ham laid over a glass to keep flies out, since the word tapa means lid or cover.",
+    "source_url": "https://en.wikipedia.org/wiki/Tapas"
+  },
+  {
+    "region": "Iberian",
+    "text": "Jamon iberico comes from black hoofed pigs that fatten on acorns in oak woodland, and the best legs are cured for years before anyone slices into them."
+  },
+  {
+    "region": "Iberian",
+    "text": "Portuguese cooks claim there are more than three hundred ways to prepare bacalhau, salt cod, even though the fish is not caught in Portuguese waters and had to be imported."
+  },
+  {
+    "region": "Nordic",
+    "text": "The long dark winters of the north made preserving food essential, which is why cured, smoked, pickled, and fermented fish run through Nordic cooking."
+  },
+  {
+    "region": "Nordic",
+    "text": "Dense dark rye bread is a Scandinavian staple, and the open faced sandwich built on it has its own name and its own etiquette in Denmark."
+  },
+  {
+    "region": "Nordic",
+    "text": "The New Nordic movement that began in the mid two thousands pushed chefs back toward foraged and local ingredients like sea buckthorn, birch sap, and wild herbs.",
+    "source_url": "https://en.wikipedia.org/wiki/New_Nordic_Cuisine"
+  },
+  {
+    "region": "Central European",
+    "text": "The pretzel's knotted shape is often linked to monks who supposedly twisted strips of dough to look like arms folded in prayer.",
+    "source_url": "https://en.wikipedia.org/wiki/Pretzel"
+  },
+  {
+    "region": "Central European",
+    "text": "Central Europe runs on the sausage, with hundreds of regional types, and German rules have long been strict about what is allowed into each named variety."
+  },
+  {
+    "region": "Central European",
+    "text": "The Viennese coffee house was a place to linger for hours over a single coffee and a newspaper, and the culture around it is recognized as part of Austria's heritage."
+  },
+  {
+    "region": "Eastern European",
+    "text": "Borscht, the beet soup, has so many regional versions across Eastern Europe that arguing over which one is the real one is practically a regional sport.",
+    "source_url": "https://en.wikipedia.org/wiki/Borscht"
+  },
+  {
+    "region": "Eastern European",
+    "text": "Fermenting and pickling vegetables for winter, especially turning cabbage into sauerkraut and cucumbers into brined pickles, is a deep habit born of short growing seasons."
+  },
+  {
+    "region": "Eastern European",
+    "text": "The filled dumpling, called pierogi, vareniki, or pelmeni depending on where you stand, shows up at celebrations and weeknight dinners alike across the region."
+  },
+  {
+    "region": "British Isles",
+    "text": "The Sunday roast, meat with potatoes and a baked batter pudding, grew out of cooking a joint of meat slowly while the household was away at church."
+  },
+  {
+    "region": "British Isles",
+    "text": "Fish and chips spread quickly in the nineteenth century thanks to rail delivered fish and cheap frying oil, and it was deliberately kept off rationing during the Second World War to protect morale.",
+    "source_url": "https://en.wikipedia.org/wiki/Fish_and_chips"
+  },
+  {
+    "region": "British Isles",
+    "text": "Afternoon tea as a small meal is credited to a duchess in the eighteen forties who got hungry in the long gap between lunch and a late dinner."
+  },
+  {
+    "region": "North African",
+    "text": "Couscous, tiny steamed semolina, is so central across the Maghreb that the knowledge and rituals around making it are on UNESCO's heritage list, shared by several countries.",
+    "source_url": "https://en.wikipedia.org/wiki/Couscous"
+  },
+  {
+    "region": "North African",
+    "text": "The tagine is both the cone lidded clay pot and the slow stew cooked in it, the shape designed to trap steam and return it to the dish in a dry climate."
+  },
+  {
+    "region": "North African",
+    "text": "Preserved lemons, packed in salt until they turn soft and intensely fragrant, are a North African pantry staple that turns up in stews, salads, and relishes."
+  },
+  {
+    "region": "West African",
+    "text": "Jollof rice, cooked in a spiced tomato base, is the friendly battleground of West Africa, with Nigeria, Ghana, and Senegal each insisting that theirs is the best.",
+    "source_url": "https://en.wikipedia.org/wiki/Jollof_rice"
+  },
+  {
+    "region": "West African",
+    "text": "The groundnut, or peanut, traveled from the Americas and became so woven into West African cooking that rich peanut stews are now treated as classic regional dishes."
+  },
+  {
+    "region": "West African",
+    "text": "Fermented and pounded cassava, yam, or plantain becomes the stretchy fufu eaten by pinching off a piece and using it to scoop up soup."
+  },
+  {
+    "region": "East African",
+    "text": "Ethiopian and Eritrean meals are served on injera, a large spongy sourdough flatbread made from teff, a grain so tiny that a handful holds thousands of seeds.",
+    "source_url": "https://en.wikipedia.org/wiki/Injera"
+  },
+  {
+    "region": "East African",
+    "text": "Coffee is widely believed to have originated in the Ethiopian highlands, and the traditional coffee ceremony there roasts, grinds, and brews the beans in front of the guests."
+  },
+  {
+    "region": "East African",
+    "text": "The East African coast absorbed centuries of Indian Ocean trade, which is why Swahili cooking leans on coconut milk, cardamom, and rice alongside local ingredients."
+  },
+  {
+    "region": "Caribbean",
+    "text": "Jamaican jerk seasoning traces back to the Maroons, formerly enslaved people who smoked spiced meat slowly over pimento wood in the hills.",
+    "source_url": "https://en.wikipedia.org/wiki/Jerk_(cooking)"
+  },
+  {
+    "region": "Caribbean",
+    "text": "The Scotch bonnet pepper, fruity and fierce at the same time, is the signature heat of the Caribbean and shows up in everything from stews to bottled pepper sauce."
+  },
+  {
+    "region": "Caribbean",
+    "text": "Rice and peas, usually rice cooked with kidney beans or pigeon peas in coconut milk, is the Sunday side dish across much of the English speaking Caribbean."
+  },
+  {
+    "region": "Central American",
+    "text": "Corn is treated almost as sacred across Central America, and the ancient step of soaking it in mineral lime, called nixtamalization, makes it more nutritious and easier to grind into masa."
+  },
+  {
+    "region": "Central American",
+    "text": "Pupusas, thick stuffed corn cakes, are the national dish of El Salvador, with their own holiday and a usual topping of tangy fermented cabbage slaw.",
+    "source_url": "https://en.wikipedia.org/wiki/Pupusa"
+  },
+  {
+    "region": "Central American",
+    "text": "Chocolate began here as a bitter ceremonial drink among the Maya and Aztec, spiced rather than sweetened, long before sugar ever touched it."
+  },
+  {
+    "region": "North American",
+    "text": "Many iconic American foods are immigrant inventions adapted to new surroundings, from the bagel to chop suey to the deli pastrami sandwich."
+  },
+  {
+    "region": "North American",
+    "text": "The Indigenous Three Sisters planting of corn, beans, and squash together fed much of North America and still shapes regional dishes today.",
+    "source_url": "https://en.wikipedia.org/wiki/Three_Sisters_(agriculture)"
+  },
+  {
+    "region": "North American",
+    "text": "Barbecue in the American South splintered into rival regional styles, with different states swearing by pork or beef and by vinegar, mustard, or tomato based sauces."
+  },
+  {
+    "region": "South American",
+    "text": "The potato was domesticated in the Andes, where farmers still grow thousands of varieties in colors and shapes rarely seen anywhere else."
+  },
+  {
+    "region": "South American",
+    "text": "Ceviche, raw fish cured in citrus juice, is a point of pride along the Pacific coast, especially in Peru, where it even has its own national day.",
+    "source_url": "https://en.wikipedia.org/wiki/Ceviche"
+  },
+  {
+    "region": "South American",
+    "text": "The gaucho tradition of grilling beef over open fire, called asado in Argentina and churrasco in Brazil, turned barbecue into a weekend social ritual."
+  },
+  {
+    "region": "Southeast Asian",
+    "text": "Fish sauce, fermented from salted anchovies, is the salty backbone of much Southeast Asian cooking, called nuoc mam in Vietnam and nam pla in Thailand.",
+    "source_url": "https://en.wikipedia.org/wiki/Fish_sauce"
+  },
+  {
+    "region": "Southeast Asian",
+    "text": "Southeast Asian flavor balance aims for sour, sweet, salty, and spicy all in one dish, which is why a single bite can carry lime, palm sugar, fish sauce, and chili at once."
+  },
+  {
+    "region": "Southeast Asian",
+    "text": "The banana leaf is a workhorse here, used as a plate, a wrapper for steaming, and a lid, then simply composted when the meal is done."
+  },
+  {
+    "region": "Central Asian",
+    "text": "Plov, also called pilaf or osh, is the centerpiece of Central Asian gatherings, often cooked outdoors in a huge cast iron kazan over a wood fire.",
+    "source_url": "https://en.wikipedia.org/wiki/Pilaf"
+  },
+  {
+    "region": "Central Asian",
+    "text": "Nomadic herding shaped the region's diet around mutton, horse meat, and dairy, including the fermented mare's milk known as kumis."
+  },
+  {
+    "region": "Central Asian",
+    "text": "Round flatbread called non or lepyoshka is treated with respect, traditionally never set down upside down and often stamped with a decorative pattern before baking."
+  },
+  {
+    "region": "Oceanian",
+    "text": "The earth oven, called an umu, hangi, or lovo across the Pacific, slow cooks meat and root vegetables on hot stones buried under leaves and soil."
+  },
+  {
+    "region": "Oceanian",
+    "text": "Taro, breadfruit, and coconut form the backbone of traditional island cooking, carried between islands by voyagers over thousands of years."
+  },
+  {
+    "region": "Oceanian",
+    "text": "The pavlova, a meringue dessert topped with cream and fruit, is claimed by both Australia and New Zealand, and the rivalry over where it was first made is genuinely heated.",
+    "source_url": "https://en.wikipedia.org/wiki/Pavlova_(cake)"
+  }
+]


### PR DESCRIPTION
## Summary
- Add curated region-tied CulturalFact data (~93 facts, 3 per region across the 31 broad cuisine regions that seeded recipes use)
- Add a standalone, idempotent seed_cultural_facts command that resolves each entry's region by name, leaves heritage_group null, and warns and skips unknown regions instead of crashing
- Add apps/heritage/tests_facts_seed.py covering count, per-region coverage, heritage_group-null invariant, idempotency, unknown-region skipping, ?region= filter, and /random/

## Test plan
- [x] cd app/backend && python manage.py seed_canonical && python manage.py seed_cultural_facts
- [x] python manage.py test apps.heritage.tests_facts_seed
- [x] python manage.py test apps.heritage (67 tests, all green)
- [x] python manage.py makemigrations --check --dry-run (clean)

## Notes
- Region-tied facts only (heritage_group left null); the four heritage groups already had nested facts via seed_canonical, so region coverage was the gap. Standalone fixtures/cultural_facts.json and command to avoid contention on seed_canonical.json.
- "Caucasian" appears in the fixture but is not currently a seeded region, so the command warns and skips it; this also exercises the missing-region path on every run.

Closes #664.