### PR TITLE
fix(mobile): dedupe paginated story/recipe lists by id

### DIFF
--- a/app/mobile/src/services/recipeService.ts
+++ b/app/mobile/src/services/recipeService.ts
@@ -155,7 +155,15 @@ export async function fetchRecipesList(filter?: { author?: number | string }): P
       break;
     }
   }
-  return collected.map((r) => {
+  // Defensive dedupe by id — see backend #770 (pagination ordering instability).
+  const byId = new Map<string | number, any>();
+  const idLess: any[] = [];
+  for (const r of collected) {
+    if (r && r.id != null) byId.set(r.id, r);
+    else idLess.push(r);
+  }
+  const deduped = [...byId.values(), ...idLess];
+  return deduped.map((r) => {
     const reg = r.region;
     const regionLabel =
       reg == null

--- a/app/mobile/src/services/storyService.ts
+++ b/app/mobile/src/services/storyService.ts
@@ -86,7 +86,16 @@ export async function fetchStoriesList(filter?: { author?: number | string }): P
       break;
     }
   }
-  return collected;
+  // Defensive dedupe by id — backend pagination occasionally returns the
+  // same row on consecutive pages when ordering has no PK tiebreaker
+  // (backend #770). Last-write-wins by id so callers get a clean list.
+  const byId = new Map<string | number, any>();
+  const idLess: any[] = [];
+  for (const s of collected) {
+    if (s && s.id != null) byId.set(s.id, s);
+    else idLess.push(s);
+  }
+  return [...byId.values(), ...idLess];
 }
 
 /** Stories where `linked_recipe` matches the given recipe id. Filters client-side. */


### PR DESCRIPTION
## Summary
Defensive Map-by-id dedupe in `fetchStoriesList` and `fetchRecipesList` after the pagination walk concatenates pages. Backend occasionally returns the same row on consecutive pages when the queryset ordering has no PK tiebreaker — surfacing as the 'Encountered two children with the same key, \`31\`' console warning on the HomeScreen stories rail.

Workaround for backend #770 (Story/Recipe pagination ordering instability).

## Test plan
- [ ] Open Home — no more duplicate-key warning toast at the bottom
- [ ] Stories rail and 'More recipes' rail still render the expected items
- [ ] No regression in author-filtered profile views (own profile Recipes/Stories tabs)