### PR TITLE
fix(frontend): mock passportService.getPassport in UserProfilePage tests

### DIFF
--- a/app/frontend/src/__tests__/UserProfilePage.test.jsx
+++ b/app/frontend/src/__tests__/UserProfilePage.test.jsx
@@ -33,6 +33,10 @@ function renderPage(username, currentUser = null) {
 beforeEach(() => {
   jest.clearAllMocks();
   passportService.getPublicProfile.mockResolvedValue(mockProfile);
+  // UserProfilePage also fires getPassport in a separate effect; without a
+  // resolved mock the auto-mocked function returns undefined and the .then
+  // call crashes before the .catch handler can swallow it.
+  passportService.getPassport.mockResolvedValue(null);
 });
 
 describe('UserProfilePage', () => {


### PR DESCRIPTION
## Summary

`UserProfilePage` mounts two effects: one fetches `getPublicProfile`, another fetches `getPassport` for the tab data. The test file mocks the `passportService` module via `jest.mock(...)` (auto-mock) and explicitly configures `getPublicProfile.mockResolvedValue(mockProfile)` but never sets up `getPassport`. Auto-mocked functions return `undefined`, so `getPassport(username).then(setPassport)` throws `TypeError: Cannot read properties of undefined (reading 'then')` before the `.catch(() => {})` handler can swallow it. Eight of the nine assertions in `UserProfilePage.test.jsx` fail as a result.

This shipped as part of #765 (Cultural Passport tabs) when `getPassport` was introduced — the test file was not updated alongside.

## Fix

One line added in `beforeEach`:

```js
passportService.getPassport.mockResolvedValue(null);
```

`UserProfilePage` already guards every passport read with `passport?.xxx ?? []`, so `null` is a safe payload for the existing test cases (none of them exercise the passport tabs — they only assert the public profile fields).

## Test plan

- [x] `CI=true npm test -- --testPathPattern=UserProfilePage` → 9/9 pass
- [x] `CI=true npm test` → 588/588 pass (was 580/588 before this fix)

## Unblocks

This is the main test failure that was making PR #769 and PR #773 (and any other recent branch) show red CI. Both have heads-up notes about it. Once this lands, a CI rerun on those PRs will go green.