### PR TITLE
feat(mobile): bookmark recipes — detail button, card icon, saved tab (closes #708, closes #710)

### DIFF
--- a/app/mobile/src/components/search/SearchResultCard.tsx
+++ b/app/mobile/src/components/search/SearchResultCard.tsx
@@ -53,6 +53,11 @@ export function SearchResultCard({ item, onPress }: Props) {
         </View>
         <RankReasonBadge reason={item.rankReason} />
       </View>
+      {item.isBookmarked ? (
+        <View style={styles.bookmarkBadge} accessibilityLabel="Bookmarked recipe">
+          <Text style={styles.bookmarkBadgeIcon}>🔖</Text>
+        </View>
+      ) : null}
     </Pressable>
   );
 }
@@ -96,5 +101,21 @@ const styles = StyleSheet.create({
     paddingHorizontal: 8,
   },
   tagText: { fontSize: 12, color: tokens.colors.text, fontWeight: '800' },
+  // Top-right read-only indicator — tap on the card still routes to detail.
+  // The card sets `overflow: hidden`, so this stays clipped to the rounded corner.
+  bookmarkBadge: {
+    position: 'absolute',
+    top: 8,
+    right: 8,
+    width: 28,
+    height: 28,
+    borderRadius: 999,
+    backgroundColor: tokens.colors.surface,
+    borderWidth: 1.5,
+    borderColor: tokens.colors.surfaceDark,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  bookmarkBadgeIcon: { fontSize: 14 },
 });
 

--- a/app/mobile/src/screens/RecipeDetailScreen.tsx
+++ b/app/mobile/src/screens/RecipeDetailScreen.tsx
@@ -17,6 +17,7 @@ import { DidYouKnowSection } from '../components/cultural/DidYouKnowSection';
 import { fetchCulturalFactsByRegion, type CulturalFact } from '../services/culturalFactService';
 import type { RootStackParamList } from '../navigation/types';
 import { fetchCheckedIngredients, toggleCheckedIngredient } from '../services/checkOffService';
+import { toggleBookmark } from '../services/bookmarkService';
 import { fetchRecipeById } from '../services/recipeService';
 import { fetchStoriesForRecipe, type StoryListItem } from '../services/storyService';
 import { fetchConversion } from '../services/unitConversionService';
