### PR TITLE
feat(mobile): PassportCover component + theme resolver with level- and calendar-based themes (closes #600)

### DIFF
--- a/app/mobile/__tests__/components/PassportCover.test.tsx
+++ b/app/mobile/__tests__/components/PassportCover.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { PassportCover } from '../../src/components/passport/PassportCover';
+import { PASSPORT_THEMES, resolveTheme } from '../../src/utils/passportTheme';
+
+describe('PassportCover', () => {
+  it('renders the username, level pill, and theme copy', () => {
+    const theme = PASSPORT_THEMES['Mediterranean Journal'];
+    const { getByText } = render(
+      <PassportCover
+        theme={theme}
+        level={7}
+        totalPoints={1234}
+        username="ayse"
+      />,
+    );
+    expect(getByText('ayse')).toBeTruthy();
+    expect(getByText('MEDITERRANEAN JOURNAL')).toBeTruthy();
+    expect(getByText('LEVEL 7 · 1234 PTS')).toBeTruthy();
+  });
+
+  it('renders the theme glyph', () => {
+    const theme = PASSPORT_THEMES['Ramazan'];
+    const { getByText } = render(
+      <PassportCover theme={theme} level={4} totalPoints={400} username="bob" />,
+    );
+    expect(getByText(theme.glyph)).toBeTruthy();
+  });
+
+  it('exposes a descriptive accessibility label', () => {
+    const theme = resolveTheme('classic_traveler', 1);
+    const { getByLabelText } = render(
+      <PassportCover theme={theme} level={1} totalPoints={50} username="ayse" />,
+    );
+    expect(
+      getByLabelText('Passport cover, theme Classic Traveler, level 1, 50 points'),
+    ).toBeTruthy();
+  });
+
+  it('works with a calendar-based theme resolved by name', () => {
+    const theme = resolveTheme({ name: 'Lunar New Year' }, 2);
+    const { getByText } = render(
+      <PassportCover theme={theme} level={2} totalPoints={120} username="ling" />,
+    );
+    expect(getByText('LUNAR NEW YEAR')).toBeTruthy();
+    expect(getByText('ling')).toBeTruthy();
+  });
+});

--- a/app/mobile/__tests__/utils/passportTheme.test.ts
+++ b/app/mobile/__tests__/utils/passportTheme.test.ts
@@ -1,0 +1,80 @@
+import {
+  PASSPORT_THEMES,
+  resolveTheme,
+  themeForLevel,
+} from '../../src/utils/passportTheme';
+
+describe('resolveTheme', () => {
+  it('resolves an exact catalogue name', () => {
+    const theme = resolveTheme({ name: 'Mediterranean Journal' }, 1);
+    expect(theme.name).toBe('Mediterranean Journal');
+    expect(theme.copy).toBe('MEDITERRANEAN JOURNAL');
+  });
+
+  it('resolves a backend slug string ("classic_traveler")', () => {
+    const theme = resolveTheme('classic_traveler', 1);
+    expect(theme.name).toBe('Classic Traveler');
+  });
+
+  it('resolves alias slugs to their canonical theme', () => {
+    expect(resolveTheme('aegean_voyager', 1).name).toBe('Mediterranean Journal');
+    expect(resolveTheme('ramadan', 1).name).toBe('Ramazan');
+  });
+
+  it('resolves calendar-based themes by name', () => {
+    expect(resolveTheme({ name: 'Eid Festival' }).name).toBe('Eid Festival');
+    expect(resolveTheme({ name: 'Lunar New Year' }).name).toBe('Lunar New Year');
+    expect(resolveTheme({ name: 'Harvest Moon' }).name).toBe('Harvest Moon');
+  });
+
+  it('falls back to a level-based theme when name is unknown', () => {
+    expect(resolveTheme({ name: 'Nonexistent' }, 1).name).toBe('Classic Traveler');
+    expect(resolveTheme({ name: 'Nonexistent' }, 4).name).toBe('Vintage Recipe Book');
+    expect(resolveTheme({ name: 'Nonexistent' }, 7).name).toBe('Mediterranean Journal');
+    expect(resolveTheme({ name: 'Nonexistent' }, 10).name).toBe('Heritage Archive');
+  });
+
+  it('falls back when active is null/undefined/empty', () => {
+    expect(resolveTheme(null, 1).name).toBe('Classic Traveler');
+    expect(resolveTheme(undefined, 5).name).toBe('Vintage Recipe Book');
+    expect(resolveTheme({ name: '' }, 6).name).toBe('Mediterranean Journal');
+  });
+
+  it('defaults to Classic Traveler when level is missing', () => {
+    expect(resolveTheme(null).name).toBe('Classic Traveler');
+  });
+});
+
+describe('themeForLevel', () => {
+  it('maps levels into the right bucket', () => {
+    expect(themeForLevel(1).name).toBe('Classic Traveler');
+    expect(themeForLevel(2).name).toBe('Classic Traveler');
+    expect(themeForLevel(3).name).toBe('Vintage Recipe Book');
+    expect(themeForLevel(5).name).toBe('Vintage Recipe Book');
+    expect(themeForLevel(6).name).toBe('Mediterranean Journal');
+    expect(themeForLevel(8).name).toBe('Mediterranean Journal');
+    expect(themeForLevel(9).name).toBe('Heritage Archive');
+  });
+
+  it('treats invalid levels as level 1', () => {
+    expect(themeForLevel(undefined).name).toBe('Classic Traveler');
+    expect(themeForLevel(0).name).toBe('Classic Traveler');
+    expect(themeForLevel(-3).name).toBe('Classic Traveler');
+  });
+});
+
+describe('PASSPORT_THEMES catalogue', () => {
+  it('exposes all 11 themes from the spec', () => {
+    expect(Object.keys(PASSPORT_THEMES)).toHaveLength(11);
+  });
+
+  it('each theme has the required visual fields', () => {
+    Object.values(PASSPORT_THEMES).forEach((t) => {
+      expect(t.background).toBeTruthy();
+      expect(t.accent).toBeTruthy();
+      expect(t.textOnCover).toBeTruthy();
+      expect(t.glyph).toBeTruthy();
+      expect(t.copy).toBeTruthy();
+    });
+  });
+});

--- a/app/mobile/src/components/passport/PassportCover.tsx
+++ b/app/mobile/src/components/passport/PassportCover.tsx
@@ -1,0 +1,144 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { tokens } from '../../theme';
+import type { PassportTheme } from '../../utils/passportTheme';
+
+type Props = {
+  theme: PassportTheme;
+  level: number;
+  totalPoints: number;
+  username: string;
+};
+
+/**
+ * Dynamic Cultural Passport cover (#600). Renders a tall banner whose colours,
+ * glyph, and copy come from the resolved {@link PassportTheme}. The cover is
+ * intentionally self-contained so any screen that already has a passport
+ * payload can drop it in:
+ *
+ * ```tsx
+ * <PassportCover
+ *   theme={resolveTheme(passport.active_theme, passport.level)}
+ *   level={passport.level}
+ *   totalPoints={passport.total_points}
+ *   username={user.username}
+ * />
+ * ```
+ */
+export function PassportCover({ theme, level, totalPoints, username }: Props) {
+  const a11yLabel = `Passport cover, theme ${theme.name}, level ${level}, ${totalPoints} points`;
+
+  return (
+    <View
+      accessibilityLabel={a11yLabel}
+      accessible
+      style={[styles.cover, { backgroundColor: theme.background }]}
+    >
+      <View style={styles.topRow}>
+        <View style={[styles.glyphCircle, { backgroundColor: theme.accent }]}>
+          <Text style={styles.glyphText}>{theme.glyph}</Text>
+        </View>
+      </View>
+
+      <View style={styles.centerBlock}>
+        <Text style={[styles.username, { color: theme.textOnCover }]} numberOfLines={1}>
+          {username}
+        </Text>
+        <Text style={[styles.copy, { color: theme.textOnCover }]} numberOfLines={1}>
+          {theme.copy}
+        </Text>
+      </View>
+
+      <View style={[styles.stripe, { backgroundColor: theme.accent }]} />
+
+      <View style={styles.bottomRow}>
+        <View style={styles.levelPill}>
+          <Text style={styles.levelPillText}>
+            {`LEVEL ${level} · ${totalPoints} PTS`}
+          </Text>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  cover: {
+    height: 180,
+    borderRadius: tokens.radius.lg,
+    borderWidth: 2,
+    borderColor: tokens.colors.surfaceDark,
+    paddingHorizontal: 16,
+    paddingTop: 14,
+    paddingBottom: 14,
+    overflow: 'hidden',
+    position: 'relative',
+  },
+  topRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  glyphCircle: {
+    width: 44,
+    height: 44,
+    borderRadius: tokens.radius.pill,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 2,
+    borderColor: tokens.colors.surfaceDark,
+  },
+  glyphText: {
+    fontSize: 22,
+  },
+  centerBlock: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 12,
+  },
+  username: {
+    ...tokens.typography.display,
+    fontSize: 26,
+    letterSpacing: 0.5,
+    textAlign: 'center',
+  },
+  copy: {
+    ...tokens.typography.body,
+    fontSize: 11,
+    letterSpacing: 2,
+    textTransform: 'uppercase',
+    marginTop: 4,
+    textAlign: 'center',
+    opacity: 0.85,
+  },
+  stripe: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 38,
+    height: 8,
+    opacity: 0.45,
+  },
+  bottomRow: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    alignItems: 'center',
+  },
+  levelPill: {
+    backgroundColor: tokens.colors.bg,
+    borderRadius: tokens.radius.pill,
+    borderWidth: 1.5,
+    borderColor: tokens.colors.surfaceDark,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+  },
+  levelPillText: {
+    ...tokens.typography.body,
+    color: tokens.colors.surfaceDark,
+    fontSize: 12,
+    letterSpacing: 1,
+    fontWeight: '700',
+  },
+});
+
+export default PassportCover;

--- a/app/mobile/src/utils/passportTheme.ts
+++ b/app/mobile/src/utils/passportTheme.ts
@@ -1,0 +1,227 @@
+import { tokens } from '../theme';
+
+/**
+ * Catalogue of passport cover themes shipped with the mobile app (#600).
+ *
+ * Themes fall into two buckets:
+ *   - Level-based: awarded as the user climbs through Cultural Passport
+ *     levels (Classic Traveler → Heritage Archive → ...).
+ *   - Calendar-based: surfaced during cultural events such as Ramazan, Eid,
+ *     Harvest Moon, and Lunar New Year.
+ *
+ * The backend stores `active_theme` as a slug string on the passport (see
+ * apps/passport/models.py) but the issue spec describes a future-proof
+ * `{ name, kind? }` shape. `resolveTheme` accepts both, plus plain strings,
+ * so the component is forward-compatible while still working today.
+ */
+
+export type PassportThemeName =
+  | 'Classic Traveler'
+  | 'Vintage Recipe Book'
+  | 'Street Food Explorer'
+  | "Grandmother's Kitchen"
+  | 'Mediterranean Journal'
+  | 'Heritage Archive'
+  | 'World Kitchen Explorer'
+  | 'Ramazan'
+  | 'Eid Festival'
+  | 'Harvest Moon'
+  | 'Lunar New Year';
+
+export type PassportTheme = {
+  name: PassportThemeName | string;
+  background: string;
+  accent: string;
+  textOnCover: string;
+  glyph: string;
+  copy: string;
+};
+
+const c = tokens.colors;
+
+/** Canonical catalogue keyed by the user-facing theme name. */
+export const PASSPORT_THEMES: Record<PassportThemeName, PassportTheme> = {
+  'Classic Traveler': {
+    name: 'Classic Traveler',
+    background: c.surface,
+    accent: c.accentMustard,
+    textOnCover: c.surfaceDark,
+    glyph: '🧳',
+    copy: 'CLASSIC TRAVELER',
+  },
+  'Vintage Recipe Book': {
+    name: 'Vintage Recipe Book',
+    background: c.accentMustard,
+    accent: c.surfaceDark,
+    textOnCover: c.surfaceDark,
+    glyph: '📖',
+    copy: 'VINTAGE RECIPE BOOK',
+  },
+  'Street Food Explorer': {
+    name: 'Street Food Explorer',
+    background: c.primary,
+    accent: c.accentGreen,
+    textOnCover: c.surfaceDark,
+    glyph: '🌮',
+    copy: 'STREET FOOD EXPLORER',
+  },
+  "Grandmother's Kitchen": {
+    name: "Grandmother's Kitchen",
+    background: c.bg,
+    accent: c.primary,
+    textOnCover: c.surfaceDark,
+    glyph: '🍞',
+    copy: "GRANDMOTHER'S KITCHEN",
+  },
+  'Mediterranean Journal': {
+    name: 'Mediterranean Journal',
+    background: c.accentGreen,
+    accent: c.accentMustard,
+    textOnCover: c.bg,
+    glyph: '🫒',
+    copy: 'MEDITERRANEAN JOURNAL',
+  },
+  'Heritage Archive': {
+    name: 'Heritage Archive',
+    background: c.surfaceDark,
+    accent: c.accentMustard,
+    textOnCover: c.bg,
+    glyph: '🏛️',
+    copy: 'HERITAGE ARCHIVE',
+  },
+  'World Kitchen Explorer': {
+    name: 'World Kitchen Explorer',
+    background: c.primaryHover,
+    accent: c.accentGreen,
+    textOnCover: c.bg,
+    glyph: '🌍',
+    copy: 'WORLD KITCHEN EXPLORER',
+  },
+  Ramazan: {
+    name: 'Ramazan',
+    background: c.surfaceDark,
+    accent: c.accentMustard,
+    textOnCover: c.bg,
+    glyph: '🌙',
+    copy: 'RAMAZAN EDITION',
+  },
+  'Eid Festival': {
+    name: 'Eid Festival',
+    background: c.accentGreen,
+    accent: c.accentMustard,
+    textOnCover: c.bg,
+    glyph: '🕌',
+    copy: 'EID FESTIVAL',
+  },
+  'Harvest Moon': {
+    name: 'Harvest Moon',
+    background: c.primary,
+    accent: c.accentMustard,
+    textOnCover: c.surfaceDark,
+    glyph: '🌾',
+    copy: 'HARVEST MOON',
+  },
+  'Lunar New Year': {
+    name: 'Lunar New Year',
+    background: c.primaryHover,
+    accent: c.accentMustard,
+    textOnCover: c.bg,
+    glyph: '🧧',
+    copy: 'LUNAR NEW YEAR',
+  },
+};
+
+/**
+ * Aliases for backend slug strings, lowercase forms, and a handful of
+ * synonymous names. Anything we don't recognise will fall through to the
+ * level-based default.
+ */
+const NAME_ALIASES: Record<string, PassportThemeName> = {
+  classic_traveler: 'Classic Traveler',
+  'classic traveler': 'Classic Traveler',
+  vintage_recipe_book: 'Vintage Recipe Book',
+  'vintage recipe book': 'Vintage Recipe Book',
+  street_food_explorer: 'Street Food Explorer',
+  'street food explorer': 'Street Food Explorer',
+  grandmothers_kitchen: "Grandmother's Kitchen",
+  grandmother_kitchen: "Grandmother's Kitchen",
+  "grandmother's kitchen": "Grandmother's Kitchen",
+  mediterranean_journal: 'Mediterranean Journal',
+  'mediterranean journal': 'Mediterranean Journal',
+  aegean_voyager: 'Mediterranean Journal',
+  heritage_archive: 'Heritage Archive',
+  'heritage archive': 'Heritage Archive',
+  world_kitchen_explorer: 'World Kitchen Explorer',
+  'world kitchen explorer': 'World Kitchen Explorer',
+  ramazan: 'Ramazan',
+  ramadan: 'Ramazan',
+  eid: 'Eid Festival',
+  eid_festival: 'Eid Festival',
+  'eid festival': 'Eid Festival',
+  harvest_moon: 'Harvest Moon',
+  'harvest moon': 'Harvest Moon',
+  lunar_new_year: 'Lunar New Year',
+  'lunar new year': 'Lunar New Year',
+};
+
+function normaliseName(input: string): PassportThemeName | null {
+  if (!input) return null;
+  const trimmed = input.trim();
+  if (trimmed in PASSPORT_THEMES) {
+    return trimmed as PassportThemeName;
+  }
+  const key = trimmed.toLowerCase();
+  if (key in NAME_ALIASES) {
+    return NAME_ALIASES[key];
+  }
+  return null;
+}
+
+/**
+ * Pick a sensible theme based purely on the user's passport level. Used as a
+ * fallback when the backend doesn't return an active_theme we recognise.
+ *   1-2  → Classic Traveler
+ *   3-5  → Vintage Recipe Book
+ *   6-8  → Mediterranean Journal
+ *   9+   → Heritage Archive
+ */
+export function themeForLevel(level: number | undefined): PassportTheme {
+  const lvl = typeof level === 'number' && level > 0 ? level : 1;
+  if (lvl >= 9) return PASSPORT_THEMES['Heritage Archive'];
+  if (lvl >= 6) return PASSPORT_THEMES['Mediterranean Journal'];
+  if (lvl >= 3) return PASSPORT_THEMES['Vintage Recipe Book'];
+  return PASSPORT_THEMES['Classic Traveler'];
+}
+
+export type ActiveThemeInput =
+  | { name?: string | null }
+  | string
+  | null
+  | undefined;
+
+/**
+ * Resolve the cover theme for a passport response. Accepts either the legacy
+ * slug string returned by the backend today (e.g. `"classic_traveler"`) or
+ * the richer `{ name, kind? }` object described in the #600 spec. Falls back
+ * to a level-based default when nothing matches.
+ */
+export function resolveTheme(
+  active: ActiveThemeInput,
+  level?: number,
+): PassportTheme {
+  let rawName: string | null = null;
+  if (typeof active === 'string') {
+    rawName = active;
+  } else if (active && typeof active === 'object' && active.name) {
+    rawName = active.name;
+  }
+
+  if (rawName) {
+    const matched = normaliseName(rawName);
+    if (matched) {
+      return PASSPORT_THEMES[matched];
+    }
+  }
+
+  return themeForLevel(level);
+}


### PR DESCRIPTION
## Summary
- Added `app/mobile/src/utils/passportTheme.ts` with a typed 11-theme catalogue (Classic Traveler, Vintage Recipe Book, Street Food Explorer, Grandmother's Kitchen, Mediterranean Journal, Heritage Archive, World Kitchen Explorer, Ramazan, Eid Festival, Harvest Moon, Lunar New Year) and a `resolveTheme(active, level)` helper that accepts the backend slug string today and the future `{name, kind?}` shape, with level-based fallback (1-2 Classic, 3-5 Vintage, 6-8 Mediterranean, 9+ Heritage).
- Added standalone `app/mobile/src/components/passport/PassportCover.tsx` (180px tall cover band: glyph circle top-left, username + uppercase copy centered, level/points pill bottom-right, themed background, stripe, 2px `surfaceDark` border, descriptive `accessibilityLabel`).
- Pulled palette from existing `tokens.colors.*` so themes stay on-brand without hard-coding hexes.
- Util + component tests in `__tests__/utils/passportTheme.test.ts` and `__tests__/components/PassportCover.test.tsx` (15 tests covering exact names, slug aliases, calendar themes, level fallbacks, empty inputs, rendered username/pill/copy/glyph/a11y).
- Mobile-only change; component is standalone so sibling PR #598 can import it directly.

## Backend probe
Local backend wasn't reachable on `http://localhost`, so I traced the shape from `apps/passport/serializers.py` and `apps/passport/models.py`: `active_theme` is a `CharField(max_length=64, default='classic_traveler')` and the serializer exposes it directly as a string (e.g. `\"classic_traveler\"`, `\"aegean_voyager\"`). The resolver therefore accepts both the current string form and the `{name, kind?}` object form from the issue spec, mapping slugs (including `aegean_voyager` -> Mediterranean Journal, `ramadan` -> Ramazan) to catalogue entries via an alias table.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx jest __tests__/utils/passportTheme __tests__/components/PassportCover` -> 2 suites, 15 tests passed
- [x] Metro bundle (`/index.bundle?platform=ios&dev=false&minify=true`) returns HTTP 200 (2.3 MB)
- [ ] Reviewer: drop `<PassportCover theme={resolveTheme(passport.active_theme, passport.level)} level={passport.level} totalPoints={passport.total_points} username={user.username} />` into the passport screen and confirm visual matches mock

## Jest output
```
PASS __tests__/utils/passportTheme.test.ts
PASS __tests__/components/PassportCover.test.tsx

Test Suites: 2 passed, 2 total
Tests:       15 passed, 15 total
Snapshots:   0 total
Time:        1.818 s
```

Closes #600