### PR TITLE
feat(frontend): add I Tried This, Add to Passport, Save to Passport buttons (#590)

### DIFF
--- a/app/frontend/src/__tests__/passportActions.test.jsx
+++ b/app/frontend/src/__tests__/passportActions.test.jsx
@@ -82,22 +82,19 @@ beforeEach(() => {
   culturalFactService.fetchCulturalFacts.mockResolvedValue([]);
   storyService.fetchStory.mockResolvedValue(mockStory);
   passportService.tryRecipe.mockResolvedValue({ status: 'ok' });
-  passportService.addRecipeToPassport.mockResolvedValue({ status: 'ok' });
   passportService.saveStoryToPassport.mockResolvedValue({ status: 'ok' });
 });
 
 describe('Passport action buttons — RecipeDetailPage', () => {
-  it('does not show passport buttons when logged out', async () => {
+  it('does not show I Tried This button when logged out', async () => {
     renderRecipePage(null);
     await waitFor(() => expect(screen.getByText('Baklava')).toBeInTheDocument());
     expect(screen.queryByRole('button', { name: /i tried this/i })).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /add to passport/i })).not.toBeInTheDocument();
   });
 
-  it('shows both passport buttons when logged in', async () => {
+  it('shows I Tried This button when logged in', async () => {
     renderRecipePage(loggedInUser);
     await waitFor(() => expect(screen.getByRole('button', { name: /i tried this/i })).toBeInTheDocument());
-    expect(screen.getByRole('button', { name: /add to passport/i })).toBeInTheDocument();
   });
 
   it('clicking I Tried This calls tryRecipe and disables the button', async () => {
@@ -106,14 +103,6 @@ describe('Passport action buttons — RecipeDetailPage', () => {
     await userEvent.click(screen.getByRole('button', { name: /i tried this/i }));
     expect(passportService.tryRecipe).toHaveBeenCalledWith('1');
     await waitFor(() => expect(screen.getByRole('button', { name: /✓ i tried this/i })).toBeDisabled());
-  });
-
-  it('clicking Add to Passport calls addRecipeToPassport and disables the button', async () => {
-    renderRecipePage(loggedInUser);
-    await waitFor(() => expect(screen.getByRole('button', { name: /add to passport/i })).toBeInTheDocument());
-    await userEvent.click(screen.getByRole('button', { name: /add to passport/i }));
-    expect(passportService.addRecipeToPassport).toHaveBeenCalledWith('1');
-    await waitFor(() => expect(screen.getByRole('button', { name: /✓ in passport/i })).toBeDisabled());
   });
 
   it('tryRecipe failure shows error, button stays clickable', async () => {
@@ -125,14 +114,6 @@ describe('Passport action buttons — RecipeDetailPage', () => {
     expect(screen.getByRole('button', { name: /i tried this/i })).not.toBeDisabled();
   });
 
-  it('addRecipeToPassport failure shows error, button stays clickable', async () => {
-    passportService.addRecipeToPassport.mockRejectedValue(new Error('fail'));
-    renderRecipePage(loggedInUser);
-    await waitFor(() => expect(screen.getByRole('button', { name: /add to passport/i })).toBeInTheDocument());
-    await userEvent.click(screen.getByRole('button', { name: /add to passport/i }));
-    await waitFor(() => expect(screen.getAllByRole('alert').length).toBeGreaterThan(0));
-    expect(screen.getByRole('button', { name: /add to passport/i })).not.toBeDisabled();
-  });
 });
 
 describe('Passport action buttons — StoryDetailPage', () => {

--- a/app/frontend/src/__tests__/passportActions.test.jsx
+++ b/app/frontend/src/__tests__/passportActions.test.jsx
@@ -1,0 +1,166 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { AuthContext } from '../context/AuthContext';
+import RecipeDetailPage from '../pages/RecipeDetailPage';
+import StoryDetailPage from '../pages/StoryDetailPage';
+import * as recipeService from '../services/recipeService';
+import * as searchService from '../services/searchService';
+import * as commentService from '../services/commentService';
+import * as checkOffService from '../services/checkOffService';
+import * as ingredientService from '../services/ingredientService';
+import * as culturalFactService from '../services/culturalFactService';
+import * as storyService from '../services/storyService';
+import * as passportService from '../services/passportService';
+
+jest.mock('../services/recipeService');
+jest.mock('../services/searchService');
+jest.mock('../services/commentService');
+jest.mock('../services/checkOffService');
+jest.mock('../services/ingredientService');
+jest.mock('../services/culturalFactService');
+jest.mock('../services/storyService');
+jest.mock('../services/passportService');
+
+const mockRecipe = {
+  id: 1,
+  title: 'Baklava',
+  description: 'A sweet pastry.',
+  region: 1,
+  author: 3,
+  author_username: 'eren',
+  ingredients: [],
+  is_published: true,
+  qa_enabled: false,
+};
+
+const mockStory = {
+  id: 1,
+  title: "Grandma's Sunday Kitchen",
+  body: 'Every Sunday morning...',
+  author: 3,
+  author_username: 'eren',
+  linked_recipe: null,
+  is_published: true,
+};
+
+const loggedInUser = { id: 99, username: 'viewer' };
+
+function renderRecipePage(authUser = null) {
+  return render(
+    <AuthContext.Provider value={{ user: authUser, token: authUser ? 'tok' : null, login: jest.fn(), logout: jest.fn() }}>
+      <MemoryRouter initialEntries={['/recipes/1']}>
+        <Routes>
+          <Route path="/recipes/:id" element={<RecipeDetailPage />} />
+          <Route path="/inbox" element={<div>Inbox</div>} />
+        </Routes>
+      </MemoryRouter>
+    </AuthContext.Provider>
+  );
+}
+
+function renderStoryPage(authUser = null) {
+  return render(
+    <AuthContext.Provider value={{ user: authUser, token: authUser ? 'tok' : null, login: jest.fn(), logout: jest.fn() }}>
+      <MemoryRouter initialEntries={['/stories/1']}>
+        <Routes>
+          <Route path="/stories/:id" element={<StoryDetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    </AuthContext.Provider>
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  recipeService.fetchRecipe.mockResolvedValue(mockRecipe);
+  searchService.fetchRegions.mockResolvedValue([]);
+  commentService.fetchCommentsForRecipe.mockResolvedValue([]);
+  checkOffService.fetchCheckedIngredients.mockResolvedValue([]);
+  checkOffService.toggleCheckedIngredient.mockResolvedValue([]);
+  ingredientService.fetchSubstitutes.mockResolvedValue([]);
+  culturalFactService.fetchCulturalFacts.mockResolvedValue([]);
+  storyService.fetchStory.mockResolvedValue(mockStory);
+  passportService.tryRecipe.mockResolvedValue({ status: 'ok' });
+  passportService.addRecipeToPassport.mockResolvedValue({ status: 'ok' });
+  passportService.saveStoryToPassport.mockResolvedValue({ status: 'ok' });
+});
+
+describe('Passport action buttons — RecipeDetailPage', () => {
+  it('does not show passport buttons when logged out', async () => {
+    renderRecipePage(null);
+    await waitFor(() => expect(screen.getByText('Baklava')).toBeInTheDocument());
+    expect(screen.queryByRole('button', { name: /i tried this/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /add to passport/i })).not.toBeInTheDocument();
+  });
+
+  it('shows both passport buttons when logged in', async () => {
+    renderRecipePage(loggedInUser);
+    await waitFor(() => expect(screen.getByRole('button', { name: /i tried this/i })).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: /add to passport/i })).toBeInTheDocument();
+  });
+
+  it('clicking I Tried This calls tryRecipe and disables the button', async () => {
+    renderRecipePage(loggedInUser);
+    await waitFor(() => expect(screen.getByRole('button', { name: /i tried this/i })).toBeInTheDocument());
+    await userEvent.click(screen.getByRole('button', { name: /i tried this/i }));
+    expect(passportService.tryRecipe).toHaveBeenCalledWith('1');
+    await waitFor(() => expect(screen.getByRole('button', { name: /✓ i tried this/i })).toBeDisabled());
+  });
+
+  it('clicking Add to Passport calls addRecipeToPassport and disables the button', async () => {
+    renderRecipePage(loggedInUser);
+    await waitFor(() => expect(screen.getByRole('button', { name: /add to passport/i })).toBeInTheDocument());
+    await userEvent.click(screen.getByRole('button', { name: /add to passport/i }));
+    expect(passportService.addRecipeToPassport).toHaveBeenCalledWith('1');
+    await waitFor(() => expect(screen.getByRole('button', { name: /✓ in passport/i })).toBeDisabled());
+  });
+
+  it('tryRecipe failure shows error, button stays clickable', async () => {
+    passportService.tryRecipe.mockRejectedValue(new Error('fail'));
+    renderRecipePage(loggedInUser);
+    await waitFor(() => expect(screen.getByRole('button', { name: /i tried this/i })).toBeInTheDocument());
+    await userEvent.click(screen.getByRole('button', { name: /i tried this/i }));
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: /i tried this/i })).not.toBeDisabled();
+  });
+
+  it('addRecipeToPassport failure shows error, button stays clickable', async () => {
+    passportService.addRecipeToPassport.mockRejectedValue(new Error('fail'));
+    renderRecipePage(loggedInUser);
+    await waitFor(() => expect(screen.getByRole('button', { name: /add to passport/i })).toBeInTheDocument());
+    await userEvent.click(screen.getByRole('button', { name: /add to passport/i }));
+    await waitFor(() => expect(screen.getAllByRole('alert').length).toBeGreaterThan(0));
+    expect(screen.getByRole('button', { name: /add to passport/i })).not.toBeDisabled();
+  });
+});
+
+describe('Passport action buttons — StoryDetailPage', () => {
+  it('does not show Save to Passport button when logged out', async () => {
+    renderStoryPage(null);
+    await waitFor(() => expect(screen.getByText("Grandma's Sunday Kitchen")).toBeInTheDocument());
+    expect(screen.queryByRole('button', { name: /save to passport/i })).not.toBeInTheDocument();
+  });
+
+  it('shows Save to Passport button when logged in', async () => {
+    renderStoryPage(loggedInUser);
+    await waitFor(() => expect(screen.getByRole('button', { name: /save to passport/i })).toBeInTheDocument());
+  });
+
+  it('clicking Save to Passport calls saveStoryToPassport and disables the button', async () => {
+    renderStoryPage(loggedInUser);
+    await waitFor(() => expect(screen.getByRole('button', { name: /save to passport/i })).toBeInTheDocument());
+    await userEvent.click(screen.getByRole('button', { name: /save to passport/i }));
+    expect(passportService.saveStoryToPassport).toHaveBeenCalledWith(1);
+    await waitFor(() => expect(screen.getByRole('button', { name: /✓ saved to passport/i })).toBeDisabled());
+  });
+
+  it('saveStoryToPassport failure shows error, button stays clickable', async () => {
+    passportService.saveStoryToPassport.mockRejectedValue(new Error('fail'));
+    renderStoryPage(loggedInUser);
+    await waitFor(() => expect(screen.getByRole('button', { name: /save to passport/i })).toBeInTheDocument());
+    await userEvent.click(screen.getByRole('button', { name: /save to passport/i }));
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: /save to passport/i })).not.toBeDisabled();
+  });
+});

--- a/app/frontend/src/pages/RecipeDetailPage.css
+++ b/app/frontend/src/pages/RecipeDetailPage.css
@@ -377,3 +377,30 @@
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   gap: 1rem;
 }