@@ -42,6 +43,7 @@ export default function RecipeDetailScreen({ route, navigation }: Props) {
   const [checkedIds, setCheckedIds] = useState<Set<number>>(new Set());
   const [showShoppingList, setShowShoppingList] = useState(false);
   const [culturalFacts, setCulturalFacts] = useState<CulturalFact[]>([]);
+  const [bookmarkBusy, setBookmarkBusy] = useState(false);
   const { showToast } = useToast();
 
   useEffect(() => {
@@ -237,6 +239,45 @@ export default function RecipeDetailScreen({ route, navigation }: Props) {
   /** Hide Edit until session is restored from storage (avoids flash for signed-in authors). */
   const canEdit = isReady && isAuthenticated && isRecipeAuthor(user, recipe);
 
+  const onToggleBookmark = async () => {
+    // Auth gate mirrors the create-screen convention — unauthenticated users
+    // are routed to Login instead of seeing a silent no-op tap.
+    if (!isAuthenticated) {
+      navigation.navigate('Login');
+      return;
+    }
+    if (bookmarkBusy) return;
+    const prevFlag = recipe.is_bookmarked === true;
+    const prevCount = typeof recipe.bookmark_count === 'number' ? recipe.bookmark_count : 0;
+    const nextFlag = !prevFlag;
+    const optimisticCount = Math.max(0, prevCount + (nextFlag ? 1 : -1));
+    setBookmarkBusy(true);
+    setRecipe((prev) =>
+      prev ? { ...prev, is_bookmarked: nextFlag, bookmark_count: optimisticCount } : prev,
+    );
+    try {
+      const result = await toggleBookmark(id);
+      setRecipe((prev) =>
+        prev
+          ? { ...prev, is_bookmarked: result.is_bookmarked, bookmark_count: result.bookmark_count }
+          : prev,
+      );
+    } catch (e) {
+      // Rollback to the pre-tap state and surface the failure via the same
+      // toast channel the rest of the screen uses for errors.
+      setRecipe((prev) =>
+        prev ? { ...prev, is_bookmarked: prevFlag, bookmark_count: prevCount } : prev,
+      );
+      showToast(e instanceof Error ? e.message : 'Could not update bookmark.', 'error');
+    } finally {
+      setBookmarkBusy(false);
+    }
+  };
+
+  const isBookmarked = recipe.is_bookmarked === true;
+  const bookmarkCount =
+    typeof recipe.bookmark_count === 'number' ? recipe.bookmark_count : undefined;
+
   return (
     <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
       <ScrollView contentContainerStyle={styles.scroll}>
@@ -292,6 +333,27 @@ export default function RecipeDetailScreen({ route, navigation }: Props) {
               <Text style={styles.editLinkText}>Edit recipe</Text>
             </Pressable>
           ) : null}
+
+          <Pressable
+            onPress={() => void onToggleBookmark()}
+            disabled={bookmarkBusy}
+            style={({ pressed }) => [
+              styles.bookmarkBtn,
+              isBookmarked && styles.bookmarkBtnActive,
+              pressed && { opacity: 0.85 },
+              bookmarkBusy && { opacity: 0.6 },
+            ]}
+            accessibilityRole="button"
+            accessibilityState={{ selected: isBookmarked, busy: bookmarkBusy }}
+            accessibilityLabel={isBookmarked ? 'Remove bookmark' : 'Save recipe to bookmarks'}
+            hitSlop={8}
+          >
+            <Text style={styles.bookmarkIcon}>{isBookmarked ? '🔖' : '🏷'}</Text>
+            <Text style={[styles.bookmarkText, isBookmarked && styles.bookmarkTextActive]}>
+              {isBookmarked ? 'Saved' : 'Save'}
+              {bookmarkCount != null ? ` · ${bookmarkCount}` : ''}
+            </Text>
+          </Pressable>
 
           {recipe.image ? (
             <View style={styles.imageWrap} accessibilityLabel="Recipe image">
@@ -602,6 +664,30 @@ const styles = StyleSheet.create({
     borderColor: tokens.colors.surfaceDark,
   },
   editLinkText: { fontSize: 14, color: tokens.colors.textOnDark, fontWeight: '800', letterSpacing: 0.3 },
+  bookmarkBtn: {
+    alignSelf: 'flex-start',
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    marginTop: 12,
+    paddingVertical: 8,
+    paddingHorizontal: 14,
+    borderRadius: tokens.radius.pill,
+    backgroundColor: tokens.colors.surface,
+    borderWidth: 2,
+    borderColor: tokens.colors.surfaceDark,
+  },
+  bookmarkBtnActive: {
+    backgroundColor: tokens.colors.accentGreenTint,
+  },
+  bookmarkIcon: { fontSize: 16 },
+  bookmarkText: {
+    fontSize: 13,
+    fontWeight: '800',
+    color: tokens.colors.text,
+    letterSpacing: 0.3,
+  },
+  bookmarkTextActive: { color: tokens.colors.text },
   imageWrap: {
     marginTop: 14,
     width: '100%',

--- a/app/mobile/src/screens/UserProfileScreen.tsx
+++ b/app/mobile/src/screens/UserProfileScreen.tsx
@@ -1,11 +1,16 @@
+import { useFocusEffect } from '@react-navigation/native';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { ErrorView } from '../components/ui/ErrorView';
 import { LoadingView } from '../components/ui/LoadingView';
 import { useAuth } from '../context/AuthContext';
 import type { RootStackParamList } from '../navigation/types';
+import {
+  fetchBookmarkedRecipes,
+  type BookmarkedRecipeListItem,
+} from '../services/bookmarkService';
 import { fetchRecipesList } from '../services/recipeService';
 import { fetchStoriesList } from '../services/storyService';
 import { shadows, tokens } from '../theme';
@@ -19,17 +24,25 @@ type ListItem = {
   author?: { id?: number | string; username?: string } | number | string | null;
 };
 
+type TabKey = 'recipes' | 'stories' | 'saved';
+
 export default function UserProfileScreen({ route, navigation }: Props) {
   const { userId, username } = route.params;
   const userIdStr = String(userId);
   const { user, isAuthenticated } = useAuth();
   const canMessage = isAuthenticated && user != null && String(user.id) !== userIdStr;
+  /** Saved tab is private — only render it when viewing your own profile. */
+  const isOwnProfile = isAuthenticated && user != null && String(user.id) === userIdStr;
 
   const [recipes, setRecipes] = useState<ListItem[]>([]);
   const [stories, setStories] = useState<ListItem[]>([]);
+  const [savedRecipes, setSavedRecipes] = useState<BookmarkedRecipeListItem[]>([]);
+  const [savedLoading, setSavedLoading] = useState(false);
+  const [savedError, setSavedError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [reloadToken, setReloadToken] = useState(0);
+  const [activeTab, setActiveTab] = useState<TabKey>('recipes');
 
   useEffect(() => {
     let cancelled = false;
@@ -61,6 +74,38 @@ export default function UserProfileScreen({ route, navigation }: Props) {
       cancelled = true;
     };
   }, [userIdStr, reloadToken]);
+
+  const loadSaved = useCallback(async () => {
+    if (!isOwnProfile) return;
+    setSavedLoading(true);
+    setSavedError(null);
+    try {
+      const items = await fetchBookmarkedRecipes();
+      setSavedRecipes(items);
+    } catch (e) {
+      setSavedRecipes([]);
+      setSavedError(e instanceof Error ? e.message : 'Could not load saved recipes.');
+    } finally {
+      setSavedLoading(false);
+    }
+  }, [isOwnProfile]);
+
+  // Refresh saved recipes when this screen regains focus — so toggling a
+  // bookmark on a detail screen and tapping back shows the up-to-date list.
+  useFocusEffect(
+    useCallback(() => {
+      if (isOwnProfile && activeTab === 'saved') {
+        void loadSaved();
+      }
+    }, [isOwnProfile, activeTab, loadSaved]),
+  );
+
+  // Initial fetch when the user first opens the Saved tab.
+  useEffect(() => {
+    if (isOwnProfile && activeTab === 'saved' && savedRecipes.length === 0 && !savedLoading && !savedError) {
+      void loadSaved();
+    }
+  }, [isOwnProfile, activeTab, savedRecipes.length, savedLoading, savedError, loadSaved]);
 
   const myRecipes = recipes;
   const myStories = stories;
@@ -117,50 +162,132 @@ export default function UserProfileScreen({ route, navigation }: Props) {
           </Pressable>
         ) : null}
 
-        <Text style={styles.sectionTitle}>Recipes by {username ?? 'this user'}</Text>
-        {myRecipes.length === 0 ? (
-          <Text style={styles.muted}>No recipes yet.</Text>
-        ) : (
-          <View style={styles.list}>
-            {myRecipes.map((r) => (
-              <Pressable
-                key={`r-${r.id}`}
-                onPress={() => navigation.navigate('RecipeDetail', { id: String(r.id) })}
-                style={({ pressed }) => [styles.row, pressed && styles.pressed]}
-                accessibilityRole="button"
-                accessibilityLabel={`Open recipe ${r.title}`}
-              >
-                <Text style={styles.rowTitle} numberOfLines={1}>
-                  {r.title}
-                </Text>
-                {r.region ? <Text style={styles.rowMeta}>{r.region}</Text> : null}
-              </Pressable>
-            ))}
-          </View>
-        )}
+        <View style={styles.tabBar} accessibilityRole="tablist">
+          <TabButton
+            label={`Recipes (${myRecipes.length})`}
+            active={activeTab === 'recipes'}
+            onPress={() => setActiveTab('recipes')}
+          />
+          <TabButton
+            label={`Stories (${myStories.length})`}
+            active={activeTab === 'stories'}
+            onPress={() => setActiveTab('stories')}
+          />
+          {isOwnProfile ? (
+            <TabButton
+              label="Saved"
+              active={activeTab === 'saved'}
+              onPress={() => setActiveTab('saved')}
+            />
+          ) : null}
+        </View>
 
-        <Text style={styles.sectionTitle}>Stories by {username ?? 'this user'}</Text>
-        {myStories.length === 0 ? (
-          <Text style={styles.muted}>No stories yet.</Text>
-        ) : (
-          <View style={styles.list}>
-            {myStories.map((s) => (
-              <Pressable
-                key={`s-${s.id}`}
-                onPress={() => navigation.navigate('StoryDetail', { id: String(s.id) })}
-                style={({ pressed }) => [styles.row, pressed && styles.pressed]}
-                accessibilityRole="button"
-                accessibilityLabel={`Open story ${s.title}`}
-              >
-                <Text style={styles.rowTitle} numberOfLines={1}>
-                  {s.title}
-                </Text>
-              </Pressable>
-            ))}
-          </View>
-        )}
+        {activeTab === 'recipes' ? (
+          myRecipes.length === 0 ? (
+            <Text style={styles.muted}>No recipes yet.</Text>
+          ) : (
+            <View style={styles.list}>
+              {myRecipes.map((r) => (
+                <Pressable
+                  key={`r-${r.id}`}
+                  onPress={() => navigation.navigate('RecipeDetail', { id: String(r.id) })}
+                  style={({ pressed }) => [styles.row, pressed && styles.pressed]}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Open recipe ${r.title}`}
+                >
+                  <Text style={styles.rowTitle} numberOfLines={1}>
+                    {r.title}
+                  </Text>
+                  {r.region ? <Text style={styles.rowMeta}>{r.region}</Text> : null}
+                </Pressable>
+              ))}
+            </View>
+          )
+        ) : null}
+
+        {activeTab === 'stories' ? (
+          myStories.length === 0 ? (
+            <Text style={styles.muted}>No stories yet.</Text>
+          ) : (
+            <View style={styles.list}>
+              {myStories.map((s) => (
+                <Pressable
+                  key={`s-${s.id}`}
+                  onPress={() => navigation.navigate('StoryDetail', { id: String(s.id) })}
+                  style={({ pressed }) => [styles.row, pressed && styles.pressed]}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Open story ${s.title}`}
+                >
+                  <Text style={styles.rowTitle} numberOfLines={1}>
+                    {s.title}
+                  </Text>
+                </Pressable>
+              ))}
+            </View>
+          )
+        ) : null}
+
+        {activeTab === 'saved' && isOwnProfile ? (
+          savedLoading ? (
+            <View style={styles.savedCentered}>
+              <LoadingView message="Loading saved recipes…" />
+            </View>
+          ) : savedError ? (
+            <ErrorView message={savedError} onRetry={() => void loadSaved()} />
+          ) : savedRecipes.length === 0 ? (
+            <Text style={styles.muted}>You haven&apos;t saved any recipes yet.</Text>
+          ) : (
+            <View style={styles.list}>
+              {savedRecipes.map((r) => (
+                <Pressable
+                  key={`saved-${r.id}`}
+                  onPress={() => navigation.navigate('RecipeDetail', { id: String(r.id) })}
+                  style={({ pressed }) => [styles.row, pressed && styles.pressed]}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Open saved recipe ${r.title}`}
+                >
+                  <View style={styles.rowHeader}>
+                    <Text style={styles.rowTitle} numberOfLines={1}>
+                      {r.title}
+                    </Text>
+                    <Text style={styles.rowBookmark} accessibilityLabel="Bookmarked">
+                      🔖
+                    </Text>
+                  </View>
+                  {r.region ? <Text style={styles.rowMeta}>{r.region}</Text> : null}
+                </Pressable>
+              ))}
+            </View>
+          )
+        ) : null}
       </ScrollView>
     </SafeAreaView>
+  );
+}
+
+function TabButton({
+  label,
+  active,
+  onPress,
+}: {
+  label: string;
+  active: boolean;
+  onPress: () => void;
+}) {
+  return (
+    <Pressable
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.tab,
+        active && styles.tabActive,
+        pressed && styles.pressed,
+      ]}
+      accessibilityRole="tab"
+      accessibilityState={{ selected: active }}
+      accessibilityLabel={label}
+    >
+      <Text style={[styles.tabText, active && styles.tabTextActive]}>{label}</Text>
+    </Pressable>
   );
 }
 
@@ -221,14 +348,30 @@ const styles = StyleSheet.create({
     fontWeight: '800',
     letterSpacing: 0.4,
   },
-  sectionTitle: {
-    marginTop: 8,
-    marginBottom: 10,
-    fontSize: 18,
-    fontWeight: '700',
-    color: tokens.colors.text,
-    fontFamily: tokens.typography.display.fontFamily,
+  tabBar: {
+    flexDirection: 'row',
+    gap: 8,
+    marginBottom: 14,
+    flexWrap: 'wrap',
   },
+  tab: {
+    paddingVertical: 8,
+    paddingHorizontal: 14,
+    borderRadius: tokens.radius.pill,
+    backgroundColor: tokens.colors.surface,
+    borderWidth: 1.5,
+    borderColor: tokens.colors.surfaceDark,
+  },
+  tabActive: {
+    backgroundColor: tokens.colors.accentGreen,
+  },
+  tabText: {
+    fontSize: 13,
+    fontWeight: '800',
+    color: tokens.colors.text,
+    letterSpacing: 0.2,
+  },
+  tabTextActive: { color: tokens.colors.textOnDark },
   muted: {
     fontSize: 14,
     color: tokens.colors.textMuted,
@@ -245,7 +388,15 @@ const styles = StyleSheet.create({
     backgroundColor: tokens.colors.surface,
     ...shadows.sm,
   },
+  rowHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 8,
+  },
+  rowBookmark: { fontSize: 14 },
   pressed: { opacity: 0.85 },
-  rowTitle: { fontSize: 15, fontWeight: '700', color: tokens.colors.text },
+  rowTitle: { fontSize: 15, fontWeight: '700', color: tokens.colors.text, flexShrink: 1 },
   rowMeta: { marginTop: 4, fontSize: 12, color: tokens.colors.textMuted },
+  savedCentered: { paddingVertical: 24, alignItems: 'center' },
 });

--- a/app/mobile/src/screens/tabs/ProfileTabScreen.tsx
+++ b/app/mobile/src/screens/tabs/ProfileTabScreen.tsx
@@ -22,6 +22,24 @@ export default function ProfileTabScreen() {
               <Text style={styles.subtitle}>
                 Signed in{user ? ` as ${user.username}` : ''}.
               </Text>
+              {user ? (
+                <>
+                  <Pressable
+                    onPress={() =>
+                      navigation.navigate('Feed', {
+                        screen: 'UserProfile',
+                        params: { userId: user.id, username: user.username },
+                      })
+                    }
+                    style={({ pressed }) => [styles.actionBtn, styles.myProfileBtn, pressed && styles.pressed]}
+                    accessibilityRole="button"
+                    accessibilityLabel="View my profile"
+                  >
+                    <Text style={styles.myProfileBtnText}>My profile</Text>
+                  </Pressable>
+                  <View style={{ height: 12 }} />
+                </>
+              ) : null}
               <Pressable
                 onPress={() => navigation.navigate('Feed', { screen: 'Inbox' })}
                 style={({ pressed }) => [styles.actionBtn, styles.messagesBtn, pressed && styles.pressed]}
@@ -139,6 +157,8 @@ const styles = StyleSheet.create({
     width: '100%',
     ...shadows.md,
   },
+  myProfileBtn: { backgroundColor: tokens.colors.accentMustard },
+  myProfileBtnText: { color: tokens.colors.surfaceDark, fontSize: 16, fontWeight: '800' },
   messagesBtn: { backgroundColor: "#C8E5EB" },
   messagesBtnText: { color: tokens.colors.surfaceDark, fontSize: 16, fontWeight: '800' },
   culturalBtn: { backgroundColor: '#C8E5EB' },

--- a/app/mobile/src/services/bookmarkService.ts
+++ b/app/mobile/src/services/bookmarkService.ts
@@ -1,0 +1,117 @@
+import type { RecipeDetail } from '../types/recipe';
+import { apiGetJson, apiPostJson, nextPagePath } from './httpClient';
+
+/**
+ * Backend `POST /api/recipes/:id/bookmark/` is a toggle (no body). Returns the
+ * fresh `is_bookmarked` flag plus the updated `bookmark_count` so the UI can
+ * sync to canonical server state instead of guessing locally.
+ */
+export type ToggleBookmarkResult = {
+  is_bookmarked: boolean;
+  bookmark_count: number;
+};
+
+type RawToggle = {
+  is_bookmarked?: unknown;
+  bookmark_count?: unknown;
+};
+
+/** Defensive coerce — backend always sends these, but a stale build or proxy
+ * sometimes drops them, and we'd rather show a stable UI than crash. */
+function normalizeToggle(raw: RawToggle | null | undefined): ToggleBookmarkResult {
+  const flag = typeof raw?.is_bookmarked === 'boolean' ? raw.is_bookmarked : false;
+  const countRaw = raw?.bookmark_count;
+  const count =
+    typeof countRaw === 'number' && Number.isFinite(countRaw)
+      ? countRaw
+      : typeof countRaw === 'string' && countRaw !== ''
+        ? Number(countRaw)
+        : 0;
+  return {
+    is_bookmarked: flag,
+    bookmark_count: Number.isFinite(count) ? count : 0,
+  };
+}
+
+export async function toggleBookmark(recipeId: number | string): Promise<ToggleBookmarkResult> {
+  const data = await apiPostJson<RawToggle>(`/api/recipes/${recipeId}/bookmark/`, {});
+  return normalizeToggle(data);
+}
+
+type Paginated<T> = { count?: number; next?: string | null; results?: T[] };
+
+type RawRecipeListItem = {
+  id: number | string;
+  title?: string;
+  region?: unknown;
+  region_name?: string | null;
+  author?: unknown;
+  author_username?: string | null;
+  image?: string | null;
+  is_bookmarked?: boolean;
+  bookmark_count?: number;
+};
+
+/** Subset of RecipeDetail surfaced by the list endpoint — enough for cards. */
+export type BookmarkedRecipeListItem = {
+  id: string;
+  title: string;
+  region?: string;
+  author?: RecipeDetail['author'];
+  author_username?: string;
+  image?: string | null;
+  is_bookmarked: boolean;
+  bookmark_count?: number;
+};
+
+function normalizeListItem(raw: RawRecipeListItem): BookmarkedRecipeListItem {
+  const reg = raw.region;
+  const regionLabel =
+    typeof reg === 'string'
+      ? reg
+      : reg && typeof reg === 'object' && 'name' in reg && typeof (reg as { name: unknown }).name === 'string'
+        ? (reg as { name: string }).name
+        : typeof raw.region_name === 'string'
+          ? raw.region_name
+          : undefined;
+  return {
+    id: String(raw.id),
+    title: String(raw.title ?? ''),
+    region: regionLabel,
+    author:
+      typeof raw.author === 'number'
+        ? raw.author
+        : typeof raw.author === 'object' && raw.author !== null
+          ? (raw.author as RecipeDetail['author'])
+          : undefined,
+    author_username:
+      typeof raw.author_username === 'string' ? raw.author_username : undefined,
+    image: typeof raw.image === 'string' ? raw.image : null,
+    // Items returned by `?bookmarked=true` are by definition saved.
+    is_bookmarked: typeof raw.is_bookmarked === 'boolean' ? raw.is_bookmarked : true,
+    bookmark_count: typeof raw.bookmark_count === 'number' ? raw.bookmark_count : undefined,
+  };
+}
+
+/**
+ * Walk DRF pagination on `GET /api/recipes/?bookmarked=true`. Mirrors the
+ * pattern in `ingredientRouteService` / `mapDataService` so a profile with many
+ * saves doesn't silently truncate at the first page.
+ */
+export async function fetchBookmarkedRecipes(): Promise<BookmarkedRecipeListItem[]> {
+  const collected: BookmarkedRecipeListItem[] = [];
+  let path: string | null = '/api/recipes/?bookmarked=true';
+  while (path) {
+    const data: Paginated<RawRecipeListItem> | RawRecipeListItem[] = await apiGetJson<
+      Paginated<RawRecipeListItem> | RawRecipeListItem[]
+    >(path);
+    if (Array.isArray(data)) {
+      for (const r of data) collected.push(normalizeListItem(r));
+      break;
+    }
+    const results = Array.isArray(data.results) ? data.results : [];
+    for (const r of results) collected.push(normalizeListItem(r));
+    path = nextPagePath(data.next);
+  }
+  return collected;
+}

--- a/app/mobile/src/services/searchService.ts
+++ b/app/mobile/src/services/searchService.ts
@@ -10,6 +10,9 @@ export type SearchResultItem = {
   thumbnail?: string | null;
   rankScore: number;
   rankReason: string | null;
+  /** Surfaced only when the producer knows the state (e.g. Saved tab); leave
+   * undefined for search responses that don't include the field. */
+  isBookmarked?: boolean;
 };
 
 type BackendSearchResponse = {

--- a/app/mobile/src/types/recipe.ts
+++ b/app/mobile/src/types/recipe.ts
@@ -36,4 +36,11 @@ export type RecipeDetail = {
     source_url: string;
     created_at?: string;
   }>;
+  /**
+   * Bookmark fields surfaced by backend (#706). Optional because older
+   * responses and minimal-list shapes can omit them — UI must treat
+   * `undefined` as "not yet known" rather than "false".
+   */
+  is_bookmarked?: boolean;
+  bookmark_count?: number;
 };


### PR DESCRIPTION
## Summary
- New `bookmarkService` (toggle + paginated list) talks to `/api/recipes/:id/bookmark/` and `/api/recipes/?bookmarked=true`.
- `RecipeDetailScreen` gets a Save/Saved button with bookmark count, optimistic toggle with rollback on failure, and an auth gate that routes guests to Login.
- `SearchResultCard` shows a small read-only bookmark badge when the item carries `isBookmarked`.
- `UserProfileScreen` switched to a tabbed layout (Recipes / Stories / Saved); the Saved tab is only visible on your own profile and refreshes on focus.
- Extended `RecipeDetail` with optional `is_bookmarked` / `bookmark_count` fields.

Closes #708
Closes #710

## Test plan
- [ ] Open a recipe detail while logged out — tap Save, get routed to Login.
- [ ] Log in, tap Save on a recipe — icon fills, count increments. Re-tap — count decrements, server state wins on completion.
- [ ] Force a backend error (kill network mid-tap) — UI rolls back and a toast shows.
- [ ] Go to your own profile — Saved tab appears; lists the recipes you bookmarked; empty state shows when none.
- [ ] Open someone else's profile — Saved tab is hidden.
- [ ] From Saved tab, open a recipe, unsave it, hit back — list refreshes on focus and no longer shows it.