### PR TITLE
fix(frontend): post-M8 review feedback — null members guard and HomePage test stability

### DIFF
--- a/app/frontend/src/__tests__/HomePage.test.jsx
+++ b/app/frontend/src/__tests__/HomePage.test.jsx
@@ -53,10 +53,11 @@ describe('HomePage', () => {
 
   it('populates region chips from API', async () => {
     renderPage();
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Aegean' })).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: 'Mediterranean' })).toBeInTheDocument();
-    });
+    // Use findByRole so the assertion races with a single retried query
+    // instead of waitFor polling — the latter interleaves with async state
+    // updates from RandomCulturalFact and DailyCulturalSection and flakes.
+    expect(await screen.findByRole('button', { name: 'Aegean' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Mediterranean' })).toBeInTheDocument();
   });
 
   it('renders meal type chip buttons', () => {

--- a/app/frontend/src/pages/HeritagePage.jsx
+++ b/app/frontend/src/pages/HeritagePage.jsx
@@ -59,7 +59,7 @@ export default function HeritagePage() {
 
       <section className="heritage-members">
         <h2 className="heritage-section-heading">Recipes & Stories</h2>
-        {group.members.length === 0 ? (
+        {!group.members || group.members.length === 0 ? (
           <p className="heritage-empty">This group has no linked recipes or stories yet.</p>
         ) : (
           <ul className="heritage-members-grid">


### PR DESCRIPTION
## Summary

Follow-up to #717 (Milestone 8 web). Addresses two concrete review comments:

- **HeritagePage** — `group.members.length` now tolerates an API response where `members` is `null`/missing (guards with `!group.members || group.members.length === 0`). Prevents a runtime crash on the empty path.
- **HomePage test "populates region chips from API"** — swap `waitFor` for `findByRole` so the assertion races with a single retried query instead of polling alongside the parallel `RandomCulturalFact` and `DailyCulturalSection` effects. Removes the `act()` warnings and makes the test resilient to CI scheduling jitter.

## Test plan

- [ ] `npm test` in `app/frontend/` — full suite green (504/504 locally)
- [ ] HeritagePage still renders the empty state when a group has no members
- [ ] HomePage tests no longer surface `act()` warnings tied to RandomCulturalFact