### PR TITLE
feat(mobile): StampCollection component — categorised stamps with rarity colours, lock state, accordion (closes #601)

### DIFF
--- a/app/mobile/__tests__/components/StampCollection.test.tsx
+++ b/app/mobile/__tests__/components/StampCollection.test.tsx
@@ -1,0 +1,153 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import {
+  StampCollection,
+  normalizeStamp,
+  type Stamp,
+} from '../../src/components/passport/StampCollection';
+
+const stamp = (over: Partial<Stamp> = {}): Stamp => ({
+  id: 1,
+  name: 'Anatolian',
+  category: 'heritage',
+  rarity: 'emerald',
+  earned_at: '2026-03-10T12:00:00Z',
+  ...over,
+});
+
+describe('StampCollection', () => {
+  it('renders the empty state when there are no stamps', () => {
+    const { getByText, getByLabelText } = render(<StampCollection stamps={[]} />);
+    expect(getByLabelText('Stamp collection empty')).toBeTruthy();
+    expect(
+      getByText(
+        'No stamps earned yet. Try recipes from a new region to earn your first.',
+      ),
+    ).toBeTruthy();
+  });
+
+  it('renders a loading state when loading', () => {
+    const { getByLabelText } = render(
+      <StampCollection stamps={[]} loading />,
+    );
+    expect(getByLabelText('Stamp collection loading')).toBeTruthy();
+  });
+
+  it('groups stamps by category and shows count badges', () => {
+    const stamps: Stamp[] = [
+      stamp({ id: 1, name: 'Anatolian', category: 'heritage' }),
+      stamp({ id: 2, name: 'Black Sea', category: 'heritage' }),
+      stamp({
+        id: 3,
+        name: 'First Story',
+        category: 'story',
+        rarity: 'bronze',
+      }),
+    ];
+    const { getByText } = render(<StampCollection stamps={stamps} />);
+    expect(getByText('Heritage')).toBeTruthy();
+    expect(getByText('Story')).toBeTruthy();
+    expect(getByText('2')).toBeTruthy();
+    expect(getByText('1')).toBeTruthy();
+    expect(getByText('Anatolian')).toBeTruthy();
+    expect(getByText('First Story')).toBeTruthy();
+  });
+
+  it('formats earned date as "MMM YYYY"', () => {
+    const { getByText } = render(
+      <StampCollection
+        stamps={[stamp({ earned_at: '2026-03-10T12:00:00Z' })]}
+      />,
+    );
+    expect(getByText('Mar 2026')).toBeTruthy();
+  });
+
+  it('renders locked stamps with a lock glyph and no date', () => {
+    const stamps: Stamp[] = [
+      stamp({
+        id: 9,
+        name: 'Hidden Heritage',
+        category: 'heritage',
+        rarity: 'legendary',
+        earned_at: null,
+        is_locked: true,
+      }),
+    ];
+    const { getByText, getByLabelText, queryByText } = render(
+      <StampCollection stamps={stamps} />,
+    );
+    expect(getByText('🔒')).toBeTruthy();
+    expect(queryByText(/2026/)).toBeNull();
+    // a11y label includes "locked"
+    expect(
+      getByLabelText('Hidden Heritage, Legendary, locked'),
+    ).toBeTruthy();
+  });
+
+  it('toggles a category open/closed when its header is pressed', () => {
+    const stamps: Stamp[] = [
+      stamp({ id: 1, name: 'Anatolian', category: 'heritage' }),
+    ];
+    const { getByLabelText, queryByText } = render(
+      <StampCollection stamps={stamps} />,
+    );
+    expect(queryByText('Anatolian')).toBeTruthy();
+    fireEvent.press(getByLabelText('Heritage stamps, 1 expanded'));
+    expect(queryByText('Anatolian')).toBeNull();
+    fireEvent.press(getByLabelText('Heritage stamps, 1 collapsed'));
+    expect(queryByText('Anatolian')).toBeTruthy();
+  });
+
+  it('exposes accessibility labels with name, rarity and status', () => {
+    const stamps: Stamp[] = [
+      stamp({
+        id: 1,
+        name: 'Anatolian',
+        rarity: 'gold',
+        earned_at: '2026-01-05T00:00:00Z',
+      }),
+    ];
+    const { getByLabelText } = render(<StampCollection stamps={stamps} />);
+    expect(getByLabelText('Anatolian, Gold, earned Jan 2026')).toBeTruthy();
+  });
+});
+
+describe('normalizeStamp', () => {
+  it('aliases backend culture/kind/unlocked_at keys', () => {
+    const s = normalizeStamp({
+      id: 7,
+      culture: 'Black Sea',
+      kind: 'heritage',
+      tier: 'emerald',
+      unlocked_at: '2026-02-01T00:00:00Z',
+    });
+    expect(s.name).toBe('Black Sea');
+    expect(s.category).toBe('heritage');
+    expect(s.rarity).toBe('emerald');
+    expect(s.earned_at).toBe('2026-02-01T00:00:00Z');
+  });
+
+  it('prefers explicit name/category/rarity/earned_at when present', () => {
+    const s = normalizeStamp({
+      id: 1,
+      name: 'Explicit',
+      culture: 'Ignored',
+      category: 'story',
+      kind: 'recipe',
+      rarity: 'silver',
+      earned_at: '2026-04-04T00:00:00Z',
+    });
+    expect(s.name).toBe('Explicit');
+    expect(s.category).toBe('story');
+    expect(s.rarity).toBe('silver');
+    expect(s.earned_at).toBe('2026-04-04T00:00:00Z');
+  });
+
+  it('falls back to safe defaults for missing fields', () => {
+    const s = normalizeStamp({});
+    expect(s.name).toBe('Stamp');
+    expect(s.category).toBe('other');
+    expect(s.rarity).toBe('bronze');
+    expect(s.earned_at).toBeNull();
+  });
+});

--- a/app/mobile/src/components/passport/StampCollection.tsx
+++ b/app/mobile/src/components/passport/StampCollection.tsx
@@ -1,0 +1,455 @@
+import React, { useMemo, useState } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { tokens } from '../../theme';
+
+/**
+ * Stamp collection tab body for the user passport (#601).
+ *
+ * Standalone, reusable component — does NOT touch PassportScreen. PR #781
+ * scaffolds the passport tab bar and will import this component into the
+ * Stamps tab body.
+ *
+ * Backend probe of GET /api/users/<username>/passport/ returned items with
+ * keys: { id, culture, category, rarity, earned_at, source_recipe,
+ * source_story }. There is currently no `name`, `is_locked`, or
+ * `progress_percent` field on the wire — `normalizeStamp` aliases `culture`
+ * onto `name` so older / future shapes still render.
+ */
+
+export type StampRarity =
+  | 'bronze'
+  | 'silver'
+  | 'gold'
+  | 'emerald'
+  | 'legendary'
+  | string;
+
+export type StampCategory =
+  | 'recipe'
+  | 'story'
+  | 'heritage'
+  | 'exploration'
+  | 'community'
+  | string;
+
+export type Stamp = {
+  id: number | string;
+  name: string;
+  category: StampCategory;
+  rarity: StampRarity;
+  earned_at: string | null;
+  progress_percent?: number;
+  is_locked?: boolean;
+};
+
+type Props = {
+  stamps: Stamp[];
+  loading?: boolean;
+};
+
+const RARITY_COLOURS: Record<string, string> = {
+  bronze: '#CD7F32',
+  silver: '#C0C0C0',
+  gold: '#FFD700',
+  emerald: '#50C878',
+  legendary: '#9B59B6',
+};
+
+const CATEGORY_ORDER: StampCategory[] = [
+  'recipe',
+  'story',
+  'heritage',
+  'exploration',
+  'community',
+];
+
+const CATEGORY_LABELS: Record<string, string> = {
+  recipe: 'Recipe',
+  story: 'Story',
+  heritage: 'Heritage',
+  exploration: 'Exploration',
+  community: 'Community',
+};
+
+const titleCase = (s: string): string =>
+  s ? s.charAt(0).toUpperCase() + s.slice(1).toLowerCase() : s;
+
+const categoryLabel = (cat: string): string =>
+  CATEGORY_LABELS[cat] || titleCase(cat || 'Other');
+
+const rarityLabel = (rarity: string): string => titleCase(rarity || 'Stamp');
+
+const rarityColour = (rarity: string): string =>
+  RARITY_COLOURS[(rarity || '').toLowerCase()] || tokens.colors.primary;
+
+const formatEarned = (iso: string | null | undefined): string => {
+  if (!iso) return '';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  const months = [
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec',
+  ];
+  return `${months[d.getMonth()]} ${d.getFullYear()}`;
+};
+
+/**
+ * Map a raw stamp object from the backend (or anywhere) onto the shape this
+ * component understands. Robust against minor key drift — e.g. backend's
+ * `culture` is aliased onto `name`, `kind` onto `category`, `unlocked_at`
+ * onto `earned_at`. Unknown shapes fall back to sensible defaults so the
+ * row never blanks.
+ */
+export function normalizeStamp(raw: any): Stamp {
+  const r = raw || {};
+  const name: string =
+    r.name ?? r.title ?? r.label ?? r.culture ?? r.heritage_group ?? 'Stamp';
+  const category: string = r.category ?? r.kind ?? r.type ?? 'other';
+  const rarity: string = r.rarity ?? r.tier ?? r.level ?? 'bronze';
+  const earned_at: string | null =
+    r.earned_at ?? r.unlocked_at ?? r.acquired_at ?? r.awarded_at ?? null;
+  const progress_percent: number | undefined =
+    typeof r.progress_percent === 'number'
+      ? r.progress_percent
+      : typeof r.progress === 'number'
+        ? r.progress
+        : undefined;
+  const is_locked: boolean | undefined =
+    typeof r.is_locked === 'boolean'
+      ? r.is_locked
+      : typeof r.locked === 'boolean'
+        ? r.locked
+        : undefined;
+  return {
+    id: r.id ?? r.pk ?? `${name}-${category}-${rarity}`,
+    name: String(name),
+    category,
+    rarity,
+    earned_at,
+    progress_percent,
+    is_locked,
+  };
+}
+
+const isLocked = (s: Stamp): boolean =>
+  s.is_locked === true || s.earned_at == null;
+
+function groupByCategory(stamps: Stamp[]): Array<[string, Stamp[]]> {
+  const map = new Map<string, Stamp[]>();
+  for (const s of stamps) {
+    const key = (s.category || 'other').toLowerCase();
+    if (!map.has(key)) map.set(key, []);
+    map.get(key)!.push(s);
+  }
+  // Sort: known categories first in declared order, then alphabetical for the rest.
+  const keys = Array.from(map.keys());
+  keys.sort((a, b) => {
+    const ai = CATEGORY_ORDER.indexOf(a as StampCategory);
+    const bi = CATEGORY_ORDER.indexOf(b as StampCategory);
+    if (ai !== -1 && bi !== -1) return ai - bi;
+    if (ai !== -1) return -1;
+    if (bi !== -1) return 1;
+    return a.localeCompare(b);
+  });
+  return keys.map((k) => [k, map.get(k)!]);
+}
+
+export function StampCollection({ stamps, loading = false }: Props) {
+  const groups = useMemo(() => groupByCategory(stamps || []), [stamps]);
+  const [collapsed, setCollapsed] = useState<Record<string, boolean>>({});
+
+  const toggle = (cat: string) =>
+    setCollapsed((c) => ({ ...c, [cat]: !c[cat] }));
+
+  if (loading) {
+    return (
+      <View style={styles.container} accessibilityLabel="Stamp collection loading">
+        <Text style={styles.loadingText}>Loading stamps…</Text>
+      </View>
+    );
+  }
+
+  if (!stamps || stamps.length === 0) {
+    return (
+      <View style={styles.container} accessibilityLabel="Stamp collection empty">
+        <View style={styles.emptyCard}>
+          <Text style={styles.emptyTitle}>No stamps yet</Text>
+          <Text style={styles.emptyBody}>
+            No stamps earned yet. Try recipes from a new region to earn your
+            first.
+          </Text>
+        </View>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container} accessibilityLabel="Stamp collection">
+      {groups.map(([category, items]) => {
+        const isOpen = !collapsed[category];
+        return (
+          <View key={category} style={styles.group}>
+            <Pressable
+              onPress={() => toggle(category)}
+              accessibilityRole="button"
+              accessibilityLabel={`${categoryLabel(category)} stamps, ${items.length} ${
+                isOpen ? 'expanded' : 'collapsed'
+              }`}
+              style={({ pressed }) => [
+                styles.groupHeader,
+                pressed && styles.pressed,
+              ]}
+            >
+              <Text style={styles.groupTitle}>{categoryLabel(category)}</Text>
+              <View style={styles.headerRight}>
+                <View style={styles.countBadge}>
+                  <Text style={styles.countBadgeText}>{items.length}</Text>
+                </View>
+                <Text style={styles.chevron}>{isOpen ? '▾' : '▸'}</Text>
+              </View>
+            </Pressable>
+
+            {isOpen ? (
+              <View style={styles.rows}>
+                {items.map((stamp) => {
+                  const locked = isLocked(stamp);
+                  const swatch = rarityColour(stamp.rarity);
+                  const dateStr = formatEarned(stamp.earned_at);
+                  const progress =
+                    typeof stamp.progress_percent === 'number'
+                      ? Math.max(0, Math.min(100, stamp.progress_percent))
+                      : null;
+                  const a11y = [
+                    stamp.name,
+                    rarityLabel(stamp.rarity),
+                    locked
+                      ? 'locked'
+                      : dateStr
+                        ? `earned ${dateStr}`
+                        : 'earned',
+                  ].join(', ');
+                  return (
+                    <View
+                      key={String(stamp.id)}
+                      accessibilityLabel={a11y}
+                      style={[styles.row, locked && styles.rowLocked]}
+                    >
+                      <View
+                        style={[
+                          styles.swatch,
+                          {
+                            backgroundColor: locked ? '#B8B8B8' : swatch,
+                            borderColor: locked ? '#8A8A8A' : '#1A1A1A',
+                          },
+                        ]}
+                      >
+                        {locked ? <Text style={styles.lockGlyph}>🔒</Text> : null}
+                      </View>
+                      <View style={styles.rowBody}>
+                        <Text
+                          style={[styles.rowName, locked && styles.rowNameLocked]}
+                          numberOfLines={1}
+                        >
+                          {stamp.name}
+                        </Text>
+                        <View style={styles.rowMetaRow}>
+                          <Text style={styles.rowMeta}>
+                            {rarityLabel(stamp.rarity)}
+                          </Text>
+                          {!locked && dateStr ? (
+                            <>
+                              <Text style={styles.dot}>·</Text>
+                              <Text style={styles.rowMeta}>{dateStr}</Text>
+                            </>
+                          ) : null}
+                        </View>
+                        {progress != null ? (
+                          <View
+                            style={styles.progressTrack}
+                            accessibilityLabel={`progress ${progress} percent`}
+                          >
+                            <View
+                              style={[
+                                styles.progressFill,
+                                {
+                                  width: `${progress}%`,
+                                  backgroundColor: locked ? '#8A8A8A' : swatch,
+                                },
+                              ]}
+                            />
+                          </View>
+                        ) : null}
+                      </View>
+                    </View>
+                  );
+                })}
+              </View>
+            ) : null}
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+export default StampCollection;
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: 16,
+    paddingTop: 12,
+    paddingBottom: 24,
+    gap: 12,
+  },
+  loadingText: {
+    ...tokens.typography.body,
+    color: tokens.colors.textMuted,
+    paddingVertical: 24,
+    textAlign: 'center',
+  },
+  emptyCard: {
+    backgroundColor: tokens.colors.bg,
+    borderRadius: tokens.radius.lg,
+    borderWidth: 1,
+    borderColor: tokens.colors.primaryBorder,
+    padding: 20,
+    alignItems: 'center',
+    gap: 6,
+  },
+  emptyTitle: {
+    ...tokens.typography.display,
+    fontSize: 18,
+    color: tokens.colors.text,
+  },
+  emptyBody: {
+    ...tokens.typography.body,
+    color: tokens.colors.textMuted,
+    textAlign: 'center',
+  },
+  group: {
+    borderRadius: tokens.radius.md,
+    borderWidth: 1,
+    borderColor: tokens.colors.primaryBorder,
+    backgroundColor: tokens.colors.bg,
+    overflow: 'hidden',
+  },
+  groupHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    backgroundColor: tokens.colors.primarySubtle,
+  },
+  pressed: {
+    opacity: 0.7,
+  },
+  groupTitle: {
+    ...tokens.typography.display,
+    fontSize: 16,
+    color: tokens.colors.text,
+  },
+  headerRight: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  countBadge: {
+    minWidth: 24,
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: tokens.radius.pill,
+    backgroundColor: tokens.colors.primary,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  countBadgeText: {
+    ...tokens.typography.body,
+    color: tokens.colors.textOnDark,
+    fontSize: 12,
+    fontWeight: '700',
+  },
+  chevron: {
+    ...tokens.typography.body,
+    color: tokens.colors.text,
+    fontSize: 14,
+  },
+  rows: {
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    gap: 8,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    padding: 10,
+    borderRadius: tokens.radius.sm,
+    backgroundColor: '#FFFFFF',
+    borderWidth: 1,
+    borderColor: tokens.colors.primaryBorder,
+  },
+  rowLocked: {
+    backgroundColor: '#ECECEC',
+    borderColor: '#CFCFCF',
+  },
+  swatch: {
+    width: 36,
+    height: 36,
+    borderRadius: tokens.radius.pill,
+    borderWidth: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  lockGlyph: {
+    fontSize: 16,
+  },
+  rowBody: {
+    flex: 1,
+    gap: 2,
+  },
+  rowName: {
+    ...tokens.typography.body,
+    fontSize: 15,
+    fontWeight: '600',
+    color: tokens.colors.text,
+  },
+  rowNameLocked: {
+    color: '#6B6B6B',
+  },
+  rowMetaRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  rowMeta: {
+    ...tokens.typography.body,
+    fontSize: 12,
+    color: tokens.colors.textMuted,
+  },
+  dot: {
+    color: tokens.colors.textMuted,
+    fontSize: 12,
+  },
+  progressTrack: {
+    marginTop: 6,
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: 'rgba(0,0,0,0.08)',
+    overflow: 'hidden',
+  },
+  progressFill: {
+    height: '100%',
+    borderRadius: 2,
+  },
+});


### PR DESCRIPTION
## Summary
- Adds a standalone, reusable \`StampCollection\` component for the passport Stamps tab (issue #601). Groups stamps by category (Recipe / Story / Heritage / Exploration / Community) into collapsible accordions with a count badge per group.
- Each row shows a rarity colour swatch (Bronze \`#CD7F32\`, Silver \`#C0C0C0\`, Gold \`#FFD700\`, Emerald \`#50C878\`, Legendary \`#9B59B6\`), the stamp name, the earned date formatted as "MMM YYYY", and an optional small progress bar when \`progress_percent\` is supplied.
- Locked stamps (\`is_locked: true\` or \`earned_at: null\`) render with a grey background and a 🔒 glyph, with no date.
- Empty state copy: "No stamps earned yet. Try recipes from a new region to earn your first." A11y label on every row includes name, rarity, and earned/locked status.
- Ships with \`normalizeStamp(raw)\` so the component is robust to backend key drift; PR #781 (or a follow-up) needs to import it into the passport Stamps tab body — this PR intentionally does not touch \`PassportScreen.tsx\`.

## Backend probe — actual stamp shape
Live-probed \`POST /api/auth/login/\` then \`GET /api/users/ayse/passport/\` against the local docker stack. The \`stamps\` array contains items shaped like:

\`\`\`json
{
  "id": 2,
  "culture": "Anatolian",
  "category": "heritage",
  "rarity": "emerald",
  "earned_at": "2026-05-12T10:58:38.172387Z",
  "source_recipe": 12,
  "source_story": null
}
\`\`\`

Notable gaps vs. the component's \`Stamp\` type: there is no \`name\`, no \`is_locked\`, and no \`progress_percent\` on the wire today. \`normalizeStamp\` aliases handle this:

- \`culture\` / \`title\` / \`label\` / \`heritage_group\` → \`name\`
- \`kind\` / \`type\` → \`category\`
- \`tier\` / \`level\` → \`rarity\`
- \`unlocked_at\` / \`acquired_at\` / \`awarded_at\` → \`earned_at\`
- \`progress\` → \`progress_percent\`
- \`locked\` → \`is_locked\`
- \`pk\` → \`id\`

So today's payload renders correctly (culture displays as the stamp name) and the component is forward-compatible once backend adds first-class \`name\` / lock / progress fields.

## Test plan
- [x] \`npx tsc --noEmit\` is clean.
- [x] \`npx jest __tests__/components/StampCollection\` — 10/10 pass (empty state, loading, grouping, count badges, date formatting, locked rendering, accordion toggle, a11y labels, normalizeStamp aliasing/defaults).
- [x] \`npx expo start --no-dev --minify\` Metro bundle returns HTTP 200 for \`/index.bundle?platform=ios\`.
- [ ] After PR #781 merges (or via a follow-up), wire \`<StampCollection stamps={stamps.map(normalizeStamp)} />\` into the Stamps tab body of \`PassportScreen.tsx\`.

Closes #601