### PR TITLE
feat(mobile): notifications scaffolding — screen, service, bell icon entry (closes #760)

### DIFF
--- a/app/mobile/src/navigation/PublicStackNavigator.tsx
+++ b/app/mobile/src/navigation/PublicStackNavigator.tsx
@@ -10,6 +10,7 @@ import InboxScreen from '../screens/InboxScreen';
 import LoginScreen from '../screens/LoginScreen';
 import MapDiscoveryScreen from '../screens/MapDiscoveryScreen';
 import MessageThreadScreen from '../screens/MessageThreadScreen';
+import NotificationsScreen from '../screens/NotificationsScreen';
 import OnboardingScreen from '../screens/OnboardingScreen';
 import RecipeCreateScreen from '../screens/RecipeCreateScreen';
 import RecipeDetailScreen from '../screens/RecipeDetailScreen';
@@ -140,6 +141,11 @@ export function PublicStackNavigator() {
         name="IngredientMigrationMap"
         component={IngredientMigrationMapScreen}
         options={{ title: 'Migration routes' }}
+      />
+      <Stack.Screen
+        name="Notifications"
+        component={NotificationsScreen}
+        options={{ title: 'Notifications' }}
       />
     </Stack.Navigator>
   );

--- a/app/mobile/src/navigation/types.ts
+++ b/app/mobile/src/navigation/types.ts
@@ -27,6 +27,7 @@ export type RootStackParamList = {
   CulturalCalendar: undefined;
   RegionMapDetail: { regionId: number; regionName: string };
   IngredientMigrationMap: undefined;
+  Notifications: undefined;
 };
 
 declare global {

--- a/app/mobile/src/screens/HomeScreen.tsx
+++ b/app/mobile/src/screens/HomeScreen.tsx
@@ -8,6 +8,8 @@ import { shadows, tokens } from '../theme';
 import { fetchRecipesList } from '../services/recipeService';
 import { fetchStoriesList } from '../services/storyService';
 import { fetchDailyCultural } from '../services/dailyCulturalService';
+import { fetchUnreadCount } from '../services/notificationService';
+import { useAuth } from '../context/AuthContext';
 import { fetchRecommendations, type RecommendationItem } from '../services/recommendationsService';
 import { DailyCulturalSection } from '../components/home/DailyCulturalSection';
 import { RecommendationsRail } from '../components/home/RecommendationsRail';
@@ -19,7 +21,9 @@ import type { RootStackParamList } from '../navigation/types';
 type Props = NativeStackScreenProps<RootStackParamList, 'Home'>;
 
 export default function HomeScreen({ navigation }: Props) {
+  const { isAuthenticated, isReady } = useAuth();
   const [query, setQuery] = useState('');
+  const [unreadCount, setUnreadCount] = useState(0);
 
   const [stories, setStories] = useState<any[]>([]);
   const [recipes, setRecipes] = useState<any[]>([]);
@@ -74,6 +78,30 @@ export default function HomeScreen({ navigation }: Props) {
     }, [loadFeed]),
   );
 
+  // Bell badge — refresh on focus and on auth state changes. Unauthenticated
+  // callers would just get a 401 from `/api/notifications/`, so we short
+  // circuit to 0 instead of pinging the server.
+  const refreshUnread = useCallback(async () => {
+    if (!isReady) return;
+    if (!isAuthenticated) {
+      setUnreadCount(0);
+      return;
+    }
+    try {
+      const n = await fetchUnreadCount();
+      setUnreadCount(n);
+    } catch {
+      // Bell badge is decorative — silently ignore fetch failures so the
+      // home feed remains usable even if the notifications endpoint is down.
+    }
+  }, [isAuthenticated, isReady]);
+
+  useFocusEffect(
+    useCallback(() => {
+      void refreshUnread();
+    }, [refreshUnread]),
+  );
+
   const onRecommendationPress = (item: RecommendationItem) => {
     if (item.kind === 'recipe') {
       navigation.navigate('RecipeDetail', { id: item.id });
@@ -114,6 +142,28 @@ export default function HomeScreen({ navigation }: Props) {
           <Text style={styles.heading} accessibilityRole="header">
             Search
           </Text>
+          <Pressable
+            onPress={() =>
+              navigation.navigate(isAuthenticated ? 'Notifications' : 'Login')
+            }
+            style={({ pressed }) => [styles.bellBtn, pressed && styles.pressed]}
+            accessibilityRole="button"
+            accessibilityLabel={
+              unreadCount > 0
+                ? `Notifications, ${unreadCount} unread`
+                : 'Notifications'
+            }
+            hitSlop={10}
+          >
+            <Text style={styles.bellIcon}>🔔</Text>
+            {unreadCount > 0 ? (
+              <View style={styles.bellBadge}>
+                <Text style={styles.bellBadgeText} numberOfLines={1}>
+                  {unreadCount > 99 ? '99+' : String(unreadCount)}
+                </Text>
+              </View>
+            ) : null}
+          </Pressable>
         </View>
 
         <View style={styles.searchWrap}>
@@ -496,4 +546,36 @@ const styles = StyleSheet.create({
   tagText: { fontSize: 12, fontWeight: '800', color: tokens.colors.text },
   link: { fontSize: 15, color: tokens.colors.text, fontWeight: '800' },
   recipeBadge: { marginLeft: 12, marginBottom: 12 },
+  bellBtn: {
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    backgroundColor: tokens.colors.bg,
+    borderWidth: 2,
+    borderColor: tokens.colors.surfaceDark,
+    alignItems: 'center',
+    justifyContent: 'center',
+    ...shadows.sm,
+  },
+  bellIcon: { fontSize: 20 },
+  bellBadge: {
+    position: 'absolute',
+    top: -4,
+    right: -4,
+    minWidth: 20,
+    height: 20,
+    paddingHorizontal: 5,
+    borderRadius: 10,
+    backgroundColor: tokens.colors.accentMustard,
+    borderWidth: 1.5,
+    borderColor: tokens.colors.surfaceDark,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  bellBadgeText: {
+    fontSize: 11,
+    fontWeight: '900',
+    color: tokens.colors.surfaceDark,
+    lineHeight: 14,
+  },
 });

--- a/app/mobile/src/screens/NotificationsScreen.tsx
+++ b/app/mobile/src/screens/NotificationsScreen.tsx
@@ -1,0 +1,324 @@
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { useCallback, useEffect, useState } from 'react';
+import { FlatList, Pressable, RefreshControl, StyleSheet, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { ErrorView } from '../components/ui/ErrorView';
+import { LoadingView } from '../components/ui/LoadingView';
+import { useAuth } from '../context/AuthContext';
+import { shadows, tokens } from '../theme';
+import {
+  fetchNotifications,
+  markAllRead,
+  markAsRead,
+  type Notification,
+} from '../services/notificationService';
+import type { RootStackParamList } from '../navigation/types';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'Notifications'>;
+
+/**
+ * Compact relative-time helper. We deliberately avoid pulling in `date-fns` or
+ * `dayjs` here — RN bundle size matters and the rules in #760 ask for a tiny
+ * inline helper. Output: "now", "Nm", "Nh", "Yesterday", "Nd", or the bare ISO
+ * date for anything older than a week.
+ */
+function timeAgo(iso: string): string {
+  if (!iso) return '';
+  const t = Date.parse(iso);
+  if (!Number.isFinite(t)) return '';
+  const diffSec = Math.max(0, Math.floor((Date.now() - t) / 1000));
+  if (diffSec < 60) return 'now';
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) return `${diffMin}m`;
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h`;
+  const diffDay = Math.floor(diffHr / 24);
+  if (diffDay === 1) return 'Yesterday';
+  if (diffDay < 7) return `${diffDay}d`;
+  return iso.slice(0, 10);
+}
+
+function iconFor(type: string): string {
+  if (type === 'question') return '💬';
+  if (type === 'reply') return '↪';
+  if (type === 'rating') return '⭐';
+  return '❔';
+}
+
+export default function NotificationsScreen({ navigation }: Props) {
+  const { isAuthenticated, isReady } = useAuth();
+  const [items, setItems] = useState<Notification[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [markingAll, setMarkingAll] = useState(false);
+
+  const load = useCallback(
+    async (opts: { isRefresh?: boolean } = {}) => {
+      if (!isReady) return;
+      if (!isAuthenticated) {
+        setItems([]);
+        setLoading(false);
+        return;
+      }
+      if (opts.isRefresh) setRefreshing(true);
+      else setLoading(true);
+      try {
+        const data = await fetchNotifications();
+        // Newest first — backend ordering not guaranteed across page joins.
+        data.sort((a, b) => (b.created_at || '').localeCompare(a.created_at || ''));
+        setItems(data);
+        setError(null);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'Could not load notifications.');
+      } finally {
+        setLoading(false);
+        setRefreshing(false);
+      }
+    },
+    [isAuthenticated, isReady],
+  );
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const onMarkAll = async () => {
+    if (markingAll) return;
+    // Optimistic — flip every row, then ask the server. Rollback on failure.
+    const prev = items;
+    setItems((curr) => curr.map((n) => ({ ...n, is_read: true })));
+    setMarkingAll(true);
+    try {
+      await markAllRead();
+    } catch (e) {
+      setItems(prev);
+      setError(e instanceof Error ? e.message : 'Could not mark all as read.');
+    } finally {
+      setMarkingAll(false);
+    }
+  };
+
+  const onPressItem = (n: Notification) => {
+    // Optimistic mark-read. We don't await — the navigation is what the user cares about.
+    if (!n.is_read) {
+      setItems((curr) =>
+        curr.map((it) => (it.id === n.id ? { ...it, is_read: true } : it)),
+      );
+      void markAsRead(n.id).catch(() => {
+        // Roll back silently — next refresh will reconcile.
+        setItems((curr) =>
+          curr.map((it) => (it.id === n.id ? { ...it, is_read: false } : it)),
+        );
+      });
+    }
+    // All three types (question, reply, rating) point at a recipe today.
+    if (n.recipe != null) {
+      navigation.navigate('RecipeDetail', { id: String(n.recipe) });
+    }
+  };
+
+  const unreadCount = items.reduce((acc, n) => acc + (n.is_read ? 0 : 1), 0);
+
+  if (!isReady || loading) {
+    return (
+      <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
+        <View style={styles.centered}>
+          <LoadingView message="Loading notifications…" />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return (
+      <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
+        <View style={styles.centered}>
+          <Text style={styles.emptyTitle}>Sign in to see notifications</Text>
+          <Pressable
+            onPress={() => navigation.navigate('Login')}
+            style={({ pressed }) => [styles.signInBtn, pressed && styles.pressed]}
+            accessibilityRole="button"
+          >
+            <Text style={styles.signInText}>Log in</Text>
+          </Pressable>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (error && items.length === 0) {
+    return (
+      <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
+        <View style={styles.centered}>
+          <ErrorView message={error} onRetry={() => void load()} />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
+      {unreadCount > 0 ? (
+        <View style={styles.topBar}>
+          <Text style={styles.topBarCount}>
+            {unreadCount} unread
+          </Text>
+          <Pressable
+            onPress={onMarkAll}
+            disabled={markingAll}
+            style={({ pressed }) => [
+              styles.markAllPill,
+              pressed && styles.pressed,
+              markingAll && { opacity: 0.6 },
+            ]}
+            accessibilityRole="button"
+            accessibilityLabel="Mark all notifications as read"
+          >
+            <Text style={styles.markAllText}>Mark all read</Text>
+          </Pressable>
+        </View>
+      ) : null}
+      <FlatList
+        data={items}
+        keyExtractor={(n) => String(n.id)}
+        contentContainerStyle={items.length === 0 ? styles.emptyContainer : styles.listContainer}
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={() => void load({ isRefresh: true })}
+            tintColor={tokens.colors.surfaceDark}
+          />
+        }
+        ListEmptyComponent={
+          <View style={styles.centered}>
+            <Text style={styles.emptyTitle}>No notifications yet.</Text>
+            <Text style={styles.emptyHint}>
+              We'll let you know when someone replies to or rates your recipes.
+            </Text>
+          </View>
+        }
+        renderItem={({ item }) => (
+          <Pressable
+            onPress={() => onPressItem(item)}
+            style={({ pressed }) => [
+              styles.row,
+              !item.is_read && styles.rowUnread,
+              pressed && styles.pressed,
+            ]}
+            accessibilityRole="button"
+            accessibilityLabel={`Notification: ${item.message}`}
+          >
+            <Text style={styles.icon}>{iconFor(item.notification_type)}</Text>
+            <View style={styles.body}>
+              <Text style={styles.message} numberOfLines={3}>
+                {item.message}
+              </Text>
+              <Text style={styles.time}>{timeAgo(item.created_at)}</Text>
+            </View>
+            {!item.is_read ? <View style={styles.unreadDot} /> : null}
+          </Pressable>
+        )}
+      />
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: tokens.colors.bg },
+  centered: { flex: 1, justifyContent: 'center', alignItems: 'center', padding: 24 },
+  topBar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderBottomWidth: 1,
+    borderBottomColor: tokens.colors.border,
+    backgroundColor: tokens.colors.bg,
+  },
+  topBarCount: {
+    fontSize: 13,
+    fontWeight: '800',
+    color: tokens.colors.text,
+  },
+  markAllPill: {
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    backgroundColor: tokens.colors.accentMustard,
+    borderRadius: tokens.radius.pill,
+    borderWidth: 1.5,
+    borderColor: tokens.colors.surfaceDark,
+  },
+  markAllText: {
+    fontSize: 13,
+    fontWeight: '800',
+    color: tokens.colors.surfaceDark,
+  },
+  listContainer: { paddingVertical: 8 },
+  emptyContainer: { flexGrow: 1 },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    backgroundColor: tokens.colors.bg,
+    borderBottomWidth: 1,
+    borderBottomColor: tokens.colors.border,
+  },
+  rowUnread: {
+    backgroundColor: 'rgba(212, 168, 48, 0.08)',
+  },
+  pressed: { opacity: 0.85 },
+  icon: { fontSize: 22, lineHeight: 24, width: 26, textAlign: 'center' },
+  body: { flex: 1 },
+  message: {
+    fontSize: 15,
+    color: tokens.colors.text,
+    fontWeight: '600',
+    lineHeight: 20,
+  },
+  time: {
+    fontSize: 12,
+    color: tokens.colors.textMuted,
+    marginTop: 4,
+    fontWeight: '600',
+  },
+  unreadDot: {
+    width: 10,
+    height: 10,
+    borderRadius: 5,
+    backgroundColor: tokens.colors.accentMustard,
+    marginTop: 6,
+    borderWidth: 1,
+    borderColor: tokens.colors.surfaceDark,
+  },
+  emptyTitle: {
+    fontSize: 18,
+    fontWeight: '800',
+    color: tokens.colors.text,
+    textAlign: 'center',
+  },
+  emptyHint: {
+    fontSize: 13,
+    color: tokens.colors.textMuted,
+    textAlign: 'center',
+    marginTop: 8,
+  },
+  signInBtn: {
+    marginTop: 16,
+    paddingVertical: 10,
+    paddingHorizontal: 20,
+    backgroundColor: tokens.colors.accentMustard,
+    borderRadius: tokens.radius.pill,
+    borderWidth: 2,
+    borderColor: tokens.colors.surfaceDark,
+    ...shadows.sm,
+  },
+  signInText: {
+    fontSize: 15,
+    fontWeight: '800',
+    color: tokens.colors.surfaceDark,
+  },
+});

--- a/app/mobile/src/services/notificationService.ts
+++ b/app/mobile/src/services/notificationService.ts
@@ -1,0 +1,117 @@
+import { apiGetJson, apiPostJson, nextPagePath } from './httpClient';
+
+/**
+ * Notification shape used across the mobile app. Mirrors what the backend
+ * `NotificationSerializer` returns (#737): id, actor, recipient, recipe,
+ * message, notification_type, is_read, created_at.
+ *
+ * The mobile screen only needs a subset (no `recipient` — the caller is
+ * always the recipient) so it's omitted here to keep the surface small.
+ */
+export type Notification = {
+  id: number;
+  actor: { id: number; username: string } | null;
+  recipe: number | null;
+  message: string;
+  notification_type: 'question' | 'reply' | 'rating' | string;
+  is_read: boolean;
+  created_at: string;
+};
+
+type RawActor = {
+  id?: number | string | null;
+  username?: string | null;
+} | number | string | null | undefined;
+
+type RawNotification = {
+  id: number | string;
+  actor?: RawActor;
+  recipe?: number | string | null;
+  message?: string | null;
+  notification_type?: string | null;
+  is_read?: boolean | null;
+  created_at?: string | null;
+};
+
+type Paginated<T> = { count?: number; next?: string | null; results: T[] };
+
+function toNum(v: unknown): number | null {
+  if (v == null) return null;
+  if (typeof v === 'number') return Number.isFinite(v) ? v : null;
+  if (typeof v === 'string') {
+    const n = parseFloat(v);
+    return Number.isFinite(n) ? n : null;
+  }
+  return null;
+}
+
+function normalizeActor(raw: RawActor): Notification['actor'] {
+  if (raw == null) return null;
+  if (typeof raw === 'object') {
+    const id = toNum(raw.id);
+    const username = typeof raw.username === 'string' ? raw.username : null;
+    if (id == null || !username) return null;
+    return { id, username };
+  }
+  return null;
+}
+
+function normalize(raw: RawNotification): Notification {
+  return {
+    id: Number(raw.id),
+    actor: normalizeActor(raw.actor),
+    recipe: toNum(raw.recipe),
+    message: typeof raw.message === 'string' ? raw.message : '',
+    notification_type:
+      typeof raw.notification_type === 'string' ? raw.notification_type : 'unknown',
+    is_read: raw.is_read === true,
+    created_at: typeof raw.created_at === 'string' ? raw.created_at : '',
+  };
+}
+
+/** Walk DRF pagination and collect every notification for the current user. */
+export async function fetchNotifications(): Promise<Notification[]> {
+  const all: Notification[] = [];
+  let path: string | null = '/api/notifications/';
+  while (path) {
+    const page: Paginated<RawNotification> | RawNotification[] = await apiGetJson<
+      Paginated<RawNotification> | RawNotification[]
+    >(path);
+    const results: RawNotification[] = Array.isArray(page) ? page : page.results ?? [];
+    for (const r of results) all.push(normalize(r));
+    path = Array.isArray(page) ? null : nextPagePath(page.next);
+  }
+  return all;
+}
+
+/**
+ * Mark one notification as read. Backend route (#737) is
+ * `POST /api/notifications/<id>/read/` (DRF `@action(url_path='read')`).
+ */
+export async function markAsRead(id: number): Promise<void> {
+  await apiPostJson(`/api/notifications/${id}/read/`, {});
+}
+
+/**
+ * Mark every notification as read in one shot.
+ * `POST /api/notifications/read-all/` returns `{ marked_read: <n> }`.
+ */
+export async function markAllRead(): Promise<number> {
+  const res = await apiPostJson<{ marked_read?: number } | null>(
+    '/api/notifications/read-all/',
+    {},
+  );
+  return res && typeof res.marked_read === 'number' ? res.marked_read : 0;
+}
+
+/**
+ * Unread count. The backend has no dedicated endpoint yet, so we walk the
+ * list and count unread items. Cheap enough — pages are 20 by default and
+ * most users will have one page.
+ */
+export async function fetchUnreadCount(): Promise<number> {
+  const items = await fetchNotifications();
+  let n = 0;
+  for (const item of items) if (!item.is_read) n += 1;
+  return n;
+}


### PR DESCRIPTION
## Summary
- New `notificationService.ts` wraps the backend list, mark-read, and mark-all-read endpoints, walking DRF pagination via `nextPagePath`.
- New `NotificationsScreen.tsx` renders a FlatList with per-type icons (💬 question, ↪ reply, ⭐ rating, ❔ fallback), inline time-ago helper, unread mustard dot, pull-to-refresh, empty/error states, and a top-bar Mark-all-read pill.
- HomeScreen gains a 🔔 bell button (top-right of the Search header) with a mustard unread-count badge; tap routes to `Notifications` when signed in or `Login` otherwise.
- Navigation wired: `Notifications: undefined` added to `RootStackParamList`, screen registered in `PublicStackNavigator`.
- Backend endpoints used: `GET /api/notifications/`, `POST /api/notifications/<id>/read/`, `POST /api/notifications/read-all/`. No `unread_count/` endpoint exists yet, so we compute it client-side from the paginated list.

## Test plan
- [ ] Open Home as a signed-out user — bell renders without a badge; tap routes to Login.
- [ ] Sign in, open Home — bell shows current unread count, refreshes on focus.
- [ ] Tap the bell — Notifications screen lists items newest-first with correct icons and relative time strings.
- [ ] Pull to refresh — list reloads; unread dot appears only on `is_read: false` rows.
- [ ] Tap an unread item — row marks read optimistically and navigates to `RecipeDetail` when `recipe` is set.
- [ ] Tap "Mark all read" pill — every row flips to read; pill hides when no unread remain.
- [ ] Empty inbox shows "No notifications yet." copy.

Closes #760