### PR TITLE
feat(mobile): region-centric heritage map (#667)

### DIFF
--- a/app/mobile/src/screens/HeritageMapScreen.tsx
+++ b/app/mobile/src/screens/HeritageMapScreen.tsx
@@ -50,6 +50,74 @@ function markerSizeForCount(count: number): number {
   return 32;
 }
 
+/** Just the colored dot — hardware-textured + offscreen-composited so Android
+ * properly rounds the corners when it snapshots the view into the marker
+ * bitmap (without this, borderRadius is silently dropped and the marker
+ * renders as a coloured square). */
+function HeritageRegionDot({ size, isTop }: { size: number; isTop: boolean }) {
+  return (
+    <View
+      collapsable={false}
+      renderToHardwareTextureAndroid
+      needsOffscreenAlphaCompositing
+      style={{
+        width: size + 8,
+        height: size + 8,
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: 'transparent',
+      }}
+    >
+      <View
+        style={{
+          width: size,
+          height: size,
+          borderRadius: size / 2,
+          backgroundColor: isTop
+            ? tokens.colors.accentGreen
+            : tokens.colors.accentMustard,
+          borderWidth: 3,
+          borderColor: tokens.colors.surfaceDark,
+        }}
+      />
+    </View>
+  );
+}
+
+/** Region marker — wraps the dot in a Marker and runs the dual tracksViewChanges
+ * trick (start tracking so the layout is captured, then stop tracking once
+ * the view has settled so Android doesn't re-snapshot and reintroduce the
+ * square-clipping bug on subsequent renders). */
+function HeritageRegionMarker({
+  cluster,
+  isTop,
+  size,
+  onPress,
+}: {
+  cluster: RegionCluster;
+  isTop: boolean;
+  size: number;
+  onPress: () => void;
+}) {
+  const [tracks, setTracks] = useState(true);
+  useEffect(() => {
+    const t = setTimeout(() => setTracks(false), 800);
+    return () => clearTimeout(t);
+  }, []);
+  return (
+    <Marker
+      coordinate={cluster.coords}
+      onPress={onPress}
+      title={cluster.region}
+      description={`${cluster.members.length} member${cluster.members.length === 1 ? '' : 's'}`}
+      anchor={{ x: 0.5, y: 0.5 }}
+      tracksViewChanges={tracks}
+    >
+      <HeritageRegionDot size={size} isTop={isTop} />
+    </Marker>
+  );
+}
+
 export default function HeritageMapScreen({ route, navigation }: Props) {
   const { heritageGroupId } = route.params;
   const [group, setGroup] = useState<HeritageGroupDetail | null>(null);
@@ -260,38 +328,13 @@ export default function HeritageMapScreen({ route, navigation }: Props) {
             const isTop = topRegion?.region === cluster.region;
             const size = markerSizeForCount(cluster.members.length);
             return (
-              <Marker
+              <HeritageRegionMarker
                 key={`region-${cluster.region}`}
-                coordinate={cluster.coords}
+                cluster={cluster}
+                isTop={isTop}
+                size={size}
                 onPress={() => handleMarkerPress(cluster.region)}
-                title={cluster.region}
-                description={`${cluster.members.length} member${cluster.members.length === 1 ? '' : 's'}`}
-                anchor={{ x: 0.5, y: 0.5 }}
-              >
-                <View collapsable={false} style={styles.regionMarkerWrap}>
-                  <Text
-                    style={[
-                      styles.regionMarkerDot,
-                      {
-                        fontSize: size,
-                        color: isTop
-                          ? tokens.colors.accentGreen
-                          : tokens.colors.accentMustard,
-                      },
-                    ]}
-                  >
-                    ●
-                  </Text>
-                  <Text
-                    style={[
-                      styles.regionMarkerCount,
-                      { fontSize: size >= 56 ? 22 : size >= 44 ? 18 : 14 },
-                    ]}
-                  >
-                    {cluster.members.length}
-                  </Text>
-                </View>
-              </Marker>
+              />
             );
           })}
         </MapView>
@@ -436,24 +479,6 @@ const styles = StyleSheet.create({
     fontFamily: tokens.typography.display.fontFamily,
   },
   emptyBody: { fontSize: 15, color: tokens.colors.textMuted, lineHeight: 22 },
-  regionMarkerWrap: {
-    backgroundColor: 'transparent',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  regionMarkerDot: {
-    textAlign: 'center',
-    lineHeight: undefined,
-    textShadowColor: tokens.colors.surfaceDark,
-    textShadowOffset: { width: 0, height: 0 },
-    textShadowRadius: 1.5,
-  },
-  regionMarkerCount: {
-    position: 'absolute',
-    fontWeight: '900',
-    color: tokens.colors.surfaceDark,
-    textAlign: 'center',
-  },
   legend: {
     position: 'absolute',
     top: 16,

--- a/app/mobile/src/screens/HeritageMapScreen.tsx
+++ b/app/mobile/src/screens/HeritageMapScreen.tsx
@@ -439,14 +439,15 @@ const styles = StyleSheet.create({
   emptyBody: { fontSize: 15, color: tokens.colors.textMuted, lineHeight: 22 },
   regionMarkerWrap: {
     backgroundColor: 'transparent',
-    padding: 4,
+    padding: 8,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   regionMarker: {
     borderWidth: 3,
     borderColor: tokens.colors.surfaceDark,
     alignItems: 'center',
     justifyContent: 'center',
-    overflow: 'hidden',
   },
   regionMarkerCount: {
     fontWeight: '900',

--- a/app/mobile/src/screens/HeritageMapScreen.tsx
+++ b/app/mobile/src/screens/HeritageMapScreen.tsx
@@ -269,28 +269,27 @@ export default function HeritageMapScreen({ route, navigation }: Props) {
                 anchor={{ x: 0.5, y: 0.5 }}
               >
                 <View collapsable={false} style={styles.regionMarkerWrap}>
-                  <View
+                  <Text
                     style={[
-                      styles.regionMarker,
+                      styles.regionMarkerDot,
                       {
-                        width: size,
-                        height: size,
-                        borderRadius: size / 2,
-                        backgroundColor: isTop
+                        fontSize: size,
+                        color: isTop
                           ? tokens.colors.accentGreen
                           : tokens.colors.accentMustard,
                       },
                     ]}
                   >
-                    <Text
-                      style={[
-                        styles.regionMarkerCount,
-                        { fontSize: size >= 56 ? 20 : size >= 44 ? 16 : 13 },
-                      ]}
-                    >
-                      {cluster.members.length}
-                    </Text>
-                  </View>
+                    ●
+                  </Text>
+                  <Text
+                    style={[
+                      styles.regionMarkerCount,
+                      { fontSize: size >= 56 ? 22 : size >= 44 ? 18 : 14 },
+                    ]}
+                  >
+                    {cluster.members.length}
+                  </Text>
                 </View>
               </Marker>
             );
@@ -439,19 +438,21 @@ const styles = StyleSheet.create({
   emptyBody: { fontSize: 15, color: tokens.colors.textMuted, lineHeight: 22 },
   regionMarkerWrap: {
     backgroundColor: 'transparent',
-    padding: 8,
     alignItems: 'center',
     justifyContent: 'center',
   },
-  regionMarker: {
-    borderWidth: 3,
-    borderColor: tokens.colors.surfaceDark,
-    alignItems: 'center',
-    justifyContent: 'center',
+  regionMarkerDot: {
+    textAlign: 'center',
+    lineHeight: undefined,
+    textShadowColor: tokens.colors.surfaceDark,
+    textShadowOffset: { width: 0, height: 0 },
+    textShadowRadius: 1.5,
   },
   regionMarkerCount: {
+    position: 'absolute',
     fontWeight: '900',
     color: tokens.colors.surfaceDark,
+    textAlign: 'center',
   },
   legend: {
     position: 'absolute',

--- a/app/mobile/src/screens/HeritageMapScreen.tsx
+++ b/app/mobile/src/screens/HeritageMapScreen.tsx
@@ -267,7 +267,6 @@ export default function HeritageMapScreen({ route, navigation }: Props) {
                 title={cluster.region}
                 description={`${cluster.members.length} member${cluster.members.length === 1 ? '' : 's'}`}
                 anchor={{ x: 0.5, y: 0.5 }}
-                tracksViewChanges={false}
               >
                 <View collapsable={false} style={styles.regionMarkerWrap}>
                   <View

--- a/app/mobile/src/screens/HeritageMapScreen.tsx
+++ b/app/mobile/src/screens/HeritageMapScreen.tsx
@@ -132,17 +132,6 @@ export default function HeritageMapScreen({ route, navigation }: Props) {
 
   const topRegion = clusters[0] ?? null;
 
-  /** Visual base for the fan: mean of all region pin coords. */
-  const baseCoord = useMemo<LatLng | null>(() => {
-    if (clusters.length === 0) return null;
-    const sumLat = clusters.reduce((acc, c) => acc + c.coords.latitude, 0);
-    const sumLng = clusters.reduce((acc, c) => acc + c.coords.longitude, 0);
-    return {
-      latitude: sumLat / clusters.length,
-      longitude: sumLng / clusters.length,
-    };
-  }, [clusters]);
-
   // Seed expansion state: top region open, others collapsed.
   useEffect(() => {
     if (!topRegion) return;
@@ -254,30 +243,18 @@ export default function HeritageMapScreen({ route, navigation }: Props) {
           style={styles.map}
           accessibilityLabel={`Heritage map for ${group.name}`}
         >
-          {baseCoord
-            ? clusters.map((cluster) => (
-                <Polyline
-                  key={`line-${cluster.region}`}
-                  coordinates={[baseCoord, cluster.coords]}
-                  strokeColor={tokens.colors.surfaceDark}
-                  strokeWidth={2}
-                />
-              ))
+          {topRegion
+            ? clusters
+                .filter((c) => c.region !== topRegion.region)
+                .map((cluster) => (
+                  <Polyline
+                    key={`line-${cluster.region}`}
+                    coordinates={[topRegion.coords, cluster.coords]}
+                    strokeColor={tokens.colors.surfaceDark}
+                    strokeWidth={2}
+                  />
+                ))
             : null}
-
-          {baseCoord ? (
-            <Marker
-              key="heritage-base"
-              coordinate={baseCoord}
-              anchor={{ x: 0.5, y: 0.5 }}
-              title={group.name}
-              description={`${totalMembers} member${totalMembers === 1 ? '' : 's'} across ${clusters.length} region${clusters.length === 1 ? '' : 's'}`}
-            >
-              <View style={styles.heritageBase}>
-                <Text style={styles.heritageBaseGlyph}>🏛</Text>
-              </View>
-            </Marker>
-          ) : null}
 
           {clusters.map((cluster) => {
             const isTop = topRegion?.region === cluster.region;
@@ -469,18 +446,6 @@ const styles = StyleSheet.create({
     fontWeight: '900',
     color: tokens.colors.surfaceDark,
   },
-  heritageBase: {
-    width: 40,
-    height: 40,
-    borderRadius: 20,
-    backgroundColor: tokens.colors.bg,
-    borderWidth: 3,
-    borderColor: tokens.colors.surfaceDark,
-    alignItems: 'center',
-    justifyContent: 'center',
-    ...shadows.md,
-  },
-  heritageBaseGlyph: { fontSize: 20 },
   legend: {
     position: 'absolute',
     top: 16,

--- a/app/mobile/src/screens/HeritageMapScreen.tsx
+++ b/app/mobile/src/screens/HeritageMapScreen.tsx
@@ -1,32 +1,39 @@
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { StyleSheet, Text, View } from 'react-native';
-import MapView, { Callout, Marker, Polyline } from 'react-native-maps';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import {
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import MapView, { Marker } from 'react-native-maps';
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { MapZoomControls } from '../components/map/MapZoomControls';
 import { ErrorView } from '../components/ui/ErrorView';
 import { LoadingView } from '../components/ui/LoadingView';
-import { fetchHeritageGroup, type HeritageGroupDetail } from '../services/heritageService';
+import {
+  fetchHeritageGroup,
+  type HeritageGroupDetail,
+  type HeritageMember,
+} from '../services/heritageService';
 import type { RootStackParamList } from '../navigation/types';
 import { coordsForRegion, type LatLng } from '../utils/regionGeo';
 import { shadows, tokens } from '../theme';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'HeritageMap'>;
 
-type PlottedMember = {
-  content_type: 'recipe' | 'story' | string;
-  id: number;
-  title: string;
+type MappedMember = HeritageMember & { coords: LatLng };
+
+type RegionCluster = {
+  region: string;
   coords: LatLng;
+  members: MappedMember[];
 };
 
 /** Resolve coordinates either from backend lat/lng or the hardcoded regionGeo
  * fallback when the backend hasn't seeded coordinates yet (see #657). */
-function resolveCoords(member: {
-  latitude: number | null;
-  longitude: number | null;
-  region: string | null;
-}): LatLng | null {
+function resolveCoords(member: HeritageMember): LatLng | null {
   if (member.latitude != null && member.longitude != null) {
     return { latitude: member.latitude, longitude: member.longitude };
   }
@@ -36,13 +43,24 @@ function resolveCoords(member: {
   return null;
 }
 
+/** Three-tier size scale for region pins by member count. */
+function markerSizeForCount(count: number): number {
+  if (count >= 5) return 56;
+  if (count >= 2) return 44;
+  return 32;
+}
+
 export default function HeritageMapScreen({ route, navigation }: Props) {
   const { heritageGroupId } = route.params;
   const [group, setGroup] = useState<HeritageGroupDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [reloadToken, setReloadToken] = useState(0);
+  const [expandedRegions, setExpandedRegions] = useState<Record<string, boolean>>({});
   const mapRef = useRef<MapView | null>(null);
+  const scrollRef = useRef<ScrollView | null>(null);
+  const sectionOffsets = useRef<Record<string, number>>({});
+  const insets = useSafeAreaInsets();
 
   useEffect(() => {
     let cancelled = false;
@@ -66,43 +84,115 @@ export default function HeritageMapScreen({ route, navigation }: Props) {
     };
   }, [heritageGroupId, reloadToken]);
 
-  const plotted = useMemo<PlottedMember[]>(() => {
-    if (!group) return [];
-    return group.members
-      .map((m) => {
-        const coords = resolveCoords(m);
-        if (!coords) return null;
-        return {
-          content_type: m.content_type,
-          id: m.id,
-          title: m.title,
-          coords,
-        };
-      })
-      .filter((m): m is PlottedMember => m !== null);
+  /** Members partitioned into mappable (have coords + region) and unmapped. */
+  const { mapped, unmapped } = useMemo(() => {
+    if (!group) return { mapped: [] as MappedMember[], unmapped: [] as HeritageMember[] };
+    const mappedOut: MappedMember[] = [];
+    const unmappedOut: HeritageMember[] = [];
+    for (const m of group.members) {
+      const coords = resolveCoords(m);
+      if (!coords || !m.region) {
+        unmappedOut.push(m);
+      } else {
+        mappedOut.push({ ...m, coords });
+      }
+    }
+    return { mapped: mappedOut, unmapped: unmappedOut };
   }, [group]);
 
-  const centerCoord = useMemo<LatLng | null>(() => {
-    if (plotted.length === 0) return null;
-    const sumLat = plotted.reduce((acc, p) => acc + p.coords.latitude, 0);
-    const sumLng = plotted.reduce((acc, p) => acc + p.coords.longitude, 0);
-    return {
-      latitude: sumLat / plotted.length,
-      longitude: sumLng / plotted.length,
-    };
-  }, [plotted]);
-
-  useEffect(() => {
-    if (!mapRef.current || plotted.length === 0 || !centerCoord) return;
-    const coords = [centerCoord, ...plotted.map((p) => p.coords)];
-    const t = setTimeout(() => {
-      mapRef.current?.fitToCoordinates(coords, {
-        edgePadding: { top: 80, right: 60, bottom: 80, left: 60 },
-        animated: true,
+  /** Cluster mapped members by region; coord = mean of member coords. */
+  const clusters = useMemo<RegionCluster[]>(() => {
+    const byRegion = new Map<string, MappedMember[]>();
+    for (const m of mapped) {
+      const key = m.region as string;
+      const arr = byRegion.get(key);
+      if (arr) arr.push(m);
+      else byRegion.set(key, [m]);
+    }
+    const result: RegionCluster[] = [];
+    for (const [region, members] of byRegion.entries()) {
+      const sumLat = members.reduce((acc, p) => acc + p.coords.latitude, 0);
+      const sumLng = members.reduce((acc, p) => acc + p.coords.longitude, 0);
+      result.push({
+        region,
+        coords: {
+          latitude: sumLat / members.length,
+          longitude: sumLng / members.length,
+        },
+        members,
       });
+    }
+    // Sort descending by member count, alphabetical tiebreak for determinism.
+    result.sort((a, b) => {
+      if (b.members.length !== a.members.length) return b.members.length - a.members.length;
+      return a.region.localeCompare(b.region);
+    });
+    return result;
+  }, [mapped]);
+
+  const topRegion = clusters[0] ?? null;
+
+  // Seed expansion state: top region open, others collapsed.
+  useEffect(() => {
+    if (!topRegion) return;
+    setExpandedRegions((prev) => {
+      if (Object.prototype.hasOwnProperty.call(prev, topRegion.region)) return prev;
+      const next: Record<string, boolean> = {};
+      for (const c of clusters) next[c.region] = c.region === topRegion.region;
+      return next;
+    });
+  }, [clusters, topRegion]);
+
+  // Fit all clusters, then animate-center on top region.
+  useEffect(() => {
+    if (!mapRef.current || clusters.length === 0 || !topRegion) return;
+    const coords = clusters.map((c) => c.coords);
+    const t = setTimeout(() => {
+      if (coords.length === 1) {
+        mapRef.current?.animateToRegion(
+          {
+            latitude: topRegion.coords.latitude,
+            longitude: topRegion.coords.longitude,
+            latitudeDelta: 4,
+            longitudeDelta: 4,
+          },
+          500,
+        );
+      } else {
+        mapRef.current?.fitToCoordinates(coords, {
+          edgePadding: { top: 100, right: 60, bottom: 320, left: 60 },
+          animated: true,
+        });
+        // Nudge center toward the top region after the fit settles.
+        setTimeout(() => {
+          mapRef.current?.animateCamera(
+            { center: topRegion.coords },
+            { duration: 450 },
+          );
+        }, 600);
+      }
     }, 250);
     return () => clearTimeout(t);
-  }, [plotted, centerCoord]);
+  }, [clusters, topRegion]);
+
+  const handleMarkerPress = (region: string) => {
+    setExpandedRegions((prev) => ({ ...prev, [region]: true }));
+    // Defer to next tick so the layout reflects the new expansion before we scroll.
+    setTimeout(() => {
+      const y = sectionOffsets.current[region];
+      if (scrollRef.current && typeof y === 'number') {
+        scrollRef.current.scrollTo({ y: Math.max(0, y - 8), animated: true });
+      }
+    }, 80);
+  };
+
+  const handleMemberPress = (member: HeritageMember) => {
+    if (member.content_type === 'recipe') {
+      navigation.navigate('RecipeDetail', { id: String(member.id) });
+    } else if (member.content_type === 'story') {
+      navigation.navigate('StoryDetail', { id: String(member.id) });
+    }
+  };
 
   if (loading) {
     return (
@@ -127,7 +217,7 @@ export default function HeritageMapScreen({ route, navigation }: Props) {
     );
   }
 
-  if (plotted.length === 0 || !centerCoord) {
+  if (clusters.length === 0) {
     return (
       <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
         <View style={styles.padded}>
@@ -142,60 +232,54 @@ export default function HeritageMapScreen({ route, navigation }: Props) {
     );
   }
 
+  const totalMembers = mapped.length + unmapped.length;
+  const sheetBottomInset = Math.max(insets.bottom, 12);
+
   return (
     <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
       <View style={styles.fill}>
-        <MapView ref={mapRef} style={styles.map} accessibilityLabel={`Heritage map for ${group.name}`}>
-          {/* Polylines from center → each member */}
-          {plotted.map((p) => (
-            <Polyline
-              key={`line-${p.content_type}-${p.id}`}
-              coordinates={[centerCoord, p.coords]}
-              strokeColor={tokens.colors.surfaceDark}
-              strokeWidth={2}
-            />
-          ))}
-
-          {/* Central heritage marker */}
-          <Marker
-            coordinate={centerCoord}
-            onPress={() => navigation.goBack()}
-            pinColor={tokens.colors.accentGreen}
-            title={group.name}
-            description="Tap to return to heritage details"
-          >
-            <View style={styles.heritageMarker}>
-              <Text style={styles.heritageGlyph}>🏛</Text>
-            </View>
-          </Marker>
-
-          {/* Member markers */}
-          {plotted.map((p) => (
-            <Marker
-              key={`mk-${p.content_type}-${p.id}`}
-              coordinate={p.coords}
-              pinColor={tokens.colors.accentMustard}
-              onCalloutPress={() => {
-                if (p.content_type === 'recipe') {
-                  navigation.navigate('RecipeDetail', { id: String(p.id) });
-                } else if (p.content_type === 'story') {
-                  navigation.navigate('StoryDetail', { id: String(p.id) });
-                }
-              }}
-            >
-              <Callout tooltip>
-                <View style={styles.callout}>
-                  <Text style={styles.calloutKind}>
-                    {p.content_type === 'recipe' ? 'RECIPE' : 'STORY'}
+        <MapView
+          ref={mapRef}
+          style={styles.map}
+          accessibilityLabel={`Heritage map for ${group.name}`}
+        >
+          {clusters.map((cluster) => {
+            const isTop = topRegion?.region === cluster.region;
+            const size = markerSizeForCount(cluster.members.length);
+            return (
+              <Marker
+                key={`region-${cluster.region}`}
+                coordinate={cluster.coords}
+                onPress={() => handleMarkerPress(cluster.region)}
+                title={cluster.region}
+                description={`${cluster.members.length} member${cluster.members.length === 1 ? '' : 's'}`}
+                anchor={{ x: 0.5, y: 0.5 }}
+              >
+                <View
+                  style={[
+                    styles.regionMarker,
+                    {
+                      width: size,
+                      height: size,
+                      borderRadius: size / 2,
+                      backgroundColor: isTop
+                        ? tokens.colors.accentGreen
+                        : tokens.colors.accentMustard,
+                    },
+                  ]}
+                >
+                  <Text
+                    style={[
+                      styles.regionMarkerCount,
+                      { fontSize: size >= 56 ? 20 : size >= 44 ? 16 : 13 },
+                    ]}
+                  >
+                    {cluster.members.length}
                   </Text>
-                  <Text style={styles.calloutTitle} numberOfLines={2}>
-                    {p.title}
-                  </Text>
-                  <Text style={styles.calloutHint}>Tap to open →</Text>
                 </View>
-              </Callout>
-            </Marker>
-          ))}
+              </Marker>
+            );
+          })}
         </MapView>
 
         <MapZoomControls mapRef={mapRef} style={styles.zoomControls} />
@@ -203,8 +287,122 @@ export default function HeritageMapScreen({ route, navigation }: Props) {
         <View style={styles.legend} pointerEvents="none">
           <Text style={styles.legendTitle}>{group.name}</Text>
           <Text style={styles.legendBody}>
-            🏛 Centre · {plotted.length} member{plotted.length === 1 ? '' : 's'}
+            {clusters.length} region{clusters.length === 1 ? '' : 's'} · {totalMembers} member
+            {totalMembers === 1 ? '' : 's'}
           </Text>
+        </View>
+
+        <View style={[styles.sheet, { paddingBottom: sheetBottomInset + 12 }]}>
+          <View style={styles.sheetHandle} />
+          <Text style={styles.sheetTitle}>Regions</Text>
+          <ScrollView
+            ref={scrollRef}
+            style={styles.sheetScroll}
+            contentContainerStyle={styles.sheetContent}
+            showsVerticalScrollIndicator
+          >
+            {clusters.map((cluster) => {
+              const isTop = topRegion?.region === cluster.region;
+              const expanded = expandedRegions[cluster.region] ?? isTop;
+              return (
+                <View
+                  key={`sec-${cluster.region}`}
+                  style={styles.section}
+                  onLayout={(e) => {
+                    sectionOffsets.current[cluster.region] = e.nativeEvent.layout.y;
+                  }}
+                >
+                  <Pressable
+                    style={({ pressed }) => [styles.sectionHeader, pressed && styles.pressed]}
+                    onPress={() =>
+                      setExpandedRegions((prev) => ({
+                        ...prev,
+                        [cluster.region]: !expanded,
+                      }))
+                    }
+                    accessibilityRole="button"
+                    accessibilityLabel={`${cluster.region}, ${cluster.members.length} members, ${expanded ? 'collapse' : 'expand'}`}
+                  >
+                    <View
+                      style={[
+                        styles.sectionBadge,
+                        {
+                          backgroundColor: isTop
+                            ? tokens.colors.accentGreen
+                            : tokens.colors.accentMustard,
+                        },
+                      ]}
+                    >
+                      <Text style={styles.sectionBadgeText}>{cluster.members.length}</Text>
+                    </View>
+                    <View style={styles.sectionTitleWrap}>
+                      <Text style={styles.sectionTitle} numberOfLines={1}>
+                        {cluster.region}
+                      </Text>
+                      <Text style={styles.sectionSub}>
+                        {cluster.members.length} member{cluster.members.length === 1 ? '' : 's'}
+                        {isTop ? ' · Top region' : ''}
+                      </Text>
+                    </View>
+                    <Text style={styles.chevron}>{expanded ? '▾' : '▸'}</Text>
+                  </Pressable>
+
+                  {expanded
+                    ? cluster.members.map((m) => (
+                        <Pressable
+                          key={`m-${m.content_type}-${m.id}`}
+                          style={({ pressed }) => [styles.memberRow, pressed && styles.pressed]}
+                          onPress={() => handleMemberPress(m)}
+                          accessibilityRole="button"
+                          accessibilityLabel={`Open ${m.title}`}
+                        >
+                          <Text style={styles.memberTitle} numberOfLines={2}>
+                            {m.title}
+                          </Text>
+                          <View style={styles.chip}>
+                            <Text style={styles.chipText}>
+                              {m.content_type === 'recipe' ? 'RECIPE' : 'STORY'}
+                            </Text>
+                          </View>
+                        </Pressable>
+                      ))
+                    : null}
+                </View>
+              );
+            })}
+
+            {unmapped.length > 0 ? (
+              <View style={styles.section}>
+                <View style={styles.sectionHeader}>
+                  <View style={[styles.sectionBadge, styles.sectionBadgeMuted]}>
+                    <Text style={styles.sectionBadgeText}>{unmapped.length}</Text>
+                  </View>
+                  <View style={styles.sectionTitleWrap}>
+                    <Text style={styles.sectionTitle}>Unmapped</Text>
+                    <Text style={styles.sectionSub}>No region or coordinates</Text>
+                  </View>
+                </View>
+                {unmapped.map((m) => (
+                  <Pressable
+                    key={`u-${m.content_type}-${m.id}`}
+                    style={({ pressed }) => [styles.memberRow, pressed && styles.pressed]}
+                    onPress={() => handleMemberPress(m)}
+                    accessibilityRole="button"
+                    accessibilityLabel={`Open ${m.title}`}
+                  >
+                    <Text style={styles.memberTitle} numberOfLines={2}>
+                      {m.title}
+                    </Text>
+                    <View style={styles.chip}>
+                      <Text style={styles.chipText}>
+                        {m.content_type === 'recipe' ? 'RECIPE' : 'STORY'}
+                      </Text>
+                    </View>
+                  </Pressable>
+                ))}
+              </View>
+            ) : null}
+          </ScrollView>
         </View>
       </View>
     </SafeAreaView>
@@ -224,44 +422,16 @@ const styles = StyleSheet.create({
     fontFamily: tokens.typography.display.fontFamily,
   },
   emptyBody: { fontSize: 15, color: tokens.colors.textMuted, lineHeight: 22 },
-  heritageMarker: {
-    width: 44,
-    height: 44,
-    borderRadius: 999,
-    backgroundColor: tokens.colors.accentGreen,
+  regionMarker: {
     borderWidth: 3,
     borderColor: tokens.colors.surfaceDark,
     alignItems: 'center',
     justifyContent: 'center',
     ...shadows.md,
   },
-  heritageGlyph: { fontSize: 22 },
-  callout: {
-    minWidth: 180,
-    maxWidth: 240,
-    padding: 10,
-    borderRadius: tokens.radius.lg,
-    backgroundColor: tokens.colors.bg,
-    borderWidth: 1.5,
-    borderColor: tokens.colors.surfaceDark,
-    gap: 6,
-    ...shadows.md,
-  },
-  calloutKind: {
-    fontSize: 10,
+  regionMarkerCount: {
     fontWeight: '900',
-    color: tokens.colors.textMuted,
-    letterSpacing: 1,
-  },
-  calloutTitle: {
-    fontSize: 14,
-    fontWeight: '800',
-    color: tokens.colors.text,
-  },
-  calloutHint: {
-    fontSize: 11,
-    color: tokens.colors.textMuted,
-    fontStyle: 'italic',
+    color: tokens.colors.surfaceDark,
   },
   legend: {
     position: 'absolute',
@@ -284,4 +454,104 @@ const styles = StyleSheet.create({
   },
   legendBody: { fontSize: 12, color: tokens.colors.textMuted, fontWeight: '700' },
   zoomControls: { top: 90 },
+  sheet: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    backgroundColor: tokens.colors.bg,
+    borderTopLeftRadius: tokens.radius.xl,
+    borderTopRightRadius: tokens.radius.xl,
+    borderTopWidth: 1.5,
+    borderColor: tokens.colors.surfaceDark,
+    paddingTop: 8,
+    paddingHorizontal: 16,
+    maxHeight: '55%',
+    minHeight: 220,
+    ...shadows.lg,
+  },
+  sheetHandle: {
+    alignSelf: 'center',
+    width: 44,
+    height: 5,
+    borderRadius: 999,
+    backgroundColor: tokens.colors.surfaceDark,
+    marginBottom: 10,
+    opacity: 0.5,
+  },
+  sheetTitle: {
+    fontSize: 18,
+    fontWeight: '800',
+    color: tokens.colors.text,
+    fontFamily: tokens.typography.display.fontFamily,
+    marginBottom: 8,
+  },
+  sheetScroll: { flex: 1 },
+  sheetContent: { paddingBottom: 12, gap: 12 },
+  section: { gap: 8 },
+  sectionHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    paddingVertical: 8,
+  },
+  sectionBadge: {
+    minWidth: 32,
+    height: 32,
+    paddingHorizontal: 8,
+    borderRadius: 999,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1.5,
+    borderColor: tokens.colors.surfaceDark,
+  },
+  sectionBadgeMuted: {
+    backgroundColor: tokens.colors.bg,
+  },
+  sectionBadgeText: {
+    fontSize: 13,
+    fontWeight: '900',
+    color: tokens.colors.surfaceDark,
+  },
+  sectionTitleWrap: { flex: 1 },
+  sectionTitle: {
+    fontSize: 15,
+    fontWeight: '800',
+    color: tokens.colors.text,
+    fontFamily: tokens.typography.display.fontFamily,
+  },
+  sectionSub: { fontSize: 11, color: tokens.colors.textMuted, fontWeight: '700' },
+  chevron: { fontSize: 16, color: tokens.colors.textMuted, paddingHorizontal: 6 },
+  memberRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    borderRadius: tokens.radius.lg,
+    borderWidth: 1.5,
+    borderColor: tokens.colors.surfaceDark,
+    backgroundColor: tokens.colors.bg,
+  },
+  memberTitle: {
+    flex: 1,
+    fontSize: 14,
+    fontWeight: '700',
+    color: tokens.colors.text,
+  },
+  chip: {
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: tokens.radius.pill,
+    backgroundColor: tokens.colors.accentMustard,
+    borderWidth: 1,
+    borderColor: tokens.colors.surfaceDark,
+  },
+  chipText: {
+    fontSize: 10,
+    fontWeight: '900',
+    color: tokens.colors.surfaceDark,
+    letterSpacing: 1,
+  },
+  pressed: { opacity: 0.85 },
 });

--- a/app/mobile/src/screens/HeritageMapScreen.tsx
+++ b/app/mobile/src/screens/HeritageMapScreen.tsx
@@ -267,28 +267,31 @@ export default function HeritageMapScreen({ route, navigation }: Props) {
                 title={cluster.region}
                 description={`${cluster.members.length} member${cluster.members.length === 1 ? '' : 's'}`}
                 anchor={{ x: 0.5, y: 0.5 }}
+                tracksViewChanges={false}
               >
-                <View
-                  style={[
-                    styles.regionMarker,
-                    {
-                      width: size,
-                      height: size,
-                      borderRadius: size / 2,
-                      backgroundColor: isTop
-                        ? tokens.colors.accentGreen
-                        : tokens.colors.accentMustard,
-                    },
-                  ]}
-                >
-                  <Text
+                <View collapsable={false} style={styles.regionMarkerWrap}>
+                  <View
                     style={[
-                      styles.regionMarkerCount,
-                      { fontSize: size >= 56 ? 20 : size >= 44 ? 16 : 13 },
+                      styles.regionMarker,
+                      {
+                        width: size,
+                        height: size,
+                        borderRadius: size / 2,
+                        backgroundColor: isTop
+                          ? tokens.colors.accentGreen
+                          : tokens.colors.accentMustard,
+                      },
                     ]}
                   >
-                    {cluster.members.length}
-                  </Text>
+                    <Text
+                      style={[
+                        styles.regionMarkerCount,
+                        { fontSize: size >= 56 ? 20 : size >= 44 ? 16 : 13 },
+                      ]}
+                    >
+                      {cluster.members.length}
+                    </Text>
+                  </View>
                 </View>
               </Marker>
             );
@@ -435,12 +438,16 @@ const styles = StyleSheet.create({
     fontFamily: tokens.typography.display.fontFamily,
   },
   emptyBody: { fontSize: 15, color: tokens.colors.textMuted, lineHeight: 22 },
+  regionMarkerWrap: {
+    backgroundColor: 'transparent',
+    padding: 4,
+  },
   regionMarker: {
     borderWidth: 3,
     borderColor: tokens.colors.surfaceDark,
     alignItems: 'center',
     justifyContent: 'center',
-    ...shadows.md,
+    overflow: 'hidden',
   },
   regionMarkerCount: {
     fontWeight: '900',

--- a/app/mobile/src/screens/HeritageMapScreen.tsx
+++ b/app/mobile/src/screens/HeritageMapScreen.tsx
@@ -7,7 +7,7 @@ import {
   Text,
   View,
 } from 'react-native';
-import MapView, { Marker } from 'react-native-maps';
+import MapView, { Marker, Polyline } from 'react-native-maps';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { MapZoomControls } from '../components/map/MapZoomControls';
 import { ErrorView } from '../components/ui/ErrorView';
@@ -132,6 +132,17 @@ export default function HeritageMapScreen({ route, navigation }: Props) {
 
   const topRegion = clusters[0] ?? null;
 
+  /** Visual base for the fan: mean of all region pin coords. */
+  const baseCoord = useMemo<LatLng | null>(() => {
+    if (clusters.length === 0) return null;
+    const sumLat = clusters.reduce((acc, c) => acc + c.coords.latitude, 0);
+    const sumLng = clusters.reduce((acc, c) => acc + c.coords.longitude, 0);
+    return {
+      latitude: sumLat / clusters.length,
+      longitude: sumLng / clusters.length,
+    };
+  }, [clusters]);
+
   // Seed expansion state: top region open, others collapsed.
   useEffect(() => {
     if (!topRegion) return;
@@ -243,6 +254,31 @@ export default function HeritageMapScreen({ route, navigation }: Props) {
           style={styles.map}
           accessibilityLabel={`Heritage map for ${group.name}`}
         >
+          {baseCoord
+            ? clusters.map((cluster) => (
+                <Polyline
+                  key={`line-${cluster.region}`}
+                  coordinates={[baseCoord, cluster.coords]}
+                  strokeColor={tokens.colors.surfaceDark}
+                  strokeWidth={2}
+                />
+              ))
+            : null}
+
+          {baseCoord ? (
+            <Marker
+              key="heritage-base"
+              coordinate={baseCoord}
+              anchor={{ x: 0.5, y: 0.5 }}
+              title={group.name}
+              description={`${totalMembers} member${totalMembers === 1 ? '' : 's'} across ${clusters.length} region${clusters.length === 1 ? '' : 's'}`}
+            >
+              <View style={styles.heritageBase}>
+                <Text style={styles.heritageBaseGlyph}>🏛</Text>
+              </View>
+            </Marker>
+          ) : null}
+
           {clusters.map((cluster) => {
             const isTop = topRegion?.region === cluster.region;
             const size = markerSizeForCount(cluster.members.length);
@@ -433,6 +469,18 @@ const styles = StyleSheet.create({
     fontWeight: '900',
     color: tokens.colors.surfaceDark,
   },
+  heritageBase: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: tokens.colors.bg,
+    borderWidth: 3,
+    borderColor: tokens.colors.surfaceDark,
+    alignItems: 'center',
+    justifyContent: 'center',
+    ...shadows.md,
+  },
+  heritageBaseGlyph: { fontSize: 20 },
   legend: {
     position: 'absolute',
     top: 16,


### PR DESCRIPTION
## Summary
- Cluster heritage members by region and render one numbered pin per region (size scales 32/44/56 by count); top region (most members, alpha tiebreak) uses accentGreen, others accentMustard.
- Map fits all region pins then animate-centers on the top region; polylines and centroid pin removed.
- Bottom sheet (custom inline panel pinned above safe-area inset) lists each region with member rows (title + RECIPE/STORY chip); top region expanded by default, others collapsible. Tapping a marker expands+scrolls to that section.
- Members without region or coords surface as an "Unmapped" section at the end of the sheet.
- Defensive `coordsForRegion` fallback preserved; empty state copy unchanged when no member has coords.

## Sanity check
Backend `GET /api/heritage-groups/1/` ("Sarma / Dolma"): 4 members across 3 regions (Black Sea ×2, Southeastern Anatolia ×1, Aegean ×1). Top region = Black Sea.

## Implementation notes
- Did not reuse `RegionDetailSheet` — that component is coupled to `fetchRegionContent(regionId)` and tabbed recipes/stories, which doesn't match the heritage-member shape. Built a lightweight in-screen sheet to keep the data path local.
- Size scaling: discrete 3-tier (1 / 2-4 / 5+). Collapse behavior: top expanded by default, the rest collapsed with tap-to-expand headers.
- Used `useSafeAreaInsets()` for the bottom inset (this screen is in the root stack, not under the tab bar).

## Test plan
- [ ] Open a heritage group from Heritage screen, tap "View map".
- [ ] Verify one pin per region; pin sizes vary with member count; top region pin is green.
- [ ] Map fits all pins on load and centers on the top region.
- [ ] Tap a non-top pin → bottom sheet scrolls and expands that region.
- [ ] Tap a member row → opens RecipeDetail or StoryDetail accordingly.
- [ ] Group with only one mappable region → still renders one pin and the sheet.
- [ ] Group with zero mappable members → existing empty-state copy.
- [ ] "Unmapped" section appears when at least one member has no region/coords.

Closes #667