### PR TITLE
feat(mobile): Map Discovery UX — sized marker badges, animated camera focus, region search pill, a11y (mobile half of #474)

### DIFF
--- a/app/mobile/src/components/map/RegionDotMarker.tsx
+++ b/app/mobile/src/components/map/RegionDotMarker.tsx
@@ -1,0 +1,120 @@
+import { useEffect, useState } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { Marker } from 'react-native-maps';
+import { tokens } from '../../theme';
+import type { RegionPin } from '../../services/mapDataService';
+
+/** Three-tier size scale for region pins by recipe count. */
+export function markerSizeForRecipeCount(count: number): number {
+  if (count >= 6) return 42;
+  if (count >= 2) return 32;
+  return 24;
+}
+
+/** Just the colored circle with the count number inside.
+ *
+ * Wrapped with `renderToHardwareTextureAndroid` + `needsOffscreenAlphaCompositing`
+ * so Android keeps the rounded corners when it snapshots the custom marker view
+ * into its bitmap. Without this, borderRadius gets dropped and the marker shows
+ * up as a square (same fix as #769 on the heritage map). */
+function RegionDot({
+  size,
+  isFocused,
+  count,
+}: {
+  size: number;
+  isFocused: boolean;
+  count: number;
+}) {
+  const fontSize = size >= 42 ? 14 : size >= 32 ? 12 : 10;
+  return (
+    <View
+      collapsable={false}
+      renderToHardwareTextureAndroid
+      needsOffscreenAlphaCompositing
+      style={[styles.outer, { width: size + 8, height: size + 8 }]}
+    >
+      <View
+        style={[
+          styles.dot,
+          {
+            width: size,
+            height: size,
+            borderRadius: size / 2,
+            backgroundColor: isFocused
+              ? tokens.colors.accentGreen
+              : tokens.colors.accentMustard,
+          },
+        ]}
+      >
+        <Text
+          allowFontScaling={false}
+          style={[styles.count, { fontSize, color: tokens.colors.surfaceDark }]}
+        >
+          {count}
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+/** Region marker for the discovery map.
+ *
+ * Uses the dual `tracksViewChanges` trick (start true so the layout is
+ * captured into the marker bitmap, flip to false after 800ms so Android stops
+ * re-snapshotting and reintroducing the square-clipping bug on subsequent
+ * renders). Each marker owns its own tracking state so they don't all redraw
+ * together. */
+export function RegionDotMarker({
+  pin,
+  isFocused,
+  onPress,
+}: {
+  pin: RegionPin;
+  isFocused: boolean;
+  onPress: () => void;
+}) {
+  const [tracks, setTracks] = useState(true);
+  useEffect(() => {
+    const t = setTimeout(() => setTracks(false), 800);
+    return () => clearTimeout(t);
+  }, []);
+
+  const size = markerSizeForRecipeCount(pin.recipeCount);
+
+  return (
+    <Marker
+      coordinate={pin.coords}
+      onPress={(e) => {
+        e.stopPropagation?.();
+        onPress();
+      }}
+      title={pin.name}
+      description={`${pin.recipeCount} ${pin.recipeCount === 1 ? 'recipe' : 'recipes'}`}
+      anchor={{ x: 0.5, y: 0.5 }}
+      tracksViewChanges={tracks}
+      accessibilityLabel={`${pin.name}, ${pin.recipeCount} ${
+        pin.recipeCount === 1 ? 'recipe' : 'recipes'
+      }`}
+    >
+      <RegionDot size={size} isFocused={isFocused} count={pin.recipeCount} />
+    </Marker>
+  );
+}
+
+const styles = StyleSheet.create({
+  outer: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'transparent',
+  },
+  dot: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 2,
+    borderColor: tokens.colors.surfaceDark,
+  },
+  count: {
+    fontWeight: '800',
+  },
+});

--- a/app/mobile/src/screens/MapDiscoveryScreen.tsx
+++ b/app/mobile/src/screens/MapDiscoveryScreen.tsx
@@ -1,10 +1,11 @@
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { useEffect, useRef, useState } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
-import MapView, { Marker } from 'react-native-maps';
+import MapView from 'react-native-maps';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { MapZoomControls } from '../components/map/MapZoomControls';
 import { RegionDetailSheet } from '../components/map/RegionDetailSheet';
+import { RegionDotMarker } from '../components/map/RegionDotMarker';
 import { ErrorView } from '../components/ui/ErrorView';
 import { LoadingView } from '../components/ui/LoadingView';
 import type { RootStackParamList } from '../navigation/types';
@@ -14,13 +15,18 @@ import { shadows, tokens, useTheme } from '../theme';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'MapDiscovery'>;
 
+/** Slight zoom-in when a pin is selected. react-native-maps' `animateCamera`
+ * uses Google Maps zoom levels (higher = closer); 5 lands roughly at a country
+ * frame, which feels good after the global initial view. */
+const FOCUS_ZOOM = 5;
+
 export default function MapDiscoveryScreen({ navigation }: Props) {
   const [pins, setPins] = useState<RegionPin[]>([]);
   const [focused, setFocused] = useState<RegionPin | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [reloadToken, setReloadToken] = useState(0);
-  const { accent, setFocusedRegion } = useTheme();
+  const { setFocusedRegion } = useTheme();
   const mapRef = useRef<MapView | null>(null);
 
   useEffect(() => {
@@ -52,7 +58,7 @@ export default function MapDiscoveryScreen({ navigation }: Props) {
     return (
       <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
         <View style={styles.centered}>
-          <LoadingView message="Loading map…" />
+          <LoadingView message="Loading regions across the world…" />
         </View>
       </SafeAreaView>
     );
@@ -79,20 +85,19 @@ export default function MapDiscoveryScreen({ navigation }: Props) {
           accessibilityLabel="Region discovery map"
         >
           {pins.map((pin) => (
-            <Marker
+            <RegionDotMarker
               key={pin.id}
-              coordinate={pin.coords}
-              title={pin.name}
-              description={`${pin.recipeCount} ${pin.recipeCount === 1 ? 'recipe' : 'recipes'}`}
-              pinColor={focused?.id === pin.id ? accent.accent : tokens.colors.accentMustard}
-              onPress={(e) => {
-                e.stopPropagation?.();
-                // Track for theme highlight, then dive into the zoomed
-                // per-recipe map (#464). The old `RegionDetailSheet` flow
-                // (recipes/stories overview) stays available below in case
-                // we ever want to bring it back; for now the spatial drill-in
-                // is the primary path.
+              pin={pin}
+              isFocused={focused?.id === pin.id}
+              onPress={() => {
                 setFocused(pin);
+                // Smooth zoom-in on the tapped pin before diving into the
+                // per-region map. Animation runs in parallel with navigation
+                // so the transition feels continuous instead of janky.
+                mapRef.current?.animateCamera(
+                  { center: pin.coords, zoom: FOCUS_ZOOM },
+                  { duration: 450 },
+                );
                 navigation.navigate('RegionMapDetail', {
                   regionId: pin.id,
                   regionName: pin.name,
@@ -103,6 +108,17 @@ export default function MapDiscoveryScreen({ navigation }: Props) {
         </MapView>
 
         <MapZoomControls mapRef={mapRef} />
+
+        <View style={styles.searchPillWrap} pointerEvents="box-none">
+          <Pressable
+            onPress={() => navigation.navigate('Search', { region: '' })}
+            style={({ pressed }) => [styles.searchPill, pressed && styles.searchPillPressed]}
+            accessibilityRole="button"
+            accessibilityLabel="Search regions"
+          >
+            <Text style={styles.searchPillText}>Search regions →</Text>
+          </Pressable>
+        </View>
 
         <View style={styles.routesCtaWrap} pointerEvents="box-none">
           <Pressable
@@ -117,9 +133,11 @@ export default function MapDiscoveryScreen({ navigation }: Props) {
 
         {!focused ? (
           <View style={styles.hintWrap} pointerEvents="none">
-            <View style={styles.hintCard}>
+            <View style={styles.hintCard} accessible accessibilityRole="text">
               <Text style={styles.hintText}>
-                {pins.length === 0 ? 'No mappable regions yet.' : 'Tap a pin to open the region.'}
+                {pins.length === 0
+                  ? 'No mappable regions yet. The team is still seeding coordinates.'
+                  : 'Tap a pin to open the region. Bigger pins = more recipes.'}
               </Text>
             </View>
           </View>
@@ -145,43 +163,9 @@ const styles = StyleSheet.create({
   map: { flex: 1 },
   centered: { flex: 1, justifyContent: 'center', alignItems: 'center', padding: 20 },
   padded: { flex: 1, padding: 20, justifyContent: 'center' },
-  summary: {
-    position: 'absolute',
-    left: 16,
-    right: 16,
-    bottom: 24,
-  },
-  summaryCard: {
-    padding: 16,
-    borderRadius: tokens.radius.xl,
-    backgroundColor: tokens.colors.bg,
-    borderWidth: 2,
-    borderColor: tokens.colors.surfaceDark,
-    gap: 8,
-    ...shadows.lg,
-  },
-  summaryRegion: {
-    fontSize: 20,
-    fontWeight: '800',
-    color: tokens.colors.text,
-    fontFamily: tokens.typography.display.fontFamily,
-  },
-  summaryCount: { fontSize: 13, color: tokens.colors.text },
-  cta: {
-    marginTop: 4,
-    paddingVertical: 12,
-    paddingHorizontal: 14,
-    borderRadius: tokens.radius.pill,
-    backgroundColor: tokens.colors.accentGreen,
-    borderWidth: 2,
-    borderColor: tokens.colors.surfaceDark,
-    alignItems: 'center',
-  },
-  ctaPressed: { opacity: 0.9 },
-  ctaText: { color: tokens.colors.textOnDark, fontSize: 15, fontWeight: '800' },
   hintWrap: {
     position: 'absolute',
-    top: 16,
+    top: 64,
     left: 16,
     right: 16,
     alignItems: 'center',
@@ -196,6 +180,28 @@ const styles = StyleSheet.create({
     ...shadows.sm,
   },
   hintText: { fontSize: 13, color: tokens.colors.text, fontWeight: '700' },
+  searchPillWrap: {
+    position: 'absolute',
+    top: 16,
+    left: 16,
+    right: 16,
+    alignItems: 'center',
+  },
+  searchPill: {
+    paddingVertical: 10,
+    paddingHorizontal: 18,
+    borderRadius: tokens.radius.pill,
+    backgroundColor: tokens.colors.bg,
+    borderWidth: 2,
+    borderColor: tokens.colors.surfaceDark,
+    ...shadows.md,
+  },
+  searchPillPressed: { opacity: 0.85 },
+  searchPillText: {
+    color: tokens.colors.text,
+    fontSize: 14,
+    fontWeight: '800',
+  },
   routesCtaWrap: {
     position: 'absolute',
     left: 16,


### PR DESCRIPTION
## Summary
Mobile half of #474 Map Discovery UX. Region pins are now custom dot markers whose diameter scales with recipe count (24 / 32 / 42px) and that show the count inside; tapping a pin runs a 450ms `animateCamera` zoom-in before navigating to `RegionMapDetail`. Added a top "Search regions →" pill that jumps to the existing `Search` screen pre-focused on region querying, plus better empty/loading copy and accessibility labels on markers and the hint card.

Markers use the custom-View + `renderToHardwareTextureAndroid` + `needsOffscreenAlphaCompositing` + dual `tracksViewChanges` pattern we landed in #769 for the heritage map (per-marker tracking state in a new `RegionDotMarker` component). If round markers ever regress to squares on a device, the fallback is to drop the custom child and go back to `pinColor` strings — call it out in QA.

The web half (`MapPage.jsx`) is a separate scope. `Refs #474` (not Closes).

## Test plan
- [ ] Open Discover by region tab on Android — pins render as round mustard circles with the recipe count inside, not squares
- [ ] Pin sizes look distinct: 1-recipe regions are visibly smaller than 6+ regions
- [ ] Tap a pin — map smooth-zooms onto it (~450ms) and then `RegionMapDetail` opens
- [ ] Focused pin (after tap, before navigation completes) turns green
- [ ] Tap the top "Search regions →" pill — navigates to the Search screen
- [ ] With zero pins, hint card shows the "still seeding coordinates" copy
- [ ] TalkBack/VoiceOver on a marker reads "<region name>, N recipes"
- [ ] iOS: same round-marker behaviour, no regressions in zoom controls or the bottom Ingredient routes pill