### PR TITLE
ci(backend): speed up + de-flake the backend test job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,5 @@
 # Local equivalents:
-#   cd app/backend && coverage run --source=apps manage.py test && coverage report --omit='*/migrations/*,*/tests*'
+#   cd app/backend && coverage run --source=apps manage.py test --parallel auto && coverage combine && coverage report --omit='*/migrations/*,*/tests*'
 #   cd app/frontend && npm test -- --watchAll=false --coverage
 
 name: Tests
@@ -18,7 +18,7 @@ jobs:
   backend-tests:
     name: Backend tests
     runs-on: ubuntu-latest
-    timeout-minutes: 8
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: app/backend
@@ -39,11 +39,15 @@ jobs:
           pip install coverage==7.13.5
 
       - name: Run Django test suite
-        run: coverage run --source=apps manage.py test --noinput --verbosity=2
+        # --parallel auto fans the suite across the runner's CPUs (~2x on the
+        # 2-core GitHub runner). .coveragerc has concurrency=multiprocessing so
+        # subprocess coverage is captured; `coverage combine` merges it below.
+        run: coverage run --source=apps manage.py test --noinput --parallel auto
 
       - name: Backend coverage report
         if: always()
         run: |
+          coverage combine || true
           echo "## Backend coverage" >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
           coverage report --omit='*/migrations/*,*/tests*' --skip-empty | tail -25 >> "$GITHUB_STEP_SUMMARY"

--- a/app/backend/.coveragerc
+++ b/app/backend/.coveragerc
@@ -1,5 +1,11 @@
 [run]
 source = apps
+# Django's `manage.py test --parallel` runs each test bucket in a subprocess,
+# so coverage must hook multiprocessing and write per-process data files.
+# The CI workflow runs `coverage combine` before `coverage report`.
+concurrency = multiprocessing
+parallel = true
+sigterm = true
 omit =
     */migrations/*
     */tests*

--- a/app/backend/config/settings.py
+++ b/app/backend/config/settings.py
@@ -116,6 +116,11 @@ if 'test' in sys.argv or not os.environ.get('POSTGRES_HOST'):
         'NAME': BASE_DIR / 'db.sqlite3',
     }
 
+# Tests create a lot of users; the default PBKDF2 hasher dominates the runtime.
+# A fast hasher cuts the suite substantially and is irrelevant to test behaviour.
+if 'test' in sys.argv:
+    PASSWORD_HASHERS = ['django.contrib.auth.hashers.MD5PasswordHasher']
+
 # Django REST Framework
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (

--- a/app/backend/requirements.txt
+++ b/app/backend/requirements.txt
@@ -15,4 +15,5 @@ boto3==1.38.11
 exponent-server-sdk==2.1.0
 django-cors-headers==4.9.0
 coverage==7.13.5
+tblib==3.2.2  # lets `manage.py test --parallel` pickle subprocess tracebacks
 requests==2.32.3  # used by scripts/download_fixture_images.py


### PR DESCRIPTION
Summary
Backend CI: The `Backend tests` job kept exceeding its 8-minute `timeout-minutes` (823 tests, ~6m40s on the runner + install + coverage) and the flood of pushes/PR updates kept cancelling in-flight runs — so the required check rarely went green and merges were blocked. This makes the job small and fast:
- `config/settings.py`: under `test`, switch to `MD5PasswordHasher`. Django 5.1+ defaults PBKDF2 to 1,000,000 iterations; with ~150 `create_user` calls plus JWT token issue/rotate/blacklist across the suite that hashing dominated the runtime.
- `tests.yml`: run `manage.py test --parallel auto` to fan the suite across the runner's CPUs.
- `requirements.txt`: add `tblib==3.2.2` so the parallel runner can pickle subprocess tracebacks (failures still report cleanly).
- `.coveragerc`: `concurrency = multiprocessing` + `parallel = true` + `sigterm = true` so coverage is captured in the `--parallel` subprocesses; `tests.yml` runs `coverage combine` before `coverage report`.
- `tests.yml`: bump the backend job `timeout-minutes` 8 → 15 as a safety margin.

Local timing (M-series mac): full suite 823 tests
- before: ~2m51s single-process
- `--parallel auto` only: ~1m00s
- `--parallel auto` + fast hasher (this PR): ~8s
On the 2-core GitHub runner expect the job to drop from ~6m40s to roughly 1–2 min. All 823 tests still pass; coverage report still produced (93% TOTAL locally).

Test plan
 [ ] CI: `Backend tests` job goes green in well under the (new) 15-min limit
 [ ] CI step summary still shows the `## Backend coverage` table with non-zero coverage (confirms `coverage combine` works under `--parallel`)
 [ ] Locally: `cd app/backend && coverage run --source=apps manage.py test --noinput --parallel auto && coverage combine && coverage report` → `OK`, coverage printed