### PR TITLE
feat(mobile): story pins on region map detail (#731)

### DIFF
--- a/app/mobile/src/screens/RegionMapDetailScreen.tsx
+++ b/app/mobile/src/screens/RegionMapDetailScreen.tsx
@@ -1,14 +1,16 @@
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { FlatList, Image, Pressable, StyleSheet, Text, View } from 'react-native';
-import MapView, { Marker } from 'react-native-maps';
+import MapView, { Callout, Marker } from 'react-native-maps';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { ErrorView } from '../components/ui/ErrorView';
 import { LoadingView } from '../components/ui/LoadingView';
 import { MapZoomControls } from '../components/map/MapZoomControls';
 import {
   fetchRegionRecipes,
+  fetchRegionStories,
   type RegionRecipesPayload,
+  type RegionStoryPin,
   type UnlocatedRecipe,
 } from '../services/mapDataService';
 import type { RootStackParamList } from '../navigation/types';
@@ -17,8 +19,9 @@ import { shadows, tokens } from '../theme';
 type Props = NativeStackScreenProps<RootStackParamList, 'RegionMapDetail'>;
 
 export default function RegionMapDetailScreen({ route, navigation }: Props) {
-  const { regionName } = route.params;
+  const { regionId, regionName } = route.params;
   const [payload, setPayload] = useState<RegionRecipesPayload | null>(null);
+  const [stories, setStories] = useState<RegionStoryPin[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [reloadToken, setReloadToken] = useState(0);
@@ -45,6 +48,23 @@ export default function RegionMapDetailScreen({ route, navigation }: Props) {
       cancelled = true;
     };
   }, [regionName, reloadToken]);
+
+  // Parallel fetch of story pins (#731). Stories may have no lat/lng yet —
+  // backend #730 only just added the fields. If the call fails or returns
+  // nothing usable, the recipe map still works untouched.
+  useEffect(() => {
+    let cancelled = false;
+    fetchRegionStories(regionId)
+      .then((data) => {
+        if (!cancelled) setStories(data);
+      })
+      .catch(() => {
+        if (!cancelled) setStories([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [regionId, reloadToken]);
 
   const initialRegion = useMemo(() => {
     if (!payload) return null;
@@ -73,7 +93,10 @@ export default function RegionMapDetailScreen({ route, navigation }: Props) {
   // immediately see the spread of pins instead of a static initial frame.
   useEffect(() => {
     if (!mapRef.current || !payload) return;
-    const coords = payload.located.map((r) => r.coords);
+    const coords = [
+      ...payload.located.map((r) => r.coords),
+      ...stories.map((s) => s.coords),
+    ];
     if (coords.length === 0) return;
     const t = setTimeout(() => {
       mapRef.current?.fitToCoordinates(coords, {
@@ -82,7 +105,7 @@ export default function RegionMapDetailScreen({ route, navigation }: Props) {
       });
     }, 250);
     return () => clearTimeout(t);
-  }, [payload]);
+  }, [payload, stories]);
 
   if (loading) {
     return (
@@ -134,11 +157,44 @@ export default function RegionMapDetailScreen({ route, navigation }: Props) {
             <Marker
               key={`r-${r.id}`}
               coordinate={r.coords}
-              title={r.title}
-              description={r.authorUsername ? `By ${r.authorUsername}` : undefined}
               pinColor={tokens.colors.accentGreen}
               onCalloutPress={() => navigation.navigate('RecipeDetail', { id: r.id })}
-            />
+            >
+              <Callout tooltip>
+                <View style={styles.callout}>
+                  <Text style={styles.calloutKind}>RECIPE</Text>
+                  <Text style={styles.calloutTitle} numberOfLines={2}>
+                    {r.title}
+                  </Text>
+                  {r.authorUsername ? (
+                    <Text style={styles.calloutHint}>By {r.authorUsername}</Text>
+                  ) : null}
+                  <Text style={styles.calloutHint}>Tap to open →</Text>
+                </View>
+              </Callout>
+            </Marker>
+          ))}
+
+          {stories.map((s) => (
+            <Marker
+              key={`s-${s.id}`}
+              coordinate={s.coords}
+              pinColor={tokens.colors.accentMustard}
+              onCalloutPress={() => navigation.navigate('StoryDetail', { id: String(s.id) })}
+            >
+              <View style={styles.storyMarker}>
+                <Text style={styles.storyGlyph}>📖</Text>
+              </View>
+              <Callout tooltip>
+                <View style={styles.callout}>
+                  <Text style={styles.calloutKind}>STORY · {s.title}</Text>
+                  {s.author ? (
+                    <Text style={styles.calloutHint}>By {s.author}</Text>
+                  ) : null}
+                  <Text style={styles.calloutHint}>Tap to open →</Text>
+                </View>
+              </Callout>
+            </Marker>
           ))}
         </MapView>
 
@@ -148,7 +204,12 @@ export default function RegionMapDetailScreen({ route, navigation }: Props) {
           <View style={styles.headerCard}>
             <Text style={styles.headerTitle}>{regionName}</Text>
             <Text style={styles.headerSub}>
-              {payload.located.length} on map · {payload.unlocated.length} without a location
+              📖 {stories.length} stor{stories.length === 1 ? 'y' : 'ies'} · 📍{' '}
+              {payload.located.length} recipe{payload.located.length === 1 ? '' : 's'}
+            </Text>
+            <Text style={styles.headerSubMuted}>
+              {payload.unlocated.length} recipe{payload.unlocated.length === 1 ? '' : 's'} without
+              a location
             </Text>
           </View>
         </View>
@@ -249,7 +310,41 @@ const styles = StyleSheet.create({
     color: tokens.colors.text,
     fontFamily: tokens.typography.display.fontFamily,
   },
-  headerSub: { fontSize: 12, fontWeight: '700', color: tokens.colors.textMuted },
+  headerSub: { fontSize: 12, fontWeight: '700', color: tokens.colors.text },
+  headerSubMuted: { fontSize: 11, fontWeight: '600', color: tokens.colors.textMuted },
+
+  storyMarker: {
+    width: 36,
+    height: 36,
+    borderRadius: 999,
+    backgroundColor: tokens.colors.accentMustard,
+    borderWidth: 2.5,
+    borderColor: tokens.colors.surfaceDark,
+    alignItems: 'center',
+    justifyContent: 'center',
+    ...shadows.sm,
+  },
+  storyGlyph: { fontSize: 16 },
+
+  callout: {
+    minWidth: 180,
+    maxWidth: 240,
+    padding: 10,
+    borderRadius: tokens.radius.lg,
+    backgroundColor: tokens.colors.bg,
+    borderWidth: 1.5,
+    borderColor: tokens.colors.surfaceDark,
+    gap: 4,
+    ...shadows.md,
+  },
+  calloutKind: {
+    fontSize: 10,
+    fontWeight: '900',
+    letterSpacing: 1.2,
+    color: tokens.colors.textMuted,
+  },
+  calloutTitle: { fontSize: 13, fontWeight: '800', color: tokens.colors.text },
+  calloutHint: { fontSize: 11, fontWeight: '700', color: tokens.colors.textMuted },
 
   unlocatedWrap: {
     position: 'absolute',

--- a/app/mobile/src/services/mapDataService.ts
+++ b/app/mobile/src/services/mapDataService.ts
@@ -25,6 +25,13 @@ export type RegionRecipePin = {
   coords: LatLng;
 };
 
+export type RegionStoryPin = {
+  id: number;
+  title: string;
+  coords: LatLng;
+  author: string | null;
+};
+
 export type UnlocatedRecipe = {
   id: string;
   title: string;
@@ -200,4 +207,58 @@ export async function fetchRegionRecipes(
   }
 
   return { located, unlocated, bbox, centroid };
+}
+
+/**
+ * Fetch stories scoped to a region and return only those with usable lat/lng
+ * (closes #731). Backend #730 added `latitude`/`longitude` to the Story
+ * serializer; DRF may serialize them as numbers OR strings depending on the
+ * underlying field type, so we coerce defensively. Stories without coords are
+ * silently dropped — until the seed data fills them in, this list will often
+ * be empty, and the screen should still show recipes as before.
+ */
+export async function fetchRegionStories(regionId: number): Promise<RegionStoryPin[]> {
+  const toNum = (v: unknown): number | null => {
+    if (v == null) return null;
+    if (typeof v === 'number') return Number.isFinite(v) ? v : null;
+    if (typeof v === 'string') {
+      const n = parseFloat(v);
+      return Number.isFinite(n) ? n : null;
+    }
+    return null;
+  };
+
+  const collected: any[] = [];
+  let path: string | null = `/api/stories/?region=${encodeURIComponent(String(regionId))}`;
+  while (path) {
+    const data: any = await apiGetJson<any>(path);
+    if (Array.isArray(data)) {
+      collected.push(...data);
+      break;
+    }
+    if (data && Array.isArray(data.results)) {
+      collected.push(...data.results);
+      path = nextPagePath(data.next);
+    } else {
+      break;
+    }
+  }
+
+  const pins: RegionStoryPin[] = [];
+  for (const s of collected) {
+    const lat = toNum(s.latitude);
+    const lng = toNum(s.longitude);
+    if (lat == null || lng == null) continue;
+    const id = Number(s.id);
+    if (!Number.isFinite(id)) continue;
+    const title = typeof s.title === 'string' ? s.title : '';
+    const author =
+      typeof s.author_username === 'string'
+        ? s.author_username
+        : typeof s.author === 'string'
+          ? s.author
+          : null;
+    pins.push({ id, title, coords: { latitude: lat, longitude: lng }, author });
+  }
+  return pins;
 }


### PR DESCRIPTION
## Summary
RegionMapDetailScreen now plots stories alongside recipes, using `/api/stories/?region={id}` (exposed by backend #730). Recipe pins keep the green default; story pins use a mustard circular badge with a 📖 glyph and a `STORY · {title}` callout, so the two layers stay visually distinct. `fitToCoordinates` now spans both pin sets, and the header card shows `📖 N stories · 📍 M recipes`. New service helper `fetchRegionStories(regionId)` walks DRF pagination and coerces lat/lng defensively (DecimalField → string).

If a region has no story rows with lat/lng set yet, the screen silently falls back to the prior recipe-only view — no broken empty state. Couldn't verify real seeded data: backend wasn't running on localhost:8000 from this worktree, so the story layer's presence depends on whether #732-adjacent seeding has landed.

Closes #731

## Test plan
- [ ] Open MapDiscovery → tap a region pin → RegionMapDetailScreen
- [ ] Recipe pins still render in green and open RecipeDetail on callout tap
- [ ] If the region has stories with coords, mustard 📖 markers appear; callout shows `STORY · {title}` and tap opens StoryDetail
- [ ] Map fits both recipe and story pins on initial load
- [ ] Header card shows the `📖 N stories · 📍 M recipes` line
- [ ] Region with zero located stories: screen behaves exactly as before (no error/empty state)