### PR TITLE
fix(mobile): constrain LinkedStoryPreviewCard thumb height

### DIFF
--- a/app/mobile/src/components/recipe/LinkedStoryPreviewCard.tsx
+++ b/app/mobile/src/components/recipe/LinkedStoryPreviewCard.tsx
@@ -83,6 +83,7 @@ const styles = StyleSheet.create({
   pressed: { opacity: 0.9 },
   thumb: {
     width: 86,
+    aspectRatio: 1,
     backgroundColor: tokens.colors.accentGreen,
   },
   thumbFallback: { alignItems: 'center', justifyContent: 'center' },


### PR DESCRIPTION
## Summary
The thumbnail in `LinkedStoryPreviewCard` had `width: 86` but no height constraint, so when an `<Image>` with `width:'100%', height:'100%'` loaded inside, the thumb (and therefore the card row) stretched to the image's natural pixel height. On the 'Stories about this recipe' section of `RecipeDetailScreen` this produced a ~210px-tall card with a huge empty blue strip and pushed the Heritage badge below it off the visible scroll area.

Single-line fix: add `aspectRatio: 1` to the thumb so it stays square (86×86), regardless of source image dimensions. The card row now sizes to the body content (~90-110px depending on excerpt) and the heritage badge is reachable without an extra scroll.

## Test plan
- [ ] Open any recipe with a linked story (e.g. recipe #1 'Black Sea Collard Green Sarma' on a seeded backend) — story card is short, thumb is a clean square
- [ ] Scroll past the stories section — Heritage badge for that recipe is visible without a long scroll