### PR TITLE
fix(backend): login flow reliability, regression tests and root-cause note (#392)

### DIFF
--- a/app/backend/apps/users/tests_login_reliability.py
+++ b/app/backend/apps/users/tests_login_reliability.py
@@ -1,0 +1,186 @@
+"""Login flow reliability regression tests (#392, #TD-01).
+
+Multiple demo attendees hit login errors during the MVP demo. This suite pins
+down the backend half of the login contract that the web and mobile clients
+retry against:
+
+* the login (token-obtain) endpoint returns a clean, well-shaped 4xx for bad
+  credentials, missing fields, an empty body, and a garbage body, and never a
+  500 with a leaked stack trace;
+* ``auth/token/refresh/`` behaves correctly for a valid, an expired, a
+  malformed, and a blacklisted refresh token;
+* a protected endpoint answers ``401 {"code": "token_not_valid"}`` (not 403,
+  not 500) for an expired or garbage access token, so clients can branch on it;
+* the wrong HTTP method on the login route is a plain ``405``, not a blank 500.
+
+The session-rotation/logout lifecycle is covered separately in
+``apps/users/tests_session.py`` (#393); a couple of access-token cases overlap
+on purpose so this file documents the full login-reliability contract on its
+own. The remaining demo-login flakiness is the mobile client not handling
+``401 token_not_valid`` (tracked in #405), not a backend defect.
+"""
+from datetime import timedelta
+
+from django.contrib.auth import get_user_model
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APITestCase
+from rest_framework_simplejwt.tokens import AccessToken, RefreshToken
+
+User = get_user_model()
+
+LOGIN_URL = '/api/auth/login/'
+REFRESH_URL = '/api/auth/token/refresh/'
+LOGOUT_URL = '/api/auth/logout/'
+ME_URL = '/api/users/me/'
+
+EMAIL = 'login-reliability@example.com'
+PASSWORD = 'StrongPass123!'
+
+
+def _is_server_error(response):
+    return response.status_code >= 500
+
+
+class LoginEndpointReliabilityTest(APITestCase):
+    """The login endpoint must answer every malformed request with a 4xx."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            email=EMAIL, username='loginreliabilityuser', password=PASSWORD
+        )
+
+    def test_valid_credentials_return_access_and_refresh(self):
+        response = self.client.post(LOGIN_URL, {'email': EMAIL, 'password': PASSWORD})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn('access', response.data)
+        self.assertIn('refresh', response.data)
+        self.assertTrue(response.data['access'])
+        self.assertTrue(response.data['refresh'])
+
+    def test_wrong_password_returns_400_with_json_error_no_stack_trace(self):
+        response = self.client.post(LOGIN_URL, {'email': EMAIL, 'password': 'wrong-password'})
+        self.assertFalse(_is_server_error(response))
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIsInstance(response.data, dict)
+        self.assertIn('non_field_errors', response.data)
+        # The body is the serializer's error dict, never a rendered traceback.
+        self.assertNotIn('Traceback', response.content.decode())
+
+    def test_missing_password_returns_400_field_error(self):
+        response = self.client.post(LOGIN_URL, {'email': EMAIL})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('password', response.data)
+
+    def test_missing_email_returns_400_field_error(self):
+        response = self.client.post(LOGIN_URL, {'password': PASSWORD})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('email', response.data)
+
+    def test_empty_body_returns_400_not_500(self):
+        response = self.client.post(LOGIN_URL)
+        self.assertFalse(_is_server_error(response))
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('email', response.data)
+        self.assertIn('password', response.data)
+
+    def test_garbage_json_body_returns_400_not_500(self):
+        response = self.client.post(
+            LOGIN_URL, data='}{ this is not valid json', content_type='application/json'
+        )
+        self.assertFalse(_is_server_error(response))
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_non_object_json_body_returns_400_not_500(self):
+        response = self.client.post(LOGIN_URL, data=['not', 'an', 'object'], format='json')
+        self.assertFalse(_is_server_error(response))
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_wrong_method_returns_405_not_blank_500(self):
+        response = self.client.get(LOGIN_URL)
+        self.assertFalse(_is_server_error(response))
+        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+
+
+class TokenRefreshReliabilityTest(APITestCase):
+    """``auth/token/refresh/`` must rotate valid tokens and reject the rest."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            email=EMAIL, username='refreshreliabilityuser', password=PASSWORD
+        )
+        login = self.client.post(LOGIN_URL, {'email': EMAIL, 'password': PASSWORD})
+        self.assertEqual(login.status_code, status.HTTP_200_OK)
+        self.access = login.data['access']
+        self.refresh = login.data['refresh']
+
+    def test_valid_refresh_returns_new_access(self):
+        response = self.client.post(REFRESH_URL, {'refresh': self.refresh})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn('access', response.data)
+        self.assertTrue(response.data['access'])
+        self.assertNotEqual(response.data['access'], self.access)
+
+    def test_missing_refresh_returns_400(self):
+        response = self.client.post(REFRESH_URL, {})
+        self.assertFalse(_is_server_error(response))
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_expired_refresh_returns_401_token_not_valid(self):
+        token = RefreshToken.for_user(self.user)
+        # Push the expiry comfortably into the past without sleeping.
+        token.set_exp(from_time=timezone.now() - timedelta(days=120))
+        response = self.client.post(REFRESH_URL, {'refresh': str(token)})
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.data.get('code'), 'token_not_valid')
+
+    def test_malformed_refresh_returns_401_token_not_valid(self):
+        response = self.client.post(REFRESH_URL, {'refresh': 'not-a-real.jwt.token'})
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.data.get('code'), 'token_not_valid')
+
+    def test_blacklisted_refresh_after_logout_returns_401_token_not_valid(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {self.access}')
+        logout = self.client.post(LOGOUT_URL, {'refresh': self.refresh})
+        self.assertEqual(logout.status_code, status.HTTP_205_RESET_CONTENT)
+        self.client.credentials()
+        response = self.client.post(REFRESH_URL, {'refresh': self.refresh})
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.data.get('code'), 'token_not_valid')
+
+
+class ProtectedEndpointTokenContractTest(APITestCase):
+    """A protected endpoint must reject bad access tokens with token_not_valid.
+
+    Overlaps intentionally with ``tests_session.py`` so this file states the
+    full login-reliability contract; clients (``app/mobile``) branch on the
+    ``code`` field, so 403 or 500 here would break their refresh-and-retry.
+    """
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            email=EMAIL, username='guardreliabilityuser', password=PASSWORD
+        )
+
+    def test_expired_access_token_returns_401_token_not_valid(self):
+        token = AccessToken.for_user(self.user)
+        token.set_exp(from_time=timezone.now() - timedelta(hours=2))
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {token}')
+        response = self.client.get(ME_URL)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.data.get('code'), 'token_not_valid')
+
+    def test_garbage_bearer_token_returns_401_token_not_valid(self):
+        self.client.credentials(HTTP_AUTHORIZATION='Bearer complete-garbage-token')
+        response = self.client.get(ME_URL)
+        self.assertNotEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertFalse(_is_server_error(response))
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.data.get('code'), 'token_not_valid')
+
+    def test_valid_access_token_reaches_protected_endpoint(self):
+        token = AccessToken.for_user(self.user)
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {token}')
+        response = self.client.get(ME_URL)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['email'], EMAIL)

--- a/docs/td-01-login-reliability.md
+++ b/docs/td-01-login-reliability.md
@@ -1,0 +1,98 @@
+# TD-01: Login flow reliability (backend root-cause note)
+
+Issue: #392. Mobile counterpart: #405. Broader auth/session refactor: #393 (#TD-02, merged in PR #744).
+
+## Why this note exists
+
+Multiple MVP demo attendees hit login errors, which blocks onboarding and M4
+work. The issue asks for a root-cause write-up, a fix, and regression tests
+covering expired tokens, empty responses, and network-retry-shaped failures.
+This note is the backend half. The frontend reliability work (UI retry, error
+toasts) and the mobile 401 handling are tracked separately (#405 and the
+frontend issues).
+
+## The login path, end to end
+
+| Step | Route | View | Behaviour |
+| --- | --- | --- | --- |
+| Obtain tokens | `POST /api/auth/login/` | `apps/users/views.py:LoginView` | `LoginSerializer` validates `email` + `password`, calls `authenticate(username=email, password=...)`. On success returns `200 {user, access, refresh}`. On failure returns the serializer error dict with `400`. |
+| Register | `POST /api/auth/register/` | `RegisterView` | Creates the user, returns `201 {user, access, refresh}`. |
+| Refresh | `POST /api/auth/token/refresh/` (alias `POST /api/auth/refresh/`) | `TokenRefreshView` | Validates the supplied `refresh` token, blacklists it, mints and returns a new `{access, refresh}` pair (`ROTATE_REFRESH_TOKENS` + `BLACKLIST_AFTER_ROTATION` are on). |
+| Logout | `POST /api/auth/logout/` | `LogoutView` | Blacklists the supplied `refresh` token, returns `205`. |
+| Protected read | `GET /api/users/me/` (and every authenticated endpoint) | `MeView` etc. | `JWTAuthentication` is the default; an invalid/expired access token is rejected before the view with `401 {"detail": ..., "code": "token_not_valid"}`. |
+
+Token lifetimes live in `app/backend/config/settings.py` (`SIMPLE_JWT`):
+access 60 minutes, refresh 90 days.
+
+## Which backend conditions yield which status code
+
+Login (`POST /api/auth/login/`):
+
+| Input | Status | Body |
+| --- | --- | --- |
+| Valid credentials | `200` | `{user, access, refresh}` |
+| Wrong password / unknown email | `400` | `{"non_field_errors": ["Invalid credentials"]}` |
+| Missing `password` (or `email`) | `400` | `{"password": ["This field is required."]}` (resp. `email`) |
+| Empty request body | `400` | `{"email": [...], "password": [...]}` |
+| Malformed JSON body | `400` | DRF parse-error detail |
+| Non-object JSON (e.g. a list) | `400` | DRF "expected a dictionary" detail |
+| `GET` (or any non-POST) | `405` | `{"detail": "Method \"GET\" not allowed."}` |
+
+Refresh (`POST /api/auth/token/refresh/`):
+
+| Input | Status | Body |
+| --- | --- | --- |
+| Valid refresh token | `200` | `{access, refresh}` (rotated) |
+| Missing `refresh` | `400` | `{"detail": "Refresh token required."}` |
+| Malformed / wrong-signature token | `401` | `{"detail": ..., "code": "token_not_valid"}` |
+| Expired token | `401` | `{"detail": ..., "code": "token_not_valid"}` |
+| Blacklisted token (after rotation or logout) | `401` | `{"detail": ..., "code": "token_not_valid"}` |
+
+Protected endpoints with a bad `Authorization: Bearer <access>` header:
+
+| Input | Status | Body |
+| --- | --- | --- |
+| Valid access token | `200` | endpoint payload |
+| No header | `401` | `{"detail": "Authentication credentials were not provided."}` |
+| Expired access token | `401` | `{"detail": ..., "code": "token_not_valid"}` |
+| Malformed / garbage Bearer token | `401` | `{"detail": ..., "code": "token_not_valid"}` |
+
+## Backend vs client responsibility
+
+Backend-owned, and verified by the regression suite below:
+
+- The login endpoint never returns `500` for a malformed request (empty body,
+  garbage JSON, non-object JSON, wrong HTTP method); it always returns a
+  well-shaped `4xx` JSON body and never a rendered traceback.
+- `token/refresh/` returns `401 {"code": "token_not_valid"}` for an expired,
+  malformed, or blacklisted refresh token, and a `400` for a missing one.
+- Protected endpoints return `401 {"code": "token_not_valid"}` (not `403`, not
+  `500`) for an expired or garbage access token, so clients can branch on the
+  `code` field.
+
+Client-owned (out of scope here):
+
+- The mobile `httpClient` attaches the stored Bearer token but does not act on
+  `401 {"code": "token_not_valid"}`: it does not attempt a refresh, does not
+  clear stale tokens, and does not redirect to Login. A token issued by one
+  backend and replayed against another (different `SECRET_KEY`), or a token
+  that has simply aged past the 60-minute access lifetime, therefore surfaces
+  as a silent failure on every authenticated screen. That is #405.
+- Web-side retry/error-toast behaviour belongs to the frontend issues.
+
+## Conclusion
+
+No backend bug was found. The login, refresh, logout, and protected-endpoint
+paths already return correct, stable, well-shaped responses for the failure
+modes the demo exposed. The remaining demo-login flakiness is the mobile client
+not handling `401 {"code": "token_not_valid"}` (tracked in #405), not a
+backend defect. The deliverable here is the regression suite that pins the
+contract clients retry against:
+`app/backend/apps/users/tests_login_reliability.py` (16 tests; the
+session-rotation/logout lifecycle is covered in `tests_session.py`, #393).
+
+## Follow-ups (not done here)
+
+- Login is currently unthrottled. Brute-force / rate-limiting protection on
+  `POST /api/auth/login/` would be a reasonable hardening step but is out of
+  scope for #TD-01; file it as a separate tech-debt item if the team wants it.


### PR DESCRIPTION
## Summary
- Add apps/users/tests_login_reliability.py: login happy path, bad/missing/empty/garbage/non-object request bodies all return a clean 4xx (no 500, no stack trace), wrong-method 405, token/refresh with valid/expired/malformed/blacklisted refresh, protected endpoint returns 401 token_not_valid for expired and garbage access tokens (not 403, not 500). A couple of access-token cases overlap tests_session.py (#393) on purpose so the login-reliability contract reads on its own.
- Root-cause note (docs/td-01-login-reliability.md): backend login path end to end, which conditions yield which status codes, backend vs client responsibility, conclusion that no backend bug was found and the remaining demo-login flakiness is the mobile client not handling 401 token_not_valid.
- No backend fix was needed; the login/refresh/logout/protected-endpoint paths already return correct, well-shaped responses for every failure mode the demo exposed. The value here is the regression suite plus the write-up.

## Test plan
- [x] cd app/backend && python manage.py test apps.users (87 + 16 new, green)
- [x] python manage.py test (full suite, 839 tests, green)
- [x] python manage.py makemigrations --check --dry-run (no changes detected)

## Notes
- Backend slice of #TD-01. The remaining demo-login flakiness is the mobile client not handling 401 token_not_valid, tracked in #405; the web reliability items belong to the frontend issues. Login is currently unthrottled; rate limiting is noted as a possible follow-up but is out of scope here.

Closes #392.