### PR TITLE
test(mobile): unit tests across services, utils, components, and a screen (#533)

### DIFF
--- a/app/mobile/__tests__/components/DidYouKnowSection.test.tsx
+++ b/app/mobile/__tests__/components/DidYouKnowSection.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { DidYouKnowSection } from '../../src/components/cultural/DidYouKnowSection';
+import type { CulturalFact } from '../../src/services/culturalFactService';
+
+const makeFact = (over: Partial<CulturalFact> = {}): CulturalFact => ({
+  id: 1,
+  text: 'Saffron once cost more than gold by weight.',
+  source_url: 'https://example.com/saffron',
+  heritage_group: null,
+  region: null,
+  ...over,
+});
+
+describe('DidYouKnowSection', () => {
+  it('returns null when there are no facts', () => {
+    const { toJSON } = render(<DidYouKnowSection facts={[]} />);
+    expect(toJSON()).toBeNull();
+  });
+
+  it('renders the heading and each fact text', () => {
+    const facts = [
+      makeFact({ id: 1, text: 'Fact one' }),
+      makeFact({ id: 2, text: 'Fact two', source_url: '' }),
+    ];
+    const { getByText, getAllByText } = render(<DidYouKnowSection facts={facts} />);
+    expect(getByText('Did you know')).toBeTruthy();
+    expect(getByText('Fact one')).toBeTruthy();
+    expect(getByText('Fact two')).toBeTruthy();
+    // Only the fact with a source_url shows a Source pill.
+    expect(getAllByText('Source ↗')).toHaveLength(1);
+  });
+
+  it('exposes a recognisable accessibility label on the section', () => {
+    const { getByLabelText } = render(
+      <DidYouKnowSection facts={[makeFact()]} />,
+    );
+    expect(getByLabelText('Cultural context facts')).toBeTruthy();
+  });
+});

--- a/app/mobile/__tests__/components/EndangeredHeritageSection.test.tsx
+++ b/app/mobile/__tests__/components/EndangeredHeritageSection.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { EndangeredHeritageSection } from '../../src/components/heritage/EndangeredHeritageSection';
+
+describe('EndangeredHeritageSection', () => {
+  it("renders nothing when status is 'none' and notes are empty", () => {
+    const { toJSON } = render(<EndangeredHeritageSection status="none" notes={[]} />);
+    expect(toJSON()).toBeNull();
+  });
+
+  it('renders nothing when status is null/undefined and there are no notes', () => {
+    const { toJSON } = render(
+      <EndangeredHeritageSection status={null as any} notes={[]} />,
+    );
+    expect(toJSON()).toBeNull();
+  });
+
+  it('renders the endangered badge and blurb for status=endangered', () => {
+    const { getByText } = render(
+      <EndangeredHeritageSection status="endangered" notes={[]} />,
+    );
+    expect(getByText('ENDANGERED')).toBeTruthy();
+    expect(getByText(/at risk of being lost/i)).toBeTruthy();
+  });
+
+  it('renders sourced notes even when status is none', () => {
+    const notes = [
+      { id: 1, text: 'Historic kebab references in 1453.', source_url: 'https://example.com/1' },
+      { id: 2, text: 'Another sourced fact.', source_url: '' },
+    ];
+    const { getByText, getAllByText } = render(
+      <EndangeredHeritageSection status="none" notes={notes} />,
+    );
+    expect(getByText('Sourced notes')).toBeTruthy();
+    expect(getByText('Historic kebab references in 1453.')).toBeTruthy();
+    expect(getByText('Another sourced fact.')).toBeTruthy();
+    // Only the note with a source_url gets a Source pill.
+    expect(getAllByText('Source ↗')).toHaveLength(1);
+  });
+});

--- a/app/mobile/__tests__/screens/CulturalCalendarScreen.test.tsx
+++ b/app/mobile/__tests__/screens/CulturalCalendarScreen.test.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react-native';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
+
+jest.mock('../../src/services/httpClient', () => ({
+  apiGetJson: jest.fn(),
+}));
+
+jest.mock('../../src/services/calendarService', () => {
+  const actual = jest.requireActual('../../src/services/calendarService');
+  return {
+    ...actual,
+    fetchCulturalEvents: jest.fn(),
+  };
+});
+
+import CulturalCalendarScreen from '../../src/screens/CulturalCalendarScreen';
+import { fetchCulturalEvents, type CulturalEvent } from '../../src/services/calendarService';
+
+const mockedFetch = fetchCulturalEvents as jest.MockedFunction<typeof fetchCulturalEvents>;
+
+function makeProps() {
+  const navigation = {
+    navigate: jest.fn(),
+    goBack: jest.fn(),
+    setOptions: jest.fn(),
+    addListener: jest.fn(() => () => undefined),
+  } as any;
+  const route = { key: 'k', name: 'CulturalCalendar', params: undefined } as any;
+  return { navigation, route };
+}
+
+function renderScreen() {
+  const props = makeProps();
+  const utils = render(
+    <SafeAreaProvider initialMetrics={{
+      frame: { x: 0, y: 0, width: 320, height: 640 },
+      insets: { top: 0, left: 0, right: 0, bottom: 0 },
+    }}>
+      <CulturalCalendarScreen {...props} />
+    </SafeAreaProvider>,
+  );
+  return { ...utils, ...props };
+}
+
+describe('CulturalCalendarScreen', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-01-15T00:00:00Z'));
+    mockedFetch.mockReset();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('renders fetched events grouped under their resolved month', async () => {
+    const events: CulturalEvent[] = [
+      {
+        id: 1,
+        name: 'Nevruz',
+        date_rule: 'fixed:03-21',
+        region: { id: 1, name: 'Anatolian' },
+        description: 'Spring equinox celebration.',
+        recipes: [{ id: 100, title: 'Sumalak', region: 'Anatolian' }],
+      },
+      {
+        id: 2,
+        name: 'Ramadan',
+        date_rule: 'lunar:ramadan',
+        region: null,
+        description: '',
+        recipes: [],
+      },
+    ];
+    mockedFetch.mockResolvedValueOnce(events);
+
+    const { findByText, getByText } = renderScreen();
+
+    expect(await findByText('Nevruz')).toBeTruthy();
+    // Nevruz: March group label and day badge
+    expect(getByText('March')).toBeTruthy();
+    expect(getByText('21')).toBeTruthy();
+    // Ramadan resolves to Feb 18 in 2026
+    expect(getByText('Ramadan')).toBeTruthy();
+    expect(getByText('February')).toBeTruthy();
+    expect(getByText('18')).toBeTruthy();
+    // Related recipe pill
+    expect(getByText('Sumalak')).toBeTruthy();
+  });
+
+  it('renders an empty state when the service returns no events', async () => {
+    mockedFetch.mockResolvedValueOnce([]);
+    const { findByText } = renderScreen();
+    expect(await findByText(/No events match the current filter/i)).toBeTruthy();
+  });
+
+  it('renders an error view when the service rejects', async () => {
+    mockedFetch.mockRejectedValueOnce(new Error('network down'));
+    const { findByText } = renderScreen();
+    expect(await findByText('network down')).toBeTruthy();
+  });
+});

--- a/app/mobile/__tests__/services/calendarService.test.ts
+++ b/app/mobile/__tests__/services/calendarService.test.ts
@@ -1,0 +1,86 @@
+jest.mock('../../src/services/httpClient', () => ({
+  apiGetJson: jest.fn(),
+}));
+
+import { parseEventDate, MONTH_LABELS } from '../../src/services/calendarService';
+
+describe('parseEventDate', () => {
+  it('parses a fixed:MM-DD rule into a Gregorian label', () => {
+    const parsed = parseEventDate('fixed:03-21');
+    expect(parsed.monthIndex).toBe(2);
+    expect(parsed.day).toBe(21);
+    expect(parsed.label).toBe('March 21');
+    expect(parsed.isLunar).toBe(false);
+  });
+
+  it('clamps an out-of-range fixed month to a valid index', () => {
+    const parsed = parseEventDate('fixed:13-05');
+    expect(parsed.monthIndex).toBe(11);
+    expect(parsed.day).toBe(5);
+    expect(parsed.label).toBe('December 5');
+  });
+
+  it('returns a passthrough label when the fixed parts are not numeric', () => {
+    const parsed = parseEventDate('fixed:bad-date');
+    expect(parsed.monthIndex).toBeNull();
+    expect(parsed.day).toBeNull();
+    expect(parsed.label).toBe('fixed:bad-date');
+    expect(parsed.isLunar).toBe(false);
+  });
+
+  it('resolves a known lunar rule for the current year (Ramadan 2026)', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-01-15T00:00:00Z'));
+    try {
+      const parsed = parseEventDate('lunar:ramadan');
+      expect(parsed.isLunar).toBe(true);
+      expect(parsed.monthIndex).toBe(1);
+      expect(parsed.day).toBe(18);
+      expect(parsed.label).toBe('February 18');
+      expect(parsed.lunarName).toBe('Ramadan');
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('returns lunarUnresolved when the year has no entry', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('1999-01-01T00:00:00Z'));
+    try {
+      const parsed = parseEventDate('lunar:ramadan');
+      expect(parsed.isLunar).toBe(true);
+      expect(parsed.lunarUnresolved).toBe(true);
+      expect(parsed.monthIndex).toBeNull();
+      expect(parsed.label).toContain('Lunar');
+      expect(parsed.lunarName).toBe('Ramadan');
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('prettifies multi-word lunar keys', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+    try {
+      const parsed = parseEventDate('lunar:eid-fitr');
+      expect(parsed.lunarName).toBe('Eid Fitr');
+      expect(parsed.monthIndex).toBe(2);
+      expect(parsed.day).toBe(20);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('returns the trimmed rule for unrecognised prefixes', () => {
+    const parsed = parseEventDate('something-else');
+    expect(parsed.monthIndex).toBeNull();
+    expect(parsed.day).toBeNull();
+    expect(parsed.label).toBe('something-else');
+  });
+
+  it('exports 12 month labels in order', () => {
+    expect(MONTH_LABELS).toHaveLength(12);
+    expect(MONTH_LABELS[0]).toBe('January');
+    expect(MONTH_LABELS[11]).toBe('December');
+  });
+});

--- a/app/mobile/__tests__/services/ingredientRouteService.test.ts
+++ b/app/mobile/__tests__/services/ingredientRouteService.test.ts
@@ -1,0 +1,109 @@
+import { fetchIngredientRoutes } from '../../src/services/ingredientRouteService';
+import { apiGetJson } from '../../src/services/httpClient';
+
+jest.mock('../../src/services/httpClient', () => ({
+  apiGetJson: jest.fn(),
+  nextPagePath: (next: string | null | undefined) => {
+    if (!next) return null;
+    try {
+      const url = new URL(next);
+      return `${url.pathname}${url.search}`;
+    } catch {
+      return null;
+    }
+  },
+}));
+
+const mockedGet = apiGetJson as jest.MockedFunction<typeof apiGetJson>;
+
+describe('fetchIngredientRoutes', () => {
+  beforeEach(() => {
+    mockedGet.mockReset();
+  });
+
+  it('normalizes string lat/lng to numbers and id/ingredient as numbers', async () => {
+    mockedGet.mockResolvedValueOnce({
+      next: null,
+      results: [
+        {
+          id: '5',
+          ingredient: '11',
+          ingredient_name: 'Saffron',
+          waypoints: [
+            { lat: '38.5', lng: '27.0', era: 'antiquity', label: 'Aegean' },
+          ],
+        },
+      ],
+    });
+
+    const routes = await fetchIngredientRoutes();
+
+    expect(routes).toHaveLength(1);
+    expect(routes[0]).toEqual({
+      id: 5,
+      ingredient: 11,
+      ingredient_name: 'Saffron',
+      waypoints: [
+        { lat: 38.5, lng: 27.0, era: 'antiquity', label: 'Aegean' },
+      ],
+    });
+  });
+
+  it('drops waypoints with null or non-numeric lat/lng', async () => {
+    mockedGet.mockResolvedValueOnce({
+      next: null,
+      results: [
+        {
+          id: 1,
+          ingredient: 2,
+          ingredient_name: 'Pepper',
+          waypoints: [
+            { lat: 10, lng: 20, era: 'medieval', label: 'good' },
+            { lat: null, lng: 20, era: 'x', label: 'missing-lat' },
+            { lat: 10, lng: 'not-a-number', era: 'x', label: 'bad-lng' },
+            { lat: 'abc', lng: 'def', era: 'x', label: 'garbage' },
+          ],
+        },
+      ],
+    });
+
+    const routes = await fetchIngredientRoutes();
+
+    expect(routes[0].waypoints).toEqual([
+      { lat: 10, lng: 20, era: 'medieval', label: 'good' },
+    ]);
+  });
+
+  it('walks pagination, combining results from each page', async () => {
+    mockedGet
+      .mockResolvedValueOnce({
+        next: 'http://api.example.com/api/ingredient-routes/?page=2',
+        results: [
+          { id: 1, ingredient: 1, ingredient_name: 'A', waypoints: [] },
+        ],
+      })
+      .mockResolvedValueOnce({
+        next: null,
+        results: [
+          { id: 2, ingredient: 2, ingredient_name: 'B', waypoints: [] },
+        ],
+      });
+
+    const routes = await fetchIngredientRoutes();
+
+    expect(mockedGet).toHaveBeenCalledTimes(2);
+    expect(mockedGet).toHaveBeenNthCalledWith(1, '/api/ingredient-routes/');
+    expect(mockedGet).toHaveBeenNthCalledWith(2, '/api/ingredient-routes/?page=2');
+    expect(routes.map((r) => r.id)).toEqual([1, 2]);
+  });
+
+  it('handles a bare array response (unpaginated)', async () => {
+    mockedGet.mockResolvedValueOnce([
+      { id: 1, ingredient: 1, ingredient_name: 'A', waypoints: null },
+    ]);
+
+    const routes = await fetchIngredientRoutes();
+    expect(routes).toHaveLength(1);
+    expect(routes[0].waypoints).toEqual([]);
+  });
+});

--- a/app/mobile/__tests__/services/mapDataService.test.ts
+++ b/app/mobile/__tests__/services/mapDataService.test.ts
@@ -1,0 +1,145 @@
+import { fetchRegionPins, fetchRegionRecipes } from '../../src/services/mapDataService';
+import { apiGetJson } from '../../src/services/httpClient';
+
+jest.mock('../../src/services/httpClient', () => ({
+  apiGetJson: jest.fn(),
+  nextPagePath: (next: string | null | undefined) => {
+    if (!next) return null;
+    try {
+      const url = new URL(next);
+      return `${url.pathname}${url.search}`;
+    } catch {
+      return null;
+    }
+  },
+}));
+
+const mockedGet = apiGetJson as jest.MockedFunction<typeof apiGetJson>;
+
+describe('fetchRegionPins', () => {
+  beforeEach(() => mockedGet.mockReset());
+
+  it('prefers backend lat/lng but falls back to the regionGeo table when missing', async () => {
+    mockedGet.mockResolvedValueOnce({
+      results: [
+        { id: 1, name: 'Aegean', latitude: null, longitude: null, content_count: { recipes: 4 } },
+        { id: 2, name: 'CustomLand', latitude: 12.3, longitude: 45.6, content_count: { recipes: 2 } },
+        { id: 3, name: 'UnknownLand', latitude: null, longitude: null },
+      ],
+    });
+
+    const pins = await fetchRegionPins();
+
+    expect(mockedGet).toHaveBeenCalledWith('/api/map/regions/?geo_only=false');
+    // UnknownLand has no backend coords and no fallback in regionGeo, so it's dropped.
+    expect(pins.map((p) => p.name)).toEqual(['Aegean', 'CustomLand']);
+    // Aegean uses the fallback coords from regionGeo (38.5, 27.0).
+    expect(pins[0].coords).toEqual({ latitude: 38.5, longitude: 27.0 });
+    expect(pins[0].recipeCount).toBe(4);
+    // CustomLand uses the backend-provided coords.
+    expect(pins[1].coords).toEqual({ latitude: 12.3, longitude: 45.6 });
+    expect(pins[1].recipeCount).toBe(2);
+  });
+
+  it('defaults recipeCount to 0 when content_count is missing', async () => {
+    mockedGet.mockResolvedValueOnce({
+      results: [{ id: 1, name: 'Aegean', latitude: null, longitude: null }],
+    });
+
+    const pins = await fetchRegionPins();
+    expect(pins[0].recipeCount).toBe(0);
+  });
+});
+
+describe('fetchRegionRecipes', () => {
+  beforeEach(() => mockedGet.mockReset());
+
+  it('walks pagination and splits recipes into located vs unlocated', async () => {
+    // First call: region metadata
+    mockedGet.mockResolvedValueOnce({
+      results: [
+        {
+          id: 1,
+          name: 'Aegean',
+          latitude: 38.5,
+          longitude: 27.0,
+          bbox_north: 40,
+          bbox_south: 36,
+          bbox_east: 28,
+          bbox_west: 25,
+        },
+      ],
+    });
+    // Page 1 of recipes
+    mockedGet.mockResolvedValueOnce({
+      next: 'http://api.example.com/api/recipes/?region=Aegean&page=2',
+      results: [
+        {
+          id: 10,
+          title: 'Located 1',
+          author_username: 'alice',
+          image: null,
+          latitude: '38.6',
+          longitude: '27.1',
+        },
+        {
+          id: 11,
+          title: 'Unlocated 1',
+          author_username: 'bob',
+          image: null,
+          latitude: null,
+          longitude: null,
+        },
+      ],
+    });
+    // Page 2
+    mockedGet.mockResolvedValueOnce({
+      next: null,
+      results: [
+        {
+          id: 12,
+          title: 'Located 2',
+          author_username: 'carol',
+          image: 'http://example.com/img.jpg',
+          latitude: 38.7,
+          longitude: 27.2,
+        },
+      ],
+    });
+
+    const out = await fetchRegionRecipes('Aegean');
+
+    expect(out.bbox).toEqual({ north: 40, south: 36, east: 28, west: 25 });
+    expect(out.centroid).toEqual({ latitude: 38.5, longitude: 27.0 });
+
+    expect(out.located).toHaveLength(2);
+    expect(out.located[0]).toEqual({
+      id: '10',
+      title: 'Located 1',
+      authorUsername: 'alice',
+      image: null,
+      coords: { latitude: 38.6, longitude: 27.1 },
+    });
+    expect(out.located[1].id).toBe('12');
+
+    expect(out.unlocated).toHaveLength(1);
+    expect(out.unlocated[0]).toEqual({
+      id: '11',
+      title: 'Unlocated 1',
+      authorUsername: 'bob',
+      image: null,
+    });
+  });
+
+  it('falls back to regionGeo centroid when backend metadata lookup fails', async () => {
+    mockedGet.mockRejectedValueOnce(new Error('boom'));
+    // recipes call returns empty
+    mockedGet.mockResolvedValueOnce({ next: null, results: [] });
+
+    const out = await fetchRegionRecipes('Aegean');
+    expect(out.centroid).toEqual({ latitude: 38.5, longitude: 27.0 });
+    expect(out.bbox).toBeNull();
+    expect(out.located).toEqual([]);
+    expect(out.unlocated).toEqual([]);
+  });
+});

--- a/app/mobile/__tests__/utils/parseAuthorId.test.ts
+++ b/app/mobile/__tests__/utils/parseAuthorId.test.ts
@@ -1,0 +1,32 @@
+import { parseAuthorId } from '../../src/utils/parseAuthorId';
+
+describe('parseAuthorId', () => {
+  it('returns null for null, undefined, and empty string', () => {
+    expect(parseAuthorId(null)).toBeNull();
+    expect(parseAuthorId(undefined)).toBeNull();
+    expect(parseAuthorId('')).toBeNull();
+  });
+
+  it('returns the number as-is when given a finite number', () => {
+    expect(parseAuthorId(42)).toBe(42);
+    expect(parseAuthorId(0)).toBe(0);
+  });
+
+  it('parses numeric strings', () => {
+    expect(parseAuthorId('17')).toBe(17);
+  });
+
+  it('returns null for non-numeric strings', () => {
+    expect(parseAuthorId('abc')).toBeNull();
+  });
+
+  it('unwraps a nested object with an id field', () => {
+    expect(parseAuthorId({ id: 7, username: 'foo' })).toBe(7);
+    expect(parseAuthorId({ id: '9' })).toBe(9);
+  });
+
+  it('returns null for an object without a usable id', () => {
+    expect(parseAuthorId({ id: 'not-a-number' })).toBeNull();
+    expect(parseAuthorId({ username: 'foo' })).toBeNull();
+  });
+});

--- a/app/mobile/__tests__/utils/rankReason.test.ts
+++ b/app/mobile/__tests__/utils/rankReason.test.ts
@@ -1,0 +1,20 @@
+import { rankReasonLabel } from '../../src/utils/rankReason';
+
+describe('rankReasonLabel', () => {
+  it('maps known reason codes to user-facing labels', () => {
+    expect(rankReasonLabel('regional_match')).toBe('From your region');
+    expect(rankReasonLabel('dietary_match')).toBe('Matches your dietary preference');
+    expect(rankReasonLabel('event_match')).toBe('For your events');
+    expect(rankReasonLabel('cultural_match')).toBe('Matches your interests');
+  });
+
+  it('returns null for unknown codes', () => {
+    expect(rankReasonLabel('made_up_reason')).toBeNull();
+  });
+
+  it('returns null for null, undefined, and empty string', () => {
+    expect(rankReasonLabel(null)).toBeNull();
+    expect(rankReasonLabel(undefined)).toBeNull();
+    expect(rankReasonLabel('')).toBeNull();
+  });
+});

--- a/app/mobile/__tests__/utils/regionGeo.test.ts
+++ b/app/mobile/__tests__/utils/regionGeo.test.ts
@@ -1,0 +1,40 @@
+import { coordsForRegion, INITIAL_MAP_REGION } from '../../src/utils/regionGeo';
+
+describe('coordsForRegion', () => {
+  it('returns coordinates for a known region', () => {
+    expect(coordsForRegion('Aegean')).toEqual({ latitude: 38.5, longitude: 27.0 });
+  });
+
+  it('returns coordinates for a multi-word region name', () => {
+    expect(coordsForRegion('Black Sea')).toEqual({ latitude: 41.0, longitude: 36.5 });
+    expect(coordsForRegion('Southeastern Anatolia')).toEqual({
+      latitude: 37.5,
+      longitude: 39.0,
+    });
+  });
+
+  it('returns null for an unknown region', () => {
+    expect(coordsForRegion('Atlantis')).toBeNull();
+  });
+
+  it('is case-sensitive (lookup uses exact keys)', () => {
+    // Lookup table keys are capitalised; lowercased names should miss.
+    expect(coordsForRegion('aegean')).toBeNull();
+    expect(coordsForRegion('AEGEAN')).toBeNull();
+  });
+
+  it('returns null when given null, undefined, or empty string', () => {
+    expect(coordsForRegion(null)).toBeNull();
+    expect(coordsForRegion(undefined)).toBeNull();
+    expect(coordsForRegion('')).toBeNull();
+  });
+});
+
+describe('INITIAL_MAP_REGION', () => {
+  it('exposes a sane default camera centered over the Anatolian region', () => {
+    expect(INITIAL_MAP_REGION.latitude).toBeCloseTo(38.0);
+    expect(INITIAL_MAP_REGION.longitude).toBeCloseTo(35.0);
+    expect(INITIAL_MAP_REGION.latitudeDelta).toBeGreaterThan(0);
+    expect(INITIAL_MAP_REGION.longitudeDelta).toBeGreaterThan(0);
+  });
+});

--- a/app/mobile/__tests__/utils/unitConversion.test.ts
+++ b/app/mobile/__tests__/utils/unitConversion.test.ts
@@ -1,0 +1,21 @@
+import { targetUnitFor } from '../../src/utils/unitConversion';
+
+describe('targetUnitFor', () => {
+  it('maps metric units to imperial / cooking targets', () => {
+    expect(targetUnitFor('grams')).toBe('oz');
+    expect(targetUnitFor('kg')).toBe('lb');
+    expect(targetUnitFor('ml')).toBe('fl oz');
+    expect(targetUnitFor('liters')).toBe('qt');
+  });
+
+  it('maps volumetric cooking units to millilitres', () => {
+    expect(targetUnitFor('cups')).toBe('ml');
+    expect(targetUnitFor('tablespoons')).toBe('ml');
+    expect(targetUnitFor('teaspoons')).toBe('ml');
+  });
+
+  it('returns null for unknown units', () => {
+    expect(targetUnitFor('handfuls')).toBeNull();
+    expect(targetUnitFor('')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Adds the first wave of mobile unit tests on top of the Jest + RNTL harness landed in #726. Targets the highest-value pure logic and a representative screen render.

Closes #533.

### Files covered

**Utilities** (`app/mobile/__tests__/utils/`)
- `regionGeo.test.ts` — `coordsForRegion` (known/unknown, case-sensitivity, null/undefined/empty), `INITIAL_MAP_REGION` shape
- `parseAuthorId.test.ts` — number/string/object input, nested `{ id }`, garbage rejection
- `rankReason.test.ts` — label mapping for all four known codes + nullish handling
- `unitConversion.test.ts` — `targetUnitFor` mapping table + unknown unit

**Services** (`app/mobile/__tests__/services/`)
- `ingredientRouteService.test.ts` — string→number normalization, invalid waypoint drop, pagination walk, bare-array fallback
- `mapDataService.test.ts` — `fetchRegionPins` (backend coords vs `regionGeo` fallback vs dropped) and `fetchRegionRecipes` (paginated walk, located/unlocated split, bbox/centroid, error fallback)
- `calendarService.test.ts` — `parseEventDate` fixed/lunar rules, month clamp, lunar resolver (Ramadan 2026 → Feb 18), unresolved year branch, multi-word lunar key prettify

**Components** (`app/mobile/__tests__/components/`)
- `EndangeredHeritageSection.test.tsx` — returns null for status='none' + empty notes; renders badge for endangered; renders notes even without status; only notes with `source_url` show the Source pill
- `DidYouKnowSection.test.tsx` — null on empty; renders heading + each fact; source pill only for facts with a URL; accessibility label

**Screen** (`app/mobile/__tests__/screens/`)
- `CulturalCalendarScreen.test.tsx` — mocks `fetchCulturalEvents`; asserts grouping by resolved month (fixed and lunar-resolved Ramadan 2026), empty-state copy, and error-state surfacing

All network calls are mocked via `jest.mock('../../src/services/httpClient')`.

## Jest summary

```
Test Suites: 11 passed, 11 total
Tests:       46 passed, 46 total
Snapshots:   0 total
Time:        2.742 s
```

## Test plan

- [ ] `cd app/mobile && npx jest` — all 11 suites pass locally
- [ ] No real HTTP request fires during the run (every service test stubs `apiGetJson`)
- [ ] New test files live under `app/mobile/__tests__/` matching the convention from #726