### PR TITLE
feat(mobile): PassportWorldMap component — engagement-coloured pins + tap-to-summary (closes #603)

### DIFF
--- a/app/mobile/__tests__/components/PassportWorldMap.test.tsx
+++ b/app/mobile/__tests__/components/PassportWorldMap.test.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+import { render } from '@testing-library/react-native';
+
+// Mock react-native-maps with plain RN views so jest-expo (jsdom-ish RN env)
+// can render the component without the native module. We forward `pinColor`,
+// `coordinate`, `title`, `description` and `testID` so the tests can still
+// assert on pin count + colour computation through props.
+jest.mock('react-native-maps', () => {
+  const ReactInner = require('react');
+  const { View: RNView, Text: RNText } = require('react-native');
+  const MapView = ReactInner.forwardRef(
+    ({ children, ...rest }: any, ref: any) =>
+      ReactInner.createElement(RNView, { ref, ...rest, testID: rest.testID ?? 'mock-map' }, children),
+  );
+  const Marker = (props: any) =>
+    ReactInner.createElement(
+      RNView,
+      {
+        testID: props.testID ?? `marker-${props.title ?? ''}`,
+        accessibilityLabel: `marker:${props.title ?? ''}:${props.pinColor ?? ''}`,
+      },
+      props.children,
+    );
+  const Callout = (props: any) => ReactInner.createElement(RNView, null, props.children);
+  return { __esModule: true, default: MapView, MapView, Marker, Callout };
+});
+
+import { PassportWorldMap, type CultureSummary } from '../../src/components/passport/PassportWorldMap';
+
+function makeCulture(over: Partial<CultureSummary>): CultureSummary {
+  return {
+    culture_name: 'Aegean',
+    stamp_rarity: 'bronze',
+    recipes_tried: 0,
+    stories_saved: 0,
+    ingredients_discovered: 0,
+    heritage_recipes: 0,
+    ...over,
+  };
+}
+
+describe('PassportWorldMap', () => {
+  it('renders one Marker per culture with engagement + known coords', () => {
+    const cultures: CultureSummary[] = [
+      makeCulture({ culture_name: 'Aegean', stamp_rarity: 'silver', stories_saved: 2 }),
+      makeCulture({ culture_name: 'Marmara', stamp_rarity: 'bronze', recipes_tried: 1 }),
+      makeCulture({ culture_name: 'Anatolian', stamp_rarity: 'emerald', heritage_recipes: 1 }),
+    ];
+    const { getByTestId } = render(<PassportWorldMap cultures={cultures} />);
+    expect(getByTestId('passport-pin-Aegean')).toBeTruthy();
+    expect(getByTestId('passport-pin-Marmara')).toBeTruthy();
+    expect(getByTestId('passport-pin-Anatolian')).toBeTruthy();
+  });
+
+  it('skips cultures with no engagement (level 0)', () => {
+    const cultures: CultureSummary[] = [
+      makeCulture({ culture_name: 'Aegean', stamp_rarity: '', recipes_tried: 0, stories_saved: 0 }),
+      makeCulture({ culture_name: 'Marmara', stamp_rarity: 'bronze', recipes_tried: 1 }),
+    ];
+    const { queryByTestId } = render(<PassportWorldMap cultures={cultures} />);
+    expect(queryByTestId('passport-pin-Aegean')).toBeNull();
+    expect(queryByTestId('passport-pin-Marmara')).toBeTruthy();
+  });
+
+  it('skips cultures whose name has no regionGeo centroid', () => {
+    const cultures: CultureSummary[] = [
+      makeCulture({ culture_name: 'Atlantis', stamp_rarity: 'emerald' }),
+      makeCulture({ culture_name: 'Anatolian', stamp_rarity: 'emerald' }),
+    ];
+    const { queryByTestId } = render(<PassportWorldMap cultures={cultures} />);
+    expect(queryByTestId('passport-pin-Atlantis')).toBeNull();
+    expect(queryByTestId('passport-pin-Anatolian')).toBeTruthy();
+  });
+
+  it('colours each pin by engagement level (silver / bronze / emerald / purple)', () => {
+    const cultures: CultureSummary[] = [
+      makeCulture({ culture_name: 'Aegean', stamp_rarity: 'silver' }),
+      makeCulture({ culture_name: 'Marmara', stamp_rarity: 'bronze' }),
+      makeCulture({ culture_name: 'Anatolian', stamp_rarity: 'emerald' }),
+      makeCulture({ culture_name: 'Persian', stamp_rarity: 'legendary' }),
+    ];
+    const { getByTestId } = render(<PassportWorldMap cultures={cultures} />);
+    expect(getByTestId('passport-pin-Aegean').props.accessibilityLabel).toContain('#C0C0C0');
+    expect(getByTestId('passport-pin-Marmara').props.accessibilityLabel).toContain('#CD7F32');
+    expect(getByTestId('passport-pin-Anatolian').props.accessibilityLabel).toContain('#50C878');
+    expect(getByTestId('passport-pin-Persian').props.accessibilityLabel).toContain('#9B59B6');
+  });
+
+  it('renders the empty banner when no pins are placeable', () => {
+    const { getByText } = render(<PassportWorldMap cultures={[]} />);
+    expect(getByText(/No cultures with map coordinates yet/i)).toBeTruthy();
+  });
+});
+
+// Silence the unused-import warning when this file is tree-shaken in CI.
+export const _keepAlive = { View, Text };

--- a/app/mobile/__tests__/utils/engagementLevel.test.ts
+++ b/app/mobile/__tests__/utils/engagementLevel.test.ts
@@ -1,0 +1,143 @@
+import {
+  ENGAGEMENT_COLORS,
+  colorForLevel,
+  engagementLevel,
+} from '../../src/utils/engagementLevel';
+
+describe('engagementLevel', () => {
+  it('returns 0 when the culture is null or undefined', () => {
+    expect(engagementLevel(null)).toBe(0);
+    expect(engagementLevel(undefined)).toBe(0);
+  });
+
+  it('returns 0 when there is no engagement signal of any kind', () => {
+    expect(
+      engagementLevel({
+        culture_name: 'Aegean',
+        stamp_rarity: '',
+        recipes_tried: 0,
+        stories_saved: 0,
+        heritage_recipes: 0,
+      }),
+    ).toBe(0);
+  });
+
+  it('returns 1 (silver) for stories-saved-only', () => {
+    expect(
+      engagementLevel({
+        culture_name: 'Aegean',
+        stamp_rarity: '',
+        recipes_tried: 0,
+        stories_saved: 2,
+        heritage_recipes: 0,
+      }),
+    ).toBe(1);
+  });
+
+  it('returns 1 (silver) when rarity is silver even with zero counters', () => {
+    expect(engagementLevel({ culture_name: 'Aegean', stamp_rarity: 'silver' })).toBe(1);
+  });
+
+  it('returns 2 (bronze) for at least one recipe tried', () => {
+    expect(
+      engagementLevel({
+        culture_name: 'Marmara',
+        stamp_rarity: '',
+        recipes_tried: 1,
+        stories_saved: 0,
+        heritage_recipes: 0,
+      }),
+    ).toBe(2);
+  });
+
+  it('returns 2 (bronze) when rarity is bronze', () => {
+    expect(engagementLevel({ culture_name: 'Marmara', stamp_rarity: 'bronze' })).toBe(2);
+  });
+
+  it('returns 3 (emerald) for an explicit heritage_recipes count', () => {
+    expect(
+      engagementLevel({
+        culture_name: 'Anatolian',
+        stamp_rarity: '',
+        recipes_tried: 0,
+        stories_saved: 0,
+        heritage_recipes: 1,
+      }),
+    ).toBe(3);
+  });
+
+  it('returns 3 (emerald) when rarity is emerald or gold', () => {
+    expect(engagementLevel({ culture_name: 'Anatolian', stamp_rarity: 'emerald' })).toBe(3);
+    expect(engagementLevel({ culture_name: 'Anatolian', stamp_rarity: 'gold' })).toBe(3);
+  });
+
+  it('returns 4 (legendary) and prefers it over every other signal', () => {
+    expect(
+      engagementLevel({
+        culture_name: 'Persian',
+        stamp_rarity: 'legendary',
+        recipes_tried: 0,
+        stories_saved: 0,
+        heritage_recipes: 0,
+      }),
+    ).toBe(4);
+    // Legendary still wins when counters look like a bronze tier.
+    expect(
+      engagementLevel({
+        culture_name: 'Persian',
+        stamp_rarity: 'legendary',
+        recipes_tried: 99,
+        stories_saved: 99,
+        heritage_recipes: 99,
+      }),
+    ).toBe(4);
+  });
+
+  it('falls back to counters when the rarity string is unknown', () => {
+    expect(
+      engagementLevel({
+        culture_name: 'Caucasian',
+        stamp_rarity: 'mystery-tier',
+        recipes_tried: 0,
+        stories_saved: 1,
+        heritage_recipes: 0,
+      }),
+    ).toBe(1);
+  });
+
+  it('accepts the raw backend keys (`culture` + `rarity`)', () => {
+    expect(
+      engagementLevel({
+        culture: 'Black Sea',
+        rarity: 'emerald',
+      } as any),
+    ).toBe(3);
+  });
+
+  it('tolerates missing optional fields without throwing', () => {
+    expect(engagementLevel({ culture_name: 'X' } as any)).toBe(0);
+  });
+
+  it('rarity is case-insensitive', () => {
+    expect(engagementLevel({ culture_name: 'Z', stamp_rarity: 'LEGENDARY' })).toBe(4);
+    expect(engagementLevel({ culture_name: 'Z', stamp_rarity: 'Emerald' })).toBe(3);
+  });
+});
+
+describe('colorForLevel', () => {
+  it('returns null for level 0', () => {
+    expect(colorForLevel(0)).toBeNull();
+  });
+
+  it('returns silver / bronze / emerald / purple for levels 1..4', () => {
+    expect(colorForLevel(1)).toBe('#C0C0C0');
+    expect(colorForLevel(2)).toBe('#CD7F32');
+    expect(colorForLevel(3)).toBe('#50C878');
+    expect(colorForLevel(4)).toBe('#9B59B6');
+  });
+
+  it('exports the same colours via ENGAGEMENT_COLORS', () => {
+    expect(ENGAGEMENT_COLORS[1]).toBe('#C0C0C0');
+    expect(ENGAGEMENT_COLORS[4]).toBe('#9B59B6');
+  });
+});

--- a/app/mobile/src/components/passport/PassportWorldMap.tsx
+++ b/app/mobile/src/components/passport/PassportWorldMap.tsx
@@ -1,0 +1,187 @@
+import React, { useMemo, useRef } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import MapView, { Callout, Marker } from 'react-native-maps';
+import { MapZoomControls } from '../map/MapZoomControls';
+import { coordsForRegion, INITIAL_MAP_REGION, type LatLng } from '../../utils/regionGeo';
+import {
+  ENGAGEMENT_LABELS,
+  colorForLevel,
+  engagementLevel,
+  type EngagementLevel,
+} from '../../utils/engagementLevel';
+import { shadows, tokens } from '../../theme';
+
+/**
+ * Local mirror of the passport `CultureSummary` shape. PR #784 is still open
+ * at the time of writing, so we don't import from
+ * `services/passportCultureService` to keep this component a self-contained,
+ * drop-in module that the follow-up wire-up can plug straight into the Map tab
+ * on `PassportScreen`. Keys mirror the service-layer normalization (and stay
+ * tolerant of the raw backend keys — see `engagementLevel`).
+ */
+export type CultureSummary = {
+  culture_name: string;
+  stamp_rarity: 'bronze' | 'silver' | 'gold' | 'emerald' | 'legendary' | string;
+  recipes_tried: number;
+  stories_saved: number;
+  ingredients_discovered: number;
+  heritage_recipes: number;
+};
+
+type Props = {
+  cultures: CultureSummary[];
+  /** Optional override — defaults to a 360pt frame inside the Map tab. */
+  height?: number;
+};
+
+type Pin = {
+  culture: CultureSummary;
+  coords: LatLng;
+  level: Exclude<EngagementLevel, 0>;
+};
+
+const MAP_HEIGHT = 360;
+
+/**
+ * Embedded world map for the cultural passport. Renders one pin per culture
+ * the user has any engagement with, coloured by the `engagementLevel` ladder
+ * (silver → bronze → emerald → legendary purple). Cultures without a known
+ * region centroid in `regionGeo` are silently skipped — the parent screen
+ * can surface a side-list for those if the design needs it later.
+ *
+ * Markers use native `pinColor` (default platform teardrop) following the
+ * pattern locked in by #769 — custom `borderRadius` views snapshotted as
+ * squares on Android, so we don't try to draw bespoke circles here. Legendary
+ * pins still get a star glyph inside their Callout to call them out.
+ */
+export function PassportWorldMap({ cultures, height = MAP_HEIGHT }: Props) {
+  const mapRef = useRef<MapView | null>(null);
+
+  const pins = useMemo<Pin[]>(() => {
+    const out: Pin[] = [];
+    for (const culture of cultures ?? []) {
+      const level = engagementLevel(culture);
+      if (level === 0) continue;
+      const coords = coordsForRegion(culture.culture_name);
+      if (!coords) continue;
+      out.push({ culture, coords, level });
+    }
+    return out;
+  }, [cultures]);
+
+  return (
+    <View style={[styles.wrap, { height }]} accessibilityLabel="Cultural passport world map">
+      <MapView
+        ref={mapRef}
+        style={styles.map}
+        initialRegion={INITIAL_MAP_REGION}
+        accessibilityLabel="World map of passport cultures"
+      >
+        {pins.map((pin) => (
+          <PassportPin key={`pin-${pin.culture.culture_name}`} pin={pin} />
+        ))}
+      </MapView>
+
+      <MapZoomControls mapRef={mapRef} style={styles.zoomControls} />
+
+      {pins.length === 0 ? (
+        <View style={styles.emptyBanner} pointerEvents="none">
+          <Text style={styles.emptyText}>
+            No cultures with map coordinates yet. Try a recipe or save a story to start your passport.
+          </Text>
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+function PassportPin({ pin }: { pin: Pin }) {
+  const color = colorForLevel(pin.level) ?? tokens.colors.accentGreen;
+  const isLegendary = pin.level === 4;
+  return (
+    <Marker
+      coordinate={pin.coords}
+      pinColor={color}
+      title={pin.culture.culture_name}
+      description={ENGAGEMENT_LABELS[pin.level]}
+      testID={`passport-pin-${pin.culture.culture_name}`}
+    >
+      <Callout tooltip={false}>
+        <View style={styles.callout}>
+          <Text style={styles.calloutTitle}>
+            {isLegendary ? '★ ' : ''}
+            {pin.culture.culture_name}
+          </Text>
+          <Text style={styles.calloutLine}>
+            Recipes tried: <Text style={styles.calloutValue}>{pin.culture.recipes_tried}</Text>
+          </Text>
+          <Text style={styles.calloutLine}>
+            Stories saved: <Text style={styles.calloutValue}>{pin.culture.stories_saved}</Text>
+          </Text>
+          <Text style={[styles.calloutTier, { color }]}>{ENGAGEMENT_LABELS[pin.level]}</Text>
+        </View>
+      </Callout>
+    </Marker>
+  );
+}
+
+export default PassportWorldMap;
+
+const styles = StyleSheet.create({
+  wrap: {
+    width: '100%',
+    borderRadius: tokens.radius.lg,
+    overflow: 'hidden',
+    borderWidth: 1.5,
+    borderColor: tokens.colors.surfaceDark,
+    backgroundColor: tokens.colors.bg,
+    ...shadows.md,
+  },
+  map: { flex: 1 },
+  zoomControls: { top: 12, right: 12 },
+  emptyBanner: {
+    position: 'absolute',
+    left: 16,
+    right: 16,
+    bottom: 16,
+    padding: 12,
+    borderRadius: tokens.radius.lg,
+    backgroundColor: tokens.colors.bg,
+    borderWidth: 1.5,
+    borderColor: tokens.colors.surfaceDark,
+    ...shadows.md,
+  },
+  emptyText: {
+    fontSize: 12,
+    color: tokens.colors.text,
+    fontWeight: '700',
+  },
+  callout: {
+    minWidth: 160,
+    paddingVertical: 6,
+    paddingHorizontal: 8,
+    gap: 4,
+  },
+  calloutTitle: {
+    fontSize: 14,
+    fontWeight: '800',
+    color: tokens.colors.text,
+    fontFamily: tokens.typography.display.fontFamily,
+  },
+  calloutLine: {
+    fontSize: 12,
+    color: tokens.colors.textMuted,
+    fontWeight: '600',
+  },
+  calloutValue: {
+    color: tokens.colors.text,
+    fontWeight: '800',
+  },
+  calloutTier: {
+    fontSize: 11,
+    fontWeight: '900',
+    letterSpacing: 0.6,
+    textTransform: 'uppercase',
+    marginTop: 2,
+  },
+});

--- a/app/mobile/src/utils/engagementLevel.ts
+++ b/app/mobile/src/utils/engagementLevel.ts
@@ -1,0 +1,100 @@
+/**
+ * Engagement-depth ladder used by the embedded passport world map (issue #603).
+ *
+ * Each user-culture rollup is bucketed into one of five levels that drives
+ * pin colour + glyph on the map:
+ *
+ *   0  no engagement                 — pin not rendered
+ *   1  story saved only              — silver  (#C0C0C0)
+ *   2  recipe tried                  — bronze  (#CD7F32)
+ *   3  heritage contributed          — emerald (#50C878)
+ *   4  legendary stamp               — purple  (#9B59B6)
+ *
+ * The function reads tolerantly: rarity strings are the canonical signal
+ * (the backend hands them back even when per-culture counters are zero),
+ * but raw counters (`recipes_tried`, `stories_saved`, `heritage_recipes`)
+ * are used as a fallback for any rollup whose rarity field is missing or
+ * unknown. Extracted into `utils/` so the colour rule can be unit-tested
+ * without spinning up `react-native-maps`.
+ */
+
+/**
+ * Minimal duck-typed contract — the live shape (see PR #784) is
+ * `{ culture | culture_name, stamp_rarity | rarity, recipes_tried,
+ *    stories_saved, heritage_recipes?, ingredients_discovered? }`.
+ * We accept anything with those keys so the function tolerates both the
+ * raw backend payload and the normalized service-layer shape.
+ */
+export type EngagementCulture = {
+  culture?: string | null;
+  culture_name?: string | null;
+  rarity?: string | null;
+  stamp_rarity?: string | null;
+  recipes_tried?: number | null;
+  stories_saved?: number | null;
+  heritage_recipes?: number | null;
+  interactions?: number | null;
+};
+
+export type EngagementLevel = 0 | 1 | 2 | 3 | 4;
+
+export const ENGAGEMENT_COLORS: Record<Exclude<EngagementLevel, 0>, string> = {
+  1: '#C0C0C0', // silver — story saved
+  2: '#CD7F32', // bronze — recipe tried
+  3: '#50C878', // emerald — heritage contributed
+  4: '#9B59B6', // legendary purple
+};
+
+export const ENGAGEMENT_LABELS: Record<Exclude<EngagementLevel, 0>, string> = {
+  1: 'Story saved',
+  2: 'Recipe tried',
+  3: 'Heritage contributed',
+  4: 'Legendary',
+};
+
+function toNum(value: unknown): number {
+  const n = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(n) ? n : 0;
+}
+
+/**
+ * Resolve the engagement bucket for a single culture rollup. Pure: no I/O,
+ * no React state. Rarity takes precedence because the backend bumps it on
+ * heritage shares even when per-culture interaction counters stay at zero
+ * (see `apps/passport/services.py#culture_summaries`).
+ */
+export function engagementLevel(culture: EngagementCulture | null | undefined): EngagementLevel {
+  if (!culture) return 0;
+
+  const rarityRaw =
+    (typeof culture.stamp_rarity === 'string' && culture.stamp_rarity) ||
+    (typeof culture.rarity === 'string' && culture.rarity) ||
+    '';
+  const rarity = rarityRaw.toLowerCase();
+
+  const recipes = toNum(culture.recipes_tried);
+  const stories = toNum(culture.stories_saved);
+  const heritage = toNum(culture.heritage_recipes);
+
+  // Tier 4: legendary stamp always wins, regardless of counters.
+  if (rarity === 'legendary') return 4;
+
+  // Tier 3: heritage contribution — either an explicit counter, or the
+  // backend has already promoted the stamp to emerald/gold for heritage.
+  if (heritage > 0 || rarity === 'emerald' || rarity === 'gold') return 3;
+
+  // Tier 2: at least one recipe tried (or bronze stamp without other signal).
+  if (recipes > 0 || rarity === 'bronze') return 2;
+
+  // Tier 1: stories saved only (silver stamp also lands here).
+  if (stories > 0 || rarity === 'silver') return 1;
+
+  // No engagement signal anywhere — pin is skipped by the map.
+  return 0;
+}
+
+/** Convenience: hex colour for a level, or `null` for level 0. */
+export function colorForLevel(level: EngagementLevel): string | null {
+  if (level === 0) return null;
+  return ENGAGEMENT_COLORS[level];
+}


### PR DESCRIPTION
## Summary
- New self-contained `PassportWorldMap` component (`app/mobile/src/components/passport/PassportWorldMap.tsx`) plus an extracted pure helper `engagementLevel` in `utils/` that buckets each culture rollup into a 0..4 depth tier driving pin colour.
- 360pt `MapView` with zoom + pan, native teardrop `Marker`s coloured by tier (silver / bronze / emerald / legendary purple) following the Android-safe pattern locked in by #769 (no custom `borderRadius` views).
- Each pin opens a `Callout` mini-summary with culture name, recipes tried, stories saved, and tier label. Legendary tier gets a star glyph inside the callout.
- Reuses `coordsForRegion` from `utils/regionGeo` for centroids and `MapZoomControls` from `components/map/MapZoomControls` for + / − buttons; cultures with no engagement (level 0) or no known region centroid are silently skipped, surfaced via an empty-state banner when the result set is empty.
- `PassportScreen.tsx` is intentionally untouched — wire-up will land in a follow-up that plugs this component into the placeholder Map tab from #781.

## Engagement-level rule
| Level | Trigger | Colour |
|---|---|---|
| 0 | no engagement signal | (pin not rendered) |
| 1 | `stories_saved > 0` OR `rarity === 'silver'` | `#C0C0C0` silver |
| 2 | `recipes_tried > 0` OR `rarity === 'bronze'` | `#CD7F32` bronze |
| 3 | `heritage_recipes > 0` OR `rarity` ∈ {emerald, gold} | `#50C878` emerald |
| 4 | `rarity === 'legendary'` (wins over everything) | `#9B59B6` legendary purple |

`engagementLevel` reads tolerantly from either the raw backend keys (`culture`, `rarity`) or the normalized service-layer keys (`culture_name`, `stamp_rarity`) so the component works with either feed.

## Ayse coverage
Live probe against `http://localhost/api/users/ayse/passport/` returned 2 culture summaries:
- **Anatolian** — `rarity=emerald` → level 3 → emerald pin
- **Black Sea** — `rarity=emerald` → level 3 → emerald pin

Both region names exist in `regionGeo`, so **both render as pins** (2/2 of ayse's cultures appear on the embedded map).

## Test plan
- [x] `npx tsc --noEmit` clean in `app/mobile`
- [x] `npx jest __tests__/utils/engagementLevel.test.ts __tests__/components/PassportWorldMap.test.tsx` — 21 / 21 passing
- [x] Metro bundle `/index.bundle?platform=ios&dev=false&minify=true` → HTTP 200
- [x] Metro bundle `/index.bundle?platform=android&dev=false&minify=true` → HTTP 200
- [ ] Wire the component into `PassportScreen` Map tab in a follow-up and confirm pins render on a real device

### Jest output
```
PASS __tests__/utils/engagementLevel.test.ts
PASS __tests__/components/PassportWorldMap.test.tsx

Test Suites: 2 passed, 2 total
Tests:       21 passed, 21 total
Snapshots:   0 total
Time:        2.987 s
```

Closes #603