### PR TITLE
feat(mobile): star rating UI on recipe detail and cards + notification icon (closes #735, closes #738)

### DIFF
--- a/app/mobile/src/components/recipe/StarRatingRow.tsx
+++ b/app/mobile/src/components/recipe/StarRatingRow.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { tokens } from '../../theme';
+
+export type StarScore = 1 | 2 | 3 | 4 | 5;
+
+type Props = {
+  /** Current selected score 1-5, or null when unrated. */
+  value: number | null;
+  /** Defaults to 5. */
+  max?: number;
+  size?: 'sm' | 'lg';
+  /** Disables Pressable wrapping; renders pure visual stars. */
+  readOnly?: boolean;
+  /**
+   * Called with the tapped star value. Tapping the SAME star that is already
+   * selected calls onChange(0) — caller maps this to "clear my rating".
+   */
+  onChange?: (score: StarScore | 0) => void;
+  /** Optional override for the whole row's a11y label. */
+  ariaLabel?: string;
+};
+
+export function StarRatingRow({
+  value,
+  max = 5,
+  size = 'lg',
+  readOnly = false,
+  onChange,
+  ariaLabel,
+}: Props) {
+  const stars = Array.from({ length: max }, (_, i) => i + 1);
+  const fontSize = size === 'lg' ? 28 : 16;
+  const gap = size === 'lg' ? 4 : 2;
+  const filled = typeof value === 'number' ? Math.round(value) : 0;
+
+  const handlePress = (n: number) => {
+    if (!onChange) return;
+    const next = n === filled ? 0 : (n as StarScore);
+    onChange(next);
+  };
+
+  if (readOnly) {
+    return (
+      <View
+        style={[styles.row, { gap }]}
+        accessible
+        accessibilityRole="text"
+        accessibilityLabel={
+          ariaLabel ?? (filled > 0 ? `Rated ${filled} of ${max} stars` : 'Not rated')
+        }
+      >
+        {stars.map((n) => {
+          const isOn = n <= filled;
+          return (
+            <Text
+              key={n}
+              style={{
+                fontSize,
+                color: isOn ? tokens.colors.accentMustard : tokens.colors.textMuted,
+              }}
+            >
+              {isOn ? '★' : '☆'}
+            </Text>
+          );
+        })}
+      </View>
+    );
+  }
+
+  return (
+    <View style={[styles.row, { gap }]} accessibilityLabel={ariaLabel}>
+      {stars.map((n) => {
+        const isOn = n <= filled;
+        return (
+          <Pressable
+            key={n}
+            onPress={() => handlePress(n)}
+            hitSlop={6}
+            accessibilityRole="button"
+            accessibilityLabel={`Rate ${n} ${n === 1 ? 'star' : 'stars'}`}
+            accessibilityState={{ selected: isOn }}
+            style={({ pressed }) => [pressed && { opacity: 0.6 }]}
+          >
+            <Text
+              style={{
+                fontSize,
+                color: isOn ? tokens.colors.accentMustard : tokens.colors.textMuted,
+              }}
+            >
+              {isOn ? '★' : '☆'}
+            </Text>
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+});

--- a/app/mobile/src/components/search/SearchResultCard.tsx
+++ b/app/mobile/src/components/search/SearchResultCard.tsx
@@ -3,6 +3,7 @@ import { Image, Pressable, StyleSheet, Text, View } from 'react-native';
 import type { SearchResultItem } from '../../services/searchService';
 import { shadows, tokens } from '../../theme';
 import { RankReasonBadge } from '../personalization/RankReasonBadge';
+import { StarRatingRow } from '../recipe/StarRatingRow';
 
 type Props = {
   item: SearchResultItem;
@@ -51,6 +52,15 @@ export function SearchResultCard({ item, onPress }: Props) {
             </Text>
           </View>
         </View>
+        {item.kind === 'recipe' && item.averageRating != null ? (
+          <View style={styles.ratingRow}>
+            <StarRatingRow value={item.averageRating} size="sm" readOnly />
+            <Text style={styles.ratingText}>
+              {item.averageRating.toFixed(1)}
+              {item.ratingCount ? ` · ${item.ratingCount}` : ''}
+            </Text>
+          </View>
+        ) : null}
         <RankReasonBadge reason={item.rankReason} />
       </View>
     </Pressable>
@@ -96,5 +106,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: 8,
   },
   tagText: { fontSize: 12, color: tokens.colors.text, fontWeight: '800' },
+  ratingRow: { flexDirection: 'row', alignItems: 'center', gap: 6 },
+  ratingText: { fontSize: 12, color: tokens.colors.textMuted, fontWeight: '700' },
 });
 

--- a/app/mobile/src/screens/RecipeDetailScreen.tsx
+++ b/app/mobile/src/screens/RecipeDetailScreen.tsx
@@ -10,6 +10,8 @@ import { ErrorView } from '../components/ui/ErrorView';
 import { LoadingView } from '../components/ui/LoadingView';
 import { IngredientSubstitutesSheet } from '../components/recipe/IngredientSubstitutesSheet';
 import { LinkedStoryPreviewCard } from '../components/recipe/LinkedStoryPreviewCard';
+import { StarRatingRow, type StarScore } from '../components/recipe/StarRatingRow';
+import { removeRating, submitRating } from '../services/ratingService';
 import { EndangeredHeritageSection } from '../components/heritage/EndangeredHeritageSection';
 import { HeritageBadge } from '../components/heritage/HeritageBadge';
 import { RecipeCommentsSection } from '../components/recipe/RecipeCommentsSection';
@@ -42,6 +44,7 @@ export default function RecipeDetailScreen({ route, navigation }: Props) {
   const [checkedIds, setCheckedIds] = useState<Set<number>>(new Set());
   const [showShoppingList, setShowShoppingList] = useState(false);
   const [culturalFacts, setCulturalFacts] = useState<CulturalFact[]>([]);
+  const [ratingBusy, setRatingBusy] = useState(false);
   const { showToast } = useToast();
 
   useEffect(() => {
@@ -236,6 +239,103 @@ export default function RecipeDetailScreen({ route, navigation }: Props) {
 
   /** Hide Edit until session is restored from storage (avoids flash for signed-in authors). */
   const canEdit = isReady && isAuthenticated && isRecipeAuthor(user, recipe);
+  const isOwnRecipe = isReady && isAuthenticated && isRecipeAuthor(user, recipe);
+
+  const avgRatingNum = (() => {
+    const v = recipe.average_rating;
+    if (v == null) return null;
+    if (typeof v === 'number') return Number.isFinite(v) ? v : null;
+    const n = parseFloat(v);
+    return Number.isFinite(n) ? n : null;
+  })();
+  const ratingCount = recipe.rating_count ?? 0;
+  const userRating = recipe.user_rating ?? null;
+  const ratingInteractive = isReady && isAuthenticated && !isOwnRecipe;
+
+  async function handleRate(score: StarScore | 0) {
+    if (!recipe || ratingBusy) return;
+    if (!isAuthenticated) {
+      navigation.navigate('Login');
+      return;
+    }
+    if (isOwnRecipe) {
+      showToast('You cannot rate your own recipe.', 'error');
+      return;
+    }
+    // Snapshot for rollback.
+    const prevUser = recipe.user_rating ?? null;
+    const prevAvg = avgRatingNum;
+    const prevCount = ratingCount;
+
+    // Optimistic aggregate recompute (best-effort; backend response is authoritative).
+    let optimisticAvg = prevAvg;
+    let optimisticCount = prevCount;
+    if (score === 0) {
+      if (prevUser != null && prevCount > 0) {
+        const sum = (prevAvg ?? 0) * prevCount - prevUser;
+        optimisticCount = prevCount - 1;
+        optimisticAvg = optimisticCount > 0 ? sum / optimisticCount : null;
+      }
+    } else if (prevUser == null) {
+      const sum = (prevAvg ?? 0) * prevCount + score;
+      optimisticCount = prevCount + 1;
+      optimisticAvg = sum / optimisticCount;
+    } else {
+      const sum = (prevAvg ?? 0) * prevCount - prevUser + score;
+      optimisticAvg = prevCount > 0 ? sum / prevCount : score;
+    }
+
+    setRatingBusy(true);
+    setRecipe((r) =>
+      r
+        ? {
+            ...r,
+            user_rating: score === 0 ? null : score,
+            average_rating: optimisticAvg,
+            rating_count: optimisticCount,
+          }
+        : r,
+    );
+
+    try {
+      if (score === 0) {
+        await removeRating(recipe.id);
+        // 204 — refetch to get authoritative aggregate.
+        setReloadToken((t) => t + 1);
+      } else {
+        const next = await submitRating(recipe.id, score);
+        setRecipe((r) =>
+          r
+            ? {
+                ...r,
+                user_rating: next.user_rating ?? score,
+                average_rating: next.average_rating,
+                rating_count: next.rating_count,
+              }
+            : r,
+        );
+      }
+    } catch (e) {
+      // Rollback.
+      setRecipe((r) =>
+        r
+          ? {
+              ...r,
+              user_rating: prevUser,
+              average_rating: prevAvg,
+              rating_count: prevCount,
+            }
+          : r,
+      );
+      const msg = e instanceof Error ? e.message : 'Could not save rating.';
+      showToast(
+        msg.includes('cannot rate your own') ? 'You cannot rate your own recipe.' : 'Could not save rating.',
+        'error',
+      );
+    } finally {
+      setRatingBusy(false);
+    }
+  }
 
   return (
     <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
@@ -292,6 +392,29 @@ export default function RecipeDetailScreen({ route, navigation }: Props) {
               <Text style={styles.editLinkText}>Edit recipe</Text>
             </Pressable>
           ) : null}
+
+          <View style={styles.ratingBlock}>
+            <StarRatingRow
+              value={userRating ?? (ratingInteractive ? 0 : avgRatingNum)}
+              size="lg"
+              readOnly={!ratingInteractive}
+              onChange={ratingInteractive ? handleRate : undefined}
+              ariaLabel={
+                ratingInteractive
+                  ? userRating
+                    ? `Your rating: ${userRating} of 5`
+                    : 'Rate this recipe'
+                  : avgRatingNum != null
+                    ? `Average rating ${avgRatingNum.toFixed(1)} of 5`
+                    : 'Not rated yet'
+              }
+            />
+            <Text style={styles.ratingCaption}>
+              {ratingCount === 0
+                ? 'Not rated yet'
+                : `${(avgRatingNum ?? 0).toFixed(1)} ★ · ${ratingCount} rating${ratingCount === 1 ? '' : 's'}`}
+            </Text>
+          </View>
 
           {recipe.image ? (
             <View style={styles.imageWrap} accessibilityLabel="Recipe image">
@@ -602,6 +725,8 @@ const styles = StyleSheet.create({
     borderColor: tokens.colors.surfaceDark,
   },
   editLinkText: { fontSize: 14, color: tokens.colors.textOnDark, fontWeight: '800', letterSpacing: 0.3 },
+  ratingBlock: { marginTop: 14, gap: 4 },
+  ratingCaption: { fontSize: 13, color: tokens.colors.textMuted, fontWeight: '600' },
   imageWrap: {
     marginTop: 14,
     width: '100%',

--- a/app/mobile/src/services/ratingService.ts
+++ b/app/mobile/src/services/ratingService.ts
@@ -1,0 +1,60 @@
+import { apiDelete, apiPostJson } from './httpClient';
+
+export type RatingScore = 1 | 2 | 3 | 4 | 5;
+
+export type RatingAggregate = {
+  average_rating: number | null;
+  rating_count: number;
+  user_rating: number | null;
+};
+
+/**
+ * Defensive coercion — DRF DecimalField (`average_rating`) is serialized as a
+ * string like `"4.20"`. Mirrors the pattern used in
+ * `ingredientRouteService.ts` / `mapDataService.ts`.
+ */
+function toNum(v: unknown): number | null {
+  if (v == null) return null;
+  if (typeof v === 'number') return Number.isFinite(v) ? v : null;
+  if (typeof v === 'string') {
+    const n = parseFloat(v);
+    return Number.isFinite(n) ? n : null;
+  }
+  return null;
+}
+
+function toInt(v: unknown): number {
+  const n = toNum(v);
+  return n == null ? 0 : Math.trunc(n);
+}
+
+type RawRating = {
+  average_rating?: number | string | null;
+  rating_count?: number | string | null;
+  user_rating?: number | string | null;
+};
+
+function normalize(raw: RawRating | null | undefined): RatingAggregate {
+  return {
+    average_rating: toNum(raw?.average_rating),
+    rating_count: toInt(raw?.rating_count),
+    user_rating: toNum(raw?.user_rating),
+  };
+}
+
+/** POST `/api/recipes/:id/rate/` with `{ score }`. Backend returns updated aggregate. */
+export async function submitRating(
+  recipeId: number | string,
+  score: RatingScore,
+): Promise<RatingAggregate> {
+  const data = await apiPostJson<RawRating>(`/api/recipes/${recipeId}/rate/`, { score });
+  return normalize(data);
+}
+
+/** DELETE `/api/recipes/:id/rate/`. Returns user_rating=null afterwards. */
+export async function removeRating(recipeId: number | string): Promise<RatingAggregate> {
+  await apiDelete(`/api/recipes/${recipeId}/rate/`);
+  // Endpoint typically returns 204 — caller will refetch detail to refresh
+  // aggregate. Return a neutral aggregate so optimistic flows can settle.
+  return { average_rating: null, rating_count: 0, user_rating: null };
+}

--- a/app/mobile/src/services/searchService.ts
+++ b/app/mobile/src/services/searchService.ts
@@ -10,6 +10,9 @@ export type SearchResultItem = {
   thumbnail?: string | null;
   rankScore: number;
   rankReason: string | null;
+  /** Aggregate star rating, only populated for recipes when backend supplies it. */
+  averageRating?: number | null;
+  ratingCount?: number;
 };
 
 type BackendSearchResponse = {
@@ -21,6 +24,8 @@ type BackendSearchResponse = {
     region_tag?: string | null;
     rank_score?: number;
     rank_reason?: string | null;
+    average_rating?: number | string | null;
+    rating_count?: number | string | null;
   }>;
   stories?: Array<{
     result_type: 'story';
@@ -56,17 +61,41 @@ export async function search(
   }
   const data = await apiGetJson<BackendSearchResponse>(`/api/search/?${params.toString()}`);
 
-  const recipes = (data.recipes ?? []).map<SearchResultItem>((r) => ({
-    key: `recipe-${r.id}`,
-    kind: 'recipe' as const,
-    id: String(r.id),
-    title: String(r.title ?? ''),
-    subtitle: r.region_tag ? `Recipe · ${r.region_tag}` : 'Recipe',
-    region: r.region_tag ?? undefined,
-    thumbnail: r.image ?? null,
-    rankScore: typeof r.rank_score === 'number' ? r.rank_score : 0,
-    rankReason: typeof r.rank_reason === 'string' ? r.rank_reason : null,
-  }));
+  const recipes = (data.recipes ?? []).map<SearchResultItem>((r) => {
+    const avgRaw = r.average_rating;
+    const avg =
+      typeof avgRaw === 'number'
+        ? Number.isFinite(avgRaw)
+          ? avgRaw
+          : null
+        : typeof avgRaw === 'string'
+          ? Number.isFinite(parseFloat(avgRaw))
+            ? parseFloat(avgRaw)
+            : null
+          : null;
+    const countRaw = r.rating_count;
+    const count =
+      typeof countRaw === 'number'
+        ? countRaw
+        : typeof countRaw === 'string'
+          ? Number.isFinite(parseInt(countRaw, 10))
+            ? parseInt(countRaw, 10)
+            : 0
+          : 0;
+    return {
+      key: `recipe-${r.id}`,
+      kind: 'recipe' as const,
+      id: String(r.id),
+      title: String(r.title ?? ''),
+      subtitle: r.region_tag ? `Recipe · ${r.region_tag}` : 'Recipe',
+      region: r.region_tag ?? undefined,
+      thumbnail: r.image ?? null,
+      rankScore: typeof r.rank_score === 'number' ? r.rank_score : 0,
+      rankReason: typeof r.rank_reason === 'string' ? r.rank_reason : null,
+      averageRating: avg,
+      ratingCount: count,
+    };
+  });
 
   const stories = (data.stories ?? []).map<SearchResultItem>((s) => ({
     key: `story-${s.id}`,

--- a/app/mobile/src/types/recipe.ts
+++ b/app/mobile/src/types/recipe.ts
@@ -36,4 +36,10 @@ export type RecipeDetail = {
     source_url: string;
     created_at?: string;
   }>;
+  /** Aggregate star rating (1-5, decimal). Backend may serialize DecimalField as string. */
+  average_rating?: number | string | null;
+  /** Number of users who have rated this recipe. */
+  rating_count?: number;
+  /** Current user's submitted score (1-5) or null when not rated / unauthenticated. */
+  user_rating?: number | null;
 };


### PR DESCRIPTION
## Summary
- Adds a reusable `StarRatingRow` component (5-star, mustard fill, sm/lg sizes, read-only mode, tap-same-star-to-clear) used on Recipe Detail and recipe Search cards.
- Recipe Detail: interactive star row with optimistic update against `POST /api/recipes/:id/rate/` and `DELETE` on clear. Own recipes render read-only; unauthenticated taps route to Login. Caption shows `4.2 ★ · N ratings` or `Not rated yet`.
- Search result cards (recipe kind) render a small read-only star row when `average_rating` is present in the response; hidden otherwise so we never fabricate.
- New `ratingService.ts` with defensive `toNum` for the DRF DecimalField (string `"4.20"`) shape.

## Notes
- **#738 NOT addressed in this PR:** the mobile app currently has no notifications screen, list component, or service. Filed **#760** to build the scaffolding first. #738 stays open and depends on #760.
- **Cards skipped:** `RecommendationsRail` (home recommendations) and `searchService` story results do not expose `average_rating` from the backend response — left untouched rather than fabricated.
- **Overlaps with #755 (bookmark cluster)** on `RecipeDetailScreen.tsx` and `SearchResultCard.tsx` — merge-time conflict expected if #755 lands first. Concerns are separate (save pill vs star row), so the merge will be mechanical.

## Test plan
- [ ] Open a recipe you did NOT author while signed in — tap a star, average updates optimistically, caption shows new count.
- [ ] Tap the same star again — rating clears (DELETE) and detail refetches.
- [ ] Open your own recipe — stars render but are not tappable.
- [ ] Sign out, open any recipe — stars render read-only; tapping any star routes to Login.
- [ ] Search for recipes — when backend includes `average_rating`, a small star row appears on the card.

Closes #735