### PR TITLE
feat(mobile): redesign Profile tab — identity header + action list (closes #447)

### DIFF
--- a/app/mobile/src/screens/tabs/ProfileTabScreen.tsx
+++ b/app/mobile/src/screens/tabs/ProfileTabScreen.tsx
@@ -1,78 +1,157 @@
 import React from 'react';
 import { useNavigation } from '@react-navigation/native';
-import { Pressable, StyleSheet, Text, View } from 'react-native';
+import {
+  Alert,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  ToastAndroid,
+  View,
+} from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useAuth } from '../../context/AuthContext';
 import { shadows, tokens } from '../../theme';
+
+function showComingSoon() {
+  if (Platform.OS === 'android') {
+    ToastAndroid.show('Coming soon', ToastAndroid.SHORT);
+  } else {
+    Alert.alert('Coming soon', 'Edit profile is not available yet.');
+  }
+}
+
+type ActionRowProps = {
+  icon: string;
+  label: string;
+  onPress: () => void;
+  accessibilityLabel: string;
+  danger?: boolean;
+};
+
+function ActionRow({ icon, label, onPress, accessibilityLabel, danger }: ActionRowProps) {
+  return (
+    <Pressable
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.row,
+        danger ? styles.rowDanger : null,
+        pressed && styles.pressed,
+      ]}
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
+    >
+      <Text style={styles.rowIcon}>{icon}</Text>
+      <Text style={[styles.rowLabel, danger && styles.rowLabelDanger]} numberOfLines={1}>
+        {label}
+      </Text>
+      <Text style={[styles.rowChevron, danger && styles.rowLabelDanger]}>{'→'}</Text>
+    </Pressable>
+  );
+}
 
 export default function ProfileTabScreen() {
   const navigation = useNavigation<any>();
   const { user, isAuthenticated, logout } = useAuth();
 
+  const openUserProfile = () => {
+    if (!user) return;
+    navigation.navigate('Feed', {
+      screen: 'UserProfile',
+      params: { userId: user.id, username: user.username },
+    });
+  };
+
+  const initial = (user?.username ?? 'U').slice(0, 1).toUpperCase();
+
   return (
     <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
-      <View style={styles.container}>
+      <ScrollView contentContainerStyle={styles.container} keyboardShouldPersistTaps="handled">
         <View style={styles.card}>
           <Text style={styles.title} accessibilityRole="header">
             Profile
           </Text>
 
-          {isAuthenticated ? (
+          {isAuthenticated && user ? (
             <>
-              <Text style={styles.subtitle}>
-                Signed in{user ? ` as ${user.username}` : ''}.
-              </Text>
-              {user ? (
-                <>
-                  <Pressable
-                    onPress={() =>
-                      navigation.navigate('Feed', {
-                        screen: 'UserProfile',
-                        params: { userId: user.id, username: user.username },
-                      })
-                    }
-                    style={({ pressed }) => [styles.actionBtn, styles.myProfileBtn, pressed && styles.pressed]}
-                    accessibilityRole="button"
-                    accessibilityLabel="View my profile"
-                  >
-                    <Text style={styles.myProfileBtnText}>My profile</Text>
-                  </Pressable>
-                  <View style={{ height: 12 }} />
-                </>
-              ) : null}
               <Pressable
-                onPress={() => navigation.navigate('Feed', { screen: 'Inbox' })}
-                style={({ pressed }) => [styles.actionBtn, styles.messagesBtn, pressed && styles.pressed]}
+                onPress={openUserProfile}
+                style={({ pressed }) => [styles.header, pressed && styles.pressed]}
                 accessibilityRole="button"
-                accessibilityLabel="Open messages"
+                accessibilityLabel={`Open profile for ${user.username}`}
               >
-                <Text style={styles.messagesBtnText}>Messages</Text>
+                <View style={styles.avatar}>
+                  <Text style={styles.avatarText}>{initial}</Text>
+                </View>
+                <View style={styles.headerText}>
+                  <Text style={styles.username} numberOfLines={1}>
+                    @{user.username}
+                  </Text>
+                  {user.email ? (
+                    <Text style={styles.email} numberOfLines={1}>
+                      {user.email}
+                    </Text>
+                  ) : null}
+                </View>
+                <Text style={styles.headerChevron}>{'→'}</Text>
               </Pressable>
-              <View style={{ height: 12 }} />
-              <Pressable
-                onPress={() => navigation.navigate('Feed', { screen: 'Onboarding' })}
-                style={({ pressed }) => [styles.actionBtn, styles.culturalBtn, pressed && styles.pressed]}
-                accessibilityRole="button"
-                accessibilityLabel="Update cultural preferences"
-              >
-                <Text style={styles.culturalBtnText}>Cultural preferences</Text>
-              </Pressable>
-              <View style={{ height: 12 }} />
-              <Pressable
-                onPress={() => void logout()}
-                style={({ pressed }) => [styles.actionBtn, styles.logoutBtn, pressed && styles.pressed]}
-                accessibilityRole="button"
-                accessibilityLabel="Log out"
-              >
-                <Text style={styles.logoutBtnText}>Log out</Text>
-              </Pressable>
+
+              <View style={styles.list}>
+                <ActionRow
+                  icon="\u{1F373}"
+                  label="My recipes"
+                  onPress={openUserProfile}
+                  accessibilityLabel="View my recipes"
+                />
+                <ActionRow
+                  icon="\u{1F4DC}"
+                  label="My stories"
+                  onPress={openUserProfile}
+                  accessibilityLabel="View my stories"
+                />
+                <ActionRow
+                  icon="\u{1F516}"
+                  label="Saved recipes"
+                  onPress={openUserProfile}
+                  accessibilityLabel="View saved recipes"
+                />
+                <ActionRow
+                  icon="✉️"
+                  label="Messages"
+                  onPress={() => navigation.navigate('Feed', { screen: 'Inbox' })}
+                  accessibilityLabel="Open messages"
+                />
+                <ActionRow
+                  icon="\u{1F30D}"
+                  label="Cultural preferences"
+                  onPress={() => navigation.navigate('Feed', { screen: 'Onboarding' })}
+                  accessibilityLabel="Update cultural preferences"
+                />
+                <ActionRow
+                  icon="✏️"
+                  label="Edit profile"
+                  onPress={showComingSoon}
+                  accessibilityLabel="Edit profile"
+                />
+                <ActionRow
+                  icon="\u{1F6AA}"
+                  label="Log out"
+                  onPress={() => void logout()}
+                  accessibilityLabel="Log out"
+                  danger
+                />
+              </View>
             </>
           ) : (
             <>
+              <Text style={styles.greeting}>
+                Welcome, traveller. Sign in to share recipes and stories from your culture.
+              </Text>
               <Text style={styles.subtitle}>
                 No profile yet. Log in or register to continue.
               </Text>
-              <View style={styles.row}>
+              <View style={styles.authRow}>
                 <Pressable
                   onPress={() => navigation.navigate('Feed', { screen: 'Login' })}
                   style={({ pressed }) => [styles.primary, pressed && styles.pressed]}
@@ -93,14 +172,14 @@ export default function ProfileTabScreen() {
             </>
           )}
         </View>
-      </View>
+      </ScrollView>
     </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
   safe: { flex: 1, backgroundColor: tokens.colors.bg },
-  container: { flex: 1, padding: 20, justifyContent: 'center' },
+  container: { padding: 20, paddingBottom: 32 },
   card: {
     backgroundColor: tokens.colors.surface,
     borderRadius: tokens.radius.xl,
@@ -113,11 +192,68 @@ const styles = StyleSheet.create({
     fontSize: 28,
     fontWeight: '800',
     color: tokens.colors.text,
-    marginBottom: 10,
+    marginBottom: 14,
     fontFamily: tokens.typography.display.fontFamily,
   },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 14,
+    padding: 14,
+    borderRadius: tokens.radius.xl,
+    borderWidth: 2,
+    borderColor: tokens.colors.surfaceDark,
+    backgroundColor: tokens.colors.bg,
+    marginBottom: 16,
+    ...shadows.md,
+  },
+  avatar: {
+    width: 56,
+    height: 56,
+    borderRadius: 999,
+    backgroundColor: tokens.colors.accentGreenTint,
+    borderWidth: 2,
+    borderColor: tokens.colors.surfaceDark,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  avatarText: { fontSize: 22, fontWeight: '900', color: tokens.colors.text },
+  headerText: { flex: 1, minWidth: 0 },
+  username: {
+    fontSize: 20,
+    fontWeight: '800',
+    color: tokens.colors.text,
+    fontFamily: tokens.typography.display.fontFamily,
+  },
+  email: { fontSize: 14, color: tokens.colors.textMuted, marginTop: 2 },
+  headerChevron: { fontSize: 22, fontWeight: '800', color: tokens.colors.text, marginLeft: 4 },
+  list: { gap: 10 },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    paddingVertical: 12,
+    paddingHorizontal: 14,
+    borderRadius: tokens.radius.xl,
+    borderWidth: 2,
+    borderColor: tokens.colors.surfaceDark,
+    backgroundColor: tokens.colors.bg,
+    ...shadows.md,
+  },
+  rowDanger: { backgroundColor: '#FC6C85' },
+  rowIcon: { fontSize: 18 },
+  rowLabel: { flex: 1, fontSize: 16, fontWeight: '800', color: tokens.colors.text },
+  rowLabelDanger: { color: tokens.colors.surfaceDark },
+  rowChevron: { fontSize: 18, fontWeight: '800', color: tokens.colors.text },
+  greeting: {
+    fontSize: 16,
+    color: tokens.colors.text,
+    lineHeight: 22,
+    marginBottom: 12,
+    fontStyle: 'italic',
+  },
   subtitle: { fontSize: 16, color: tokens.colors.textMuted, lineHeight: 22, marginBottom: 16 },
-  row: { flexDirection: 'row', gap: 12 },
+  authRow: { flexDirection: 'row', gap: 12 },
   primary: {
     flex: 1,
     backgroundColor: tokens.colors.accentGreen,
@@ -132,39 +268,6 @@ const styles = StyleSheet.create({
     alignSelf: 'center',
   },
   primaryText: { color: '#fff', fontSize: 16, fontWeight: '800' },
-  secondary: {
-    borderWidth: 2,
-    borderColor: tokens.colors.surfaceDark,
-    backgroundColor: tokens.colors.bg,
-    paddingVertical: 12,
-    paddingHorizontal: 14,
-    borderRadius: tokens.radius.pill,
-    alignItems: 'center',
-    maxWidth: 340,
-    alignSelf: 'center',
-    width: '100%',
-  },
-  secondaryText: { color: tokens.colors.text, fontSize: 16, fontWeight: '800' },
-  actionBtn: {
-    borderWidth: 2,
-    borderColor: tokens.colors.surfaceDark,
-    paddingVertical: 12,
-    paddingHorizontal: 14,
-    borderRadius: tokens.radius.pill,
-    alignItems: 'center',
-    maxWidth: 340,
-    alignSelf: 'center',
-    width: '100%',
-    ...shadows.md,
-  },
-  myProfileBtn: { backgroundColor: tokens.colors.accentMustard },
-  myProfileBtnText: { color: tokens.colors.surfaceDark, fontSize: 16, fontWeight: '800' },
-  messagesBtn: { backgroundColor: "#C8E5EB" },
-  messagesBtnText: { color: tokens.colors.surfaceDark, fontSize: 16, fontWeight: '800' },
-  culturalBtn: { backgroundColor: '#C8E5EB' },
-  culturalBtnText: { color: tokens.colors.surfaceDark, fontSize: 16, fontWeight: '800' },
-  logoutBtn: { backgroundColor: '#FC6C85' },
-  logoutBtnText: { color: tokens.colors.surfaceDark, fontSize: 16, fontWeight: '800' },
   registerBtn: {
     flex: 1,
     backgroundColor: '#EFBF04',
@@ -181,4 +284,3 @@ const styles = StyleSheet.create({
   registerBtnText: { color: '#000000', fontSize: 16, fontWeight: '800' },
   pressed: { opacity: 0.9 },
 });
-


### PR DESCRIPTION
## Summary
- Replaces the ProfileTab placeholder with a proper authenticated layout: tap-to-open identity header (avatar circle + @username + email) and a vertical action list.
- Action rows: My recipes, My stories, Saved recipes, Messages, Cultural preferences, Edit profile, Log out (danger pink).
- My recipes / My stories / Saved recipes all navigate to the user's UserProfile screen (deep-link to specific tabs skipped — UserProfile does not accept an `initialTab` param yet, so users tap the in-screen chip).
- Edit profile shows a "Coming soon" toast (Android `ToastAndroid`, iOS `Alert`) because no `EditProfile` route exists in `RootStackParamList`. Wiring can land once that screen exists.
- Unauthenticated state keeps Log In / Register, with a short cultural greeting above as the issue requested.

## Test plan
- [ ] Open Profile tab while signed in — header shows initial avatar, @username, email.
- [ ] Tap header — UserProfile opens for the current user.
- [ ] Tap My recipes / My stories / Saved recipes — UserProfile opens (chip selection still works inside).
- [ ] Tap Messages — Inbox opens.
- [ ] Tap Cultural preferences — Onboarding opens.
- [ ] Tap Edit profile — toast/alert "Coming soon" appears.
- [ ] Tap Log out — session ends, unauth state appears.
- [ ] Sign out and reopen Profile — greeting + Log In / Register pair render.

Closes #447