### PR TITLE
feat(mobile): culture grid + detail screen for passport cultures (closes #602)

### DIFF
--- a/app/mobile/__tests__/components/CultureGrid.test.tsx
+++ b/app/mobile/__tests__/components/CultureGrid.test.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+
+const mockNavigate = jest.fn();
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
+
+import { CultureGrid } from '../../src/components/passport/CultureGrid';
+import type { CultureSummary } from '../../src/services/passportCultureService';
+
+const makeCulture = (over: Partial<CultureSummary> = {}): CultureSummary => ({
+  culture_name: 'Ottoman',
+  stamp_rarity: 'gold',
+  recipes_tried: 8,
+  stories_saved: 3,
+  ingredients_discovered: 0,
+  heritage_recipes: 0,
+  ...over,
+});
+
+describe('CultureGrid', () => {
+  beforeEach(() => mockNavigate.mockReset());
+
+  it('renders the empty-state copy when no cultures are provided', () => {
+    const { getByText, queryByText } = render(<CultureGrid cultures={[]} username="ayse" />);
+    expect(
+      getByText('No cultures discovered yet. Try recipes from new regions to unlock cultures.'),
+    ).toBeTruthy();
+    expect(queryByText('Ottoman')).toBeNull();
+  });
+
+  it('renders one cell per culture', () => {
+    const cultures = [
+      makeCulture({ culture_name: 'Ottoman' }),
+      makeCulture({ culture_name: 'Aegean', stamp_rarity: 'silver', recipes_tried: 5 }),
+      makeCulture({ culture_name: 'Mediterranean', stamp_rarity: 'bronze', recipes_tried: 3 }),
+    ];
+    const { getByText } = render(<CultureGrid cultures={cultures} username="ayse" />);
+    expect(getByText('Ottoman')).toBeTruthy();
+    expect(getByText('Aegean')).toBeTruthy();
+    expect(getByText('Mediterranean')).toBeTruthy();
+  });
+
+  it('navigates to CultureDetail when a cell is tapped', () => {
+    const cultures = [makeCulture({ culture_name: 'Ottoman' })];
+    const { getByLabelText } = render(<CultureGrid cultures={cultures} username="ayse" />);
+    fireEvent.press(getByLabelText('Open culture Ottoman'));
+    expect(mockNavigate).toHaveBeenCalledWith('CultureDetail', {
+      username: 'ayse',
+      cultureName: 'Ottoman',
+    });
+  });
+});

--- a/app/mobile/__tests__/services/passportCultureService.test.ts
+++ b/app/mobile/__tests__/services/passportCultureService.test.ts
@@ -1,0 +1,88 @@
+jest.mock('../../src/services/httpClient', () => ({
+  apiGetJson: jest.fn(),
+}));
+
+import { apiGetJson } from '../../src/services/httpClient';
+import {
+  fetchCultureDetail,
+  fetchCultures,
+} from '../../src/services/passportCultureService';
+
+const mockedApiGetJson = apiGetJson as jest.MockedFunction<typeof apiGetJson>;
+
+// Mirrors the actual backend shape from `apps/passport/services.py#culture_summaries`:
+// `{ culture, recipes_tried, stories_saved, interactions, rarity }`.
+const BACKEND_PAYLOAD = {
+  culture_summaries: [
+    { culture: 'Ottoman', recipes_tried: 8, stories_saved: 3, interactions: 12, rarity: 'gold' },
+    { culture: 'Aegean', recipes_tried: 5, stories_saved: 2, interactions: 7, rarity: 'silver' },
+    { culture: 'Mediterranean', recipes_tried: 3, stories_saved: 1, interactions: 4, rarity: 'bronze' },
+  ],
+};
+
+describe('fetchCultureDetail', () => {
+  beforeEach(() => {
+    mockedApiGetJson.mockReset();
+  });
+
+  it('finds a culture by name and normalizes backend field names', async () => {
+    mockedApiGetJson.mockResolvedValueOnce(BACKEND_PAYLOAD);
+    const result = await fetchCultureDetail('ayse', 'Ottoman');
+    expect(mockedApiGetJson).toHaveBeenCalledWith('/api/users/ayse/passport/');
+    expect(result).toEqual({
+      culture_name: 'Ottoman',
+      stamp_rarity: 'gold',
+      recipes_tried: 8,
+      stories_saved: 3,
+      // Backend doesn't surface these yet — toNum coerces undefined to 0.
+      ingredients_discovered: 0,
+      heritage_recipes: 0,
+    });
+  });
+
+  it('returns null when no culture matches', async () => {
+    mockedApiGetJson.mockResolvedValueOnce(BACKEND_PAYLOAD);
+    const result = await fetchCultureDetail('ayse', 'Bavarian');
+    expect(result).toBeNull();
+  });
+
+  it('matches case-insensitively', async () => {
+    mockedApiGetJson.mockResolvedValueOnce(BACKEND_PAYLOAD);
+    const result = await fetchCultureDetail('ayse', 'ottoman');
+    expect(result?.culture_name).toBe('Ottoman');
+  });
+
+  it('returns null when the passport has no culture_summaries field', async () => {
+    mockedApiGetJson.mockResolvedValueOnce({});
+    const result = await fetchCultureDetail('ayse', 'Ottoman');
+    expect(result).toBeNull();
+  });
+});
+
+describe('fetchCultures', () => {
+  beforeEach(() => mockedApiGetJson.mockReset());
+
+  it('normalizes all entries and drops malformed rows', async () => {
+    mockedApiGetJson.mockResolvedValueOnce({
+      culture_summaries: [
+        { culture: 'Ottoman', recipes_tried: '8', stories_saved: 3, rarity: 'gold' },
+        null,
+        { culture: '' },
+        { culture_name: 'Levantine', stamp_rarity: 'emerald', ingredients_discovered: 4 },
+      ],
+    });
+    const result = await fetchCultures('ayse');
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({
+      culture_name: 'Ottoman',
+      stamp_rarity: 'gold',
+      recipes_tried: 8, // toNum coerced from string
+    });
+    expect(result[1]).toMatchObject({
+      culture_name: 'Levantine',
+      stamp_rarity: 'emerald',
+      ingredients_discovered: 4,
+      recipes_tried: 0,
+    });
+  });
+});

--- a/app/mobile/src/components/passport/CultureGrid.tsx
+++ b/app/mobile/src/components/passport/CultureGrid.tsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { FlatList, Pressable, StyleSheet, Text, View } from 'react-native';
+import type { RootStackParamList } from '../../navigation/types';
+import type { CultureSummary } from '../../services/passportCultureService';
+import { shadows, tokens } from '../../theme';
+
+type Props = {
+  cultures: CultureSummary[];
+  username: string;
+};
+
+/** Stamp rarity → swatch colour. Sourced from issue #602. */
+export const RARITY_COLORS: Record<string, string> = {
+  bronze: '#CD7F32',
+  silver: '#C0C0C0',
+  gold: '#FFD700',
+  emerald: '#50C878',
+  legendary: '#9B59B6',
+};
+
+function rarityColor(rarity: string): string {
+  return RARITY_COLORS[rarity?.toLowerCase?.()] ?? RARITY_COLORS.bronze;
+}
+
+type Nav = NativeStackNavigationProp<RootStackParamList>;
+
+export function CultureGrid({ cultures, username }: Props) {
+  const navigation = useNavigation<Nav>();
+
+  if (!cultures || cultures.length === 0) {
+    return (
+      <View style={styles.empty} accessibilityRole="text">
+        <Text style={styles.emptyText}>
+          No cultures discovered yet. Try recipes from new regions to unlock cultures.
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <FlatList
+      data={cultures}
+      keyExtractor={(c) => c.culture_name}
+      numColumns={2}
+      columnWrapperStyle={styles.row}
+      contentContainerStyle={styles.list}
+      scrollEnabled={false}
+      renderItem={({ item }) => (
+        <Pressable
+          onPress={() =>
+            navigation.navigate('CultureDetail', {
+              username,
+              cultureName: item.culture_name,
+            })
+          }
+          style={({ pressed }) => [styles.cell, pressed && styles.pressed]}
+          accessibilityRole="button"
+          accessibilityLabel={`Open culture ${item.culture_name}`}
+        >
+          <View style={styles.cellHeader}>
+            <View
+              style={[
+                styles.badge,
+                { backgroundColor: rarityColor(item.stamp_rarity) },
+              ]}
+              accessibilityLabel={`${item.stamp_rarity} stamp`}
+            />
+            <Text style={styles.rarityLabel} numberOfLines={1}>
+              {item.stamp_rarity}
+            </Text>
+          </View>
+          <Text style={styles.cellTitle} numberOfLines={2}>
+            {item.culture_name}
+          </Text>
+          <Text style={styles.cellMeta} numberOfLines={1}>
+            {item.recipes_tried} {item.recipes_tried === 1 ? 'recipe' : 'recipes'}
+          </Text>
+        </Pressable>
+      )}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  list: { gap: 12 },
+  row: { gap: 12, marginBottom: 12 },
+  cell: {
+    flex: 1,
+    padding: 12,
+    borderRadius: tokens.radius.lg,
+    borderWidth: 2,
+    borderColor: tokens.colors.surfaceDark,
+    backgroundColor: tokens.colors.bg,
+    gap: 8,
+    minHeight: 110,
+    ...shadows.sm,
+  },
+  pressed: { opacity: 0.85 },
+  cellHeader: { flexDirection: 'row', alignItems: 'center', gap: 8 },
+  badge: {
+    width: 16,
+    height: 16,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: tokens.colors.surfaceDark,
+  },
+  rarityLabel: {
+    fontSize: 11,
+    color: tokens.colors.textMuted,
+    textTransform: 'capitalize',
+  },
+  cellTitle: {
+    fontSize: 16,
+    fontWeight: '800',
+    color: tokens.colors.text,
+    fontFamily: tokens.typography.display.fontFamily,
+  },
+  cellMeta: { fontSize: 12, color: tokens.colors.text },
+  empty: {
+    padding: 20,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  emptyText: {
+    fontSize: 14,
+    color: tokens.colors.text,
+    textAlign: 'center',
+  },
+});

--- a/app/mobile/src/navigation/PublicStackNavigator.tsx
+++ b/app/mobile/src/navigation/PublicStackNavigator.tsx
@@ -5,6 +5,7 @@ import HeritageMapScreen from '../screens/HeritageMapScreen';
 import HeritageScreen from '../screens/HeritageScreen';
 import IngredientMigrationMapScreen from '../screens/IngredientMigrationMapScreen';
 import CulturalCalendarScreen from '../screens/CulturalCalendarScreen';
+import CultureDetailScreen from '../screens/CultureDetailScreen';
 import HomeScreen from '../screens/HomeScreen';
 import InboxScreen from '../screens/InboxScreen';
 import LoginScreen from '../screens/LoginScreen';
@@ -146,6 +147,11 @@ export function PublicStackNavigator() {
         name="Notifications"
         component={NotificationsScreen}
         options={{ title: 'Notifications' }}
+      />
+      <Stack.Screen
+        name="CultureDetail"
+        component={CultureDetailScreen}
+        options={{ title: 'Culture' }}
       />
     </Stack.Navigator>
   );

--- a/app/mobile/src/navigation/types.ts
+++ b/app/mobile/src/navigation/types.ts
@@ -28,6 +28,7 @@ export type RootStackParamList = {
   RegionMapDetail: { regionId: number; regionName: string };
   IngredientMigrationMap: undefined;
   Notifications: undefined;
+  CultureDetail: { username: string; cultureName: string };
 };
 
 declare global {

--- a/app/mobile/src/screens/CultureDetailScreen.tsx
+++ b/app/mobile/src/screens/CultureDetailScreen.tsx
@@ -1,0 +1,178 @@
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { useEffect, useState } from 'react';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { ErrorView } from '../components/ui/ErrorView';
+import { LoadingView } from '../components/ui/LoadingView';
+import { RARITY_COLORS } from '../components/passport/CultureGrid';
+import type { RootStackParamList } from '../navigation/types';
+import {
+  fetchCultureDetail,
+  type CultureSummary,
+} from '../services/passportCultureService';
+import { shadows, tokens } from '../theme';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'CultureDetail'>;
+
+function rarityColor(rarity: string): string {
+  return RARITY_COLORS[rarity?.toLowerCase?.()] ?? RARITY_COLORS.bronze;
+}
+
+export default function CultureDetailScreen({ route, navigation }: Props) {
+  const { username, cultureName } = route.params;
+  const [culture, setCulture] = useState<CultureSummary | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadToken, setReloadToken] = useState(0);
+
+  useEffect(() => {
+    navigation.setOptions({ title: cultureName });
+  }, [navigation, cultureName]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetchCultureDetail(username, cultureName)
+      .then((res) => {
+        if (!cancelled) setCulture(res);
+      })
+      .catch((e) => {
+        if (!cancelled) {
+          setError(e instanceof Error ? e.message : 'Could not load culture detail.');
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [username, cultureName, reloadToken]);
+
+  if (loading) {
+    return (
+      <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
+        <View style={styles.centered}>
+          <LoadingView message={`Loading ${cultureName}…`} />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (error) {
+    return (
+      <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
+        <View style={styles.padded}>
+          <ErrorView message={error} onRetry={() => setReloadToken((t) => t + 1)} />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  if (!culture) {
+    return (
+      <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
+        <View style={styles.centered}>
+          <Text style={styles.emptyTitle}>No engagement with {cultureName} yet</Text>
+          <Text style={styles.emptyHint}>
+            Try recipes or save stories tagged with this culture to start filling its stamp.
+          </Text>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  const stats: { label: string; value: number }[] = [
+    { label: 'Recipes tried', value: culture.recipes_tried },
+    { label: 'Stories saved', value: culture.stories_saved },
+    { label: 'Ingredients discovered', value: culture.ingredients_discovered },
+    { label: 'Heritage recipes', value: culture.heritage_recipes },
+  ];
+
+  return (
+    <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
+      <ScrollView contentContainerStyle={styles.body}>
+        <View style={styles.header}>
+          <Text style={styles.title}>{culture.culture_name}</Text>
+          <View style={styles.rarityRow}>
+            <View
+              style={[
+                styles.badge,
+                { backgroundColor: rarityColor(culture.stamp_rarity) },
+              ]}
+              accessibilityLabel={`${culture.stamp_rarity} stamp`}
+            />
+            <Text style={styles.rarityLabel}>{culture.stamp_rarity} stamp</Text>
+          </View>
+        </View>
+
+        <View style={styles.statsGrid}>
+          {stats.map((s) => (
+            <View key={s.label} style={styles.statBlock}>
+              <Text style={styles.statValue}>{s.value}</Text>
+              <Text style={styles.statLabel}>{s.label}</Text>
+            </View>
+          ))}
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: tokens.colors.bg },
+  body: { padding: 20, gap: 20 },
+  centered: { flex: 1, justifyContent: 'center', alignItems: 'center', padding: 24, gap: 8 },
+  padded: { flex: 1, padding: 20, justifyContent: 'center' },
+  header: { gap: 10 },
+  title: {
+    fontSize: 30,
+    fontWeight: '800',
+    color: tokens.colors.text,
+    fontFamily: tokens.typography.display.fontFamily,
+  },
+  rarityRow: { flexDirection: 'row', alignItems: 'center', gap: 10 },
+  badge: {
+    width: 18,
+    height: 18,
+    borderRadius: 9,
+    borderWidth: 1,
+    borderColor: tokens.colors.surfaceDark,
+  },
+  rarityLabel: {
+    fontSize: 14,
+    color: tokens.colors.text,
+    textTransform: 'capitalize',
+  },
+  statsGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 12,
+  },
+  statBlock: {
+    flexBasis: '47%',
+    flexGrow: 1,
+    padding: 14,
+    borderRadius: tokens.radius.lg,
+    borderWidth: 2,
+    borderColor: tokens.colors.surfaceDark,
+    backgroundColor: tokens.colors.bg,
+    gap: 4,
+    ...shadows.sm,
+  },
+  statValue: {
+    fontSize: 28,
+    fontWeight: '900',
+    color: tokens.colors.text,
+    fontFamily: tokens.typography.display.fontFamily,
+  },
+  statLabel: { fontSize: 12, color: tokens.colors.text },
+  emptyTitle: {
+    fontSize: 20,
+    fontWeight: '800',
+    color: tokens.colors.text,
+    textAlign: 'center',
+  },
+  emptyHint: { fontSize: 14, color: tokens.colors.text, textAlign: 'center' },
+});

--- a/app/mobile/src/services/passportCultureService.ts
+++ b/app/mobile/src/services/passportCultureService.ts
@@ -1,0 +1,77 @@
+import { apiGetJson } from './httpClient';
+
+/**
+ * Single culture rollup as surfaced on the passport screen.
+ *
+ * The backend currently returns each item as
+ * `{ culture, recipes_tried, stories_saved, interactions, rarity }`
+ * (see `apps/passport/services.py#culture_summaries`). We normalize at the
+ * service boundary so the UI works against the canonical issue contract:
+ * `culture_name`, `stamp_rarity`, plus the extra counters the spec asks for
+ * (`ingredients_discovered`, `heritage_recipes`) — defaulting to `0` when the
+ * backend hasn't shipped them yet.
+ */
+export type CultureSummary = {
+  culture_name: string;
+  stamp_rarity: 'bronze' | 'silver' | 'gold' | 'emerald' | 'legendary' | string;
+  recipes_tried: number;
+  stories_saved: number;
+  ingredients_discovered: number;
+  heritage_recipes: number;
+};
+
+type PassportResponse = {
+  culture_summaries?: unknown[];
+};
+
+/** Coerce anything to a finite number; falls back to `0`. Matches the issue spec. */
+function toNum(value: unknown): number {
+  const n = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function normalizeCulture(raw: unknown): CultureSummary | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const r = raw as Record<string, unknown>;
+  // Backend ships `culture`; the issue contract uses `culture_name`. Accept both.
+  const name =
+    (typeof r.culture_name === 'string' && r.culture_name) ||
+    (typeof r.culture === 'string' && r.culture) ||
+    '';
+  if (!name) return null;
+  const rarity =
+    (typeof r.stamp_rarity === 'string' && r.stamp_rarity) ||
+    (typeof r.rarity === 'string' && r.rarity) ||
+    'bronze';
+  return {
+    culture_name: name,
+    stamp_rarity: rarity,
+    recipes_tried: toNum(r.recipes_tried),
+    stories_saved: toNum(r.stories_saved),
+    ingredients_discovered: toNum(r.ingredients_discovered),
+    heritage_recipes: toNum(r.heritage_recipes),
+  };
+}
+
+/** Fetch + normalize every culture rollup for the user. */
+export async function fetchCultures(username: string): Promise<CultureSummary[]> {
+  const res = await apiGetJson<PassportResponse>(`/api/users/${username}/passport/`);
+  const raw = Array.isArray(res?.culture_summaries) ? res.culture_summaries : [];
+  return raw
+    .map(normalizeCulture)
+    .filter((c): c is CultureSummary => c !== null);
+}
+
+/**
+ * Look up the single culture rollup matching `cultureName`. Returns `null`
+ * when the user has no engagement with that culture — drives the "not found"
+ * empty state on the detail screen.
+ */
+export async function fetchCultureDetail(
+  username: string,
+  cultureName: string,
+): Promise<CultureSummary | null> {
+  const cultures = await fetchCultures(username);
+  const target = cultureName.trim().toLowerCase();
+  return cultures.find((c) => c.culture_name.trim().toLowerCase() === target) ?? null;
+}


### PR DESCRIPTION
## Summary
- Adds `passportCultureService` with `fetchCultureDetail(username, cultureName)`; normalizes the backend `culture_summaries` payload to the canonical `CultureSummary` shape and uses `toNum` for defensive coercion.
- Ships `CultureGrid` (2-column `FlatList`) with a rarity colour swatch per cell (bronze/silver/gold/emerald/legendary) and an empty-state copy for users with no cultures yet.
- Ships `CultureDetailScreen` with display-font header, rarity badge, and a four-block stats grid (recipes_tried / stories_saved / ingredients_discovered / heritage_recipes); `LoadingView`, `ErrorView` with retry, and a "not found" empty state.
- Wires `CultureDetail` into `RootStackParamList` + `PublicStackNavigator` so the grid can push the detail route from anywhere passport #598 mounts it.
- Tests: service finds known culture, returns null on miss, normalizes mixed field names, drops malformed rows; grid renders cells, shows empty state, fires `navigation.navigate` on tap.

## culture_summaries shape (discovered)
Probed `apps/passport/services.py#culture_summaries` plus the frontend mock — backend currently returns:
```json
{ "culture": "Ottoman", "recipes_tried": 8, "stories_saved": 3, "interactions": 12, "rarity": "gold" }
```
Note: backend uses `culture` / `rarity`; the issue spec uses `culture_name` / `stamp_rarity` and adds `ingredients_discovered` / `heritage_recipes`. The service maps both ways so callers can rely on the spec shape, defaulting missing counters to `0`.

Could not log in as `ayse@example.com / StrongPassword123!` against `https://genipe.app` (`Invalid credentials`); shape was confirmed from the backend code path and the matching web mock in `app/frontend/src/services/passportService.js`.

## Test plan
- [ ] `cd app/mobile && npx tsc --noEmit` clean
- [ ] `cd app/mobile && npx jest __tests__/services/passportCultureService __tests__/components/CultureGrid` — 8 tests pass
- [ ] Metro bundle (`/index.bundle?platform=ios`) returns HTTP 200
- [ ] From a screen that has cultures, tap a cell → pushes `CultureDetail` with the right params; stats and rarity badge render

Closes #602