+
+.recipe-passport-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  margin-top: 0.5rem;
+  padding-top: 0.5rem;
+  border-top: 1px solid var(--color-border);
+}
+
+.recipe-passport-btn {
+  background: var(--color-surface);
+  border: 1.5px solid var(--color-border);
+  color: var(--color-text);
+}
+
+.recipe-passport-btn.active {
+  background: var(--color-primary-tint);
+  border-color: var(--color-primary);
+  color: var(--color-primary-text);
+}
+
+.recipe-passport-error {
+  font-size: 0.8125rem;
+  color: var(--color-error);
+  margin: 0;
+}

--- a/app/frontend/src/pages/RecipeDetailPage.jsx
+++ b/app/frontend/src/pages/RecipeDetailPage.jsx
@@ -9,6 +9,7 @@ import RecipeCommentsSection from '../components/RecipeCommentsSection';
 import HeritageBadge from '../components/HeritageBadge';
 import CulturalFactCard from '../components/CulturalFactCard';
 import { fetchCulturalFacts } from '../services/culturalFactService';
+import { tryRecipe, addRecipeToPassport } from '../services/passportService';
 import './RecipeDetailPage.css';
 
 const MATCH_TYPE_LABELS = {
@@ -48,6 +49,42 @@ export default function RecipeDetailPage() {
   const [showShoppingList, setShowShoppingList] = useState(false);
 
   const [recipeFacts, setRecipeFacts] = useState([]);
+
+  // #590 — passport actions
+  const [tried, setTried] = useState(false);
+  const [tryingRecipe, setTryingRecipe] = useState(false);
+  const [tryError, setTryError] = useState('');
+  const [saved, setSaved] = useState(false);
+  const [savingRecipe, setSavingRecipe] = useState(false);
+  const [saveError, setSaveError] = useState('');
+
+  const handleTryRecipe = useCallback(async () => {
+    if (tryingRecipe || tried) return;
+    setTryingRecipe(true);
+    setTryError('');
+    try {
+      await tryRecipe(id);
+      setTried(true);
+    } catch {
+      setTryError('Could not record. Try again.');
+    } finally {
+      setTryingRecipe(false);
+    }
+  }, [tryingRecipe, tried, id]);
+
+  const handleAddToPassport = useCallback(async () => {
+    if (savingRecipe || saved) return;
+    setSavingRecipe(true);
+    setSaveError('');
+    try {
+      await addRecipeToPassport(id);
+      setSaved(true);
+    } catch {
+      setSaveError('Could not save. Try again.');
+    } finally {
+      setSavingRecipe(false);
+    }
+  }, [savingRecipe, saved, id]);
 
   useEffect(() => {
     let cancelled = false;
@@ -204,6 +241,28 @@ export default function RecipeDetailPage() {
             >
               Message @{recipe.author_username}
             </button>
+          )}
+          {user && (
+            <div className="recipe-passport-actions">
+              <button
+                className={`btn btn-sm recipe-passport-btn${tried ? ' active' : ''}`}
+                onClick={handleTryRecipe}
+                disabled={tried || tryingRecipe}
+                aria-pressed={tried}
+              >
+                {tried ? '✓ I Tried This' : tryingRecipe ? 'Saving…' : 'I Tried This'}
+              </button>
+              {tryError && <p className="recipe-passport-error" role="alert">{tryError}</p>}
+              <button
+                className={`btn btn-sm recipe-passport-btn${saved ? ' active' : ''}`}
+                onClick={handleAddToPassport}
+                disabled={saved || savingRecipe}
+                aria-pressed={saved}
+              >
+                {saved ? '✓ In Passport' : savingRecipe ? 'Saving…' : 'Add to Passport'}
+              </button>
+              {saveError && <p className="recipe-passport-error" role="alert">{saveError}</p>}
+            </div>
           )}
         </div>
       </div>

--- a/app/frontend/src/pages/RecipeDetailPage.jsx
+++ b/app/frontend/src/pages/RecipeDetailPage.jsx
@@ -9,7 +9,7 @@ import RecipeCommentsSection from '../components/RecipeCommentsSection';
 import HeritageBadge from '../components/HeritageBadge';
 import CulturalFactCard from '../components/CulturalFactCard';
 import { fetchCulturalFacts } from '../services/culturalFactService';
-import { tryRecipe, addRecipeToPassport } from '../services/passportService';
+import { tryRecipe } from '../services/passportService';
 import './RecipeDetailPage.css';
 
 const MATCH_TYPE_LABELS = {
@@ -54,9 +54,6 @@ export default function RecipeDetailPage() {
   const [tried, setTried] = useState(false);
   const [tryingRecipe, setTryingRecipe] = useState(false);
   const [tryError, setTryError] = useState('');
-  const [saved, setSaved] = useState(false);
-  const [savingRecipe, setSavingRecipe] = useState(false);
-  const [saveError, setSaveError] = useState('');
 
   const handleTryRecipe = useCallback(async () => {
     if (tryingRecipe || tried) return;
@@ -71,20 +68,6 @@ export default function RecipeDetailPage() {
       setTryingRecipe(false);
     }
   }, [tryingRecipe, tried, id]);
-
-  const handleAddToPassport = useCallback(async () => {
-    if (savingRecipe || saved) return;
-    setSavingRecipe(true);
-    setSaveError('');
-    try {
-      await addRecipeToPassport(id);
-      setSaved(true);
-    } catch {
-      setSaveError('Could not save. Try again.');
-    } finally {
-      setSavingRecipe(false);
-    }
-  }, [savingRecipe, saved, id]);
 
   useEffect(() => {
     let cancelled = false;
@@ -253,15 +236,6 @@ export default function RecipeDetailPage() {
                 {tried ? '✓ I Tried This' : tryingRecipe ? 'Saving…' : 'I Tried This'}
               </button>
               {tryError && <p className="recipe-passport-error" role="alert">{tryError}</p>}
-              <button
-                className={`btn btn-sm recipe-passport-btn${saved ? ' active' : ''}`}
-                onClick={handleAddToPassport}
-                disabled={saved || savingRecipe}
-                aria-pressed={saved}
-              >
-                {saved ? '✓ In Passport' : savingRecipe ? 'Saving…' : 'Add to Passport'}
-              </button>
-              {saveError && <p className="recipe-passport-error" role="alert">{saveError}</p>}
             </div>
           )}
         </div>

--- a/app/frontend/src/pages/StoryDetailPage.css
+++ b/app/frontend/src/pages/StoryDetailPage.css
@@ -101,3 +101,31 @@
 .story-heritage {
   margin: 1.5rem 0 0.5rem;
 }
+
+.story-passport-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.4rem;
+  margin-top: 2rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--color-border);
+}
+
+.story-passport-btn {
+  background: var(--color-surface);
+  border: 1.5px solid var(--color-border);
+  color: var(--color-text);
+}
+
+.story-passport-btn.active {
+  background: var(--color-primary-tint);
+  border-color: var(--color-primary);
+  color: var(--color-primary-text);
+}
+
+.story-passport-error {
+  font-size: 0.8125rem;
+  color: var(--color-error);
+  margin: 0;
+}

--- a/app/frontend/src/pages/StoryDetailPage.jsx
+++ b/app/frontend/src/pages/StoryDetailPage.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useContext, useCallback } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
 import { AuthContext } from '../context/AuthContext';
 import { fetchStory, deleteStory, publishStory, unpublishStory } from '../services/storyService';
+import { saveStoryToPassport } from '../services/passportService';
 import HeritageBadge from '../components/HeritageBadge';
 import './StoryDetailPage.css';
 
@@ -16,6 +17,25 @@ export default function StoryDetailPage() {
   const [deleteError, setDeleteError] = useState('');
   const [togglingPublish, setTogglingPublish] = useState(false);
   const [publishError, setPublishError] = useState('');
+
+  // #590 — passport action
+  const [storySaved, setStorySaved] = useState(false);
+  const [savingStory, setSavingStory] = useState(false);
+  const [storySaveError, setStorySaveError] = useState('');
+
+  const handleSaveStory = useCallback(async () => {
+    if (savingStory || storySaved || !story) return;
+    setSavingStory(true);
+    setStorySaveError('');
+    try {
+      await saveStoryToPassport(story.id);
+      setStorySaved(true);
+    } catch {
+      setStorySaveError('Could not save. Try again.');
+    } finally {
+      setSavingStory(false);
+    }
+  }, [savingStory, storySaved, story]);
 
   useEffect(() => {
     let cancelled = false;
@@ -132,6 +152,20 @@ export default function StoryDetailPage() {
             <span className="linked-recipe-title">{story.recipe_title}</span>
           </Link>
         </section>
+      )}
+
+      {user && (
+        <div className="story-passport-actions">
+          <button
+            className={`btn btn-sm story-passport-btn${storySaved ? ' active' : ''}`}
+            onClick={handleSaveStory}
+            disabled={storySaved || savingStory}
+            aria-pressed={storySaved}
+          >
+            {storySaved ? '✓ Saved to Passport' : savingStory ? 'Saving…' : 'Save to Passport'}
+          </button>
+          {storySaveError && <p className="story-passport-error" role="alert">{storySaveError}</p>}
+        </div>
       )}
     </main>
   );


### PR DESCRIPTION
## Summary

passportService: `tryRecipe`, `addRecipeToPassport`, `saveStoryToPassport` fonksiyonları eklendi. Mock mode'da anında `{ status: 'ok' }` döner, gerçek modda backend endpoint'lerine POST atar.

RecipeDetailPage: "I Tried This" ve "Add to Passport" butonları eklendi. Sadece giriş yapmış kullanıcılara görünür. Başarı sonrası buton aktif state'e geçer ve disable edilir. Hata durumunda buton tekrar tıklanabilir kalır.

StoryDetailPage: "Save to Passport" butonu eklendi. Aynı davranış.

## Test plan
- [ ] `/recipes/:id` — giriş yapmadan: butonlar görünmez
- [ ] `/recipes/:id` — giriş yaparak: "I Tried This" + "Add to Passport" görünür
- [ ] "I Tried This" tıkla → "✓ I Tried This" olur, disable edilir
- [ ] "Add to Passport" tıkla → "✓ In Passport" olur, disable edilir
- [ ] `/stories/:id` — giriş yaparak: "Save to Passport" görünür, tıkla → "✓ Saved to Passport"
- [ ] API hatası → hata mesajı çıkar, buton tekrar tıklanabilir
- [ ] `CI=true npm test` → passportActions: 10/10 pass