### PR TITLE
feat(mobile): JourneyTimeline component + paginated service for passport events (closes #604)

### DIFF
--- a/app/mobile/__tests__/components/JourneyTimeline.test.tsx
+++ b/app/mobile/__tests__/components/JourneyTimeline.test.tsx
@@ -1,0 +1,148 @@
+// Mock the service entirely — pulling in `requireActual` would transitively
+// load httpClient which imports AsyncStorage and blows up in jest-expo.
+jest.mock('../../src/services/passportTimelineService', () => ({
+  fetchTimeline: jest.fn(),
+  __resetTimelineCacheForTests: jest.fn(),
+  normalizeEvent: jest.fn(),
+}));
+
+import React from 'react';
+import { render, waitFor } from '@testing-library/react-native';
+import {
+  JourneyTimeline,
+  composeTitle,
+  formatTimeAgo,
+} from '../../src/components/passport/JourneyTimeline';
+import {
+  fetchTimeline,
+  type TimelineEvent,
+} from '../../src/services/passportTimelineService';
+
+const mockedFetch = fetchTimeline as jest.MockedFunction<typeof fetchTimeline>;
+
+const makeEvent = (over: Partial<TimelineEvent> = {}): TimelineEvent => ({
+  id: 1,
+  event_type: 'recipe_tried',
+  message: 'Tried Sarma',
+  created_at: '2026-05-10T12:00:00Z',
+  ...over,
+});
+
+describe('formatTimeAgo', () => {
+  const now = new Date('2026-05-12T12:00:00Z');
+
+  it('returns `now` for sub-minute deltas', () => {
+    expect(formatTimeAgo('2026-05-12T11:59:30Z', now)).toBe('now');
+  });
+
+  it('returns minutes for sub-hour deltas', () => {
+    expect(formatTimeAgo('2026-05-12T11:45:00Z', now)).toBe('15m');
+  });
+
+  it('returns hours for sub-day deltas', () => {
+    expect(formatTimeAgo('2026-05-12T08:00:00Z', now)).toBe('4h');
+  });
+
+  it('returns Yesterday for one-day-old events', () => {
+    expect(formatTimeAgo('2026-05-11T10:00:00Z', now)).toBe('Yesterday');
+  });
+
+  it('returns Mon D once we cross a week', () => {
+    expect(formatTimeAgo('2026-03-14T12:00:00Z', now)).toBe('Mar 14');
+  });
+
+  it('handles garbage input gracefully', () => {
+    expect(formatTimeAgo('not-a-date', now)).toBe('');
+    expect(formatTimeAgo('', now)).toBe('');
+  });
+});
+
+describe('composeTitle', () => {
+  it('uses the server message when present', () => {
+    expect(composeTitle(makeEvent({ message: 'Server says hi' }))).toBe('Server says hi');
+  });
+
+  it('falls back to recipe payload', () => {
+    expect(
+      composeTitle(
+        makeEvent({
+          message: undefined,
+          event_type: 'recipe_tried',
+          payload: { recipe_title: 'Mantı' },
+        }),
+      ),
+    ).toBe('Tried Mantı');
+  });
+
+  it('handles unknown event types with a generic title', () => {
+    expect(composeTitle(makeEvent({ message: undefined, event_type: 'mystery' }))).toBe(
+      'New journey event',
+    );
+  });
+});
+
+describe('JourneyTimeline', () => {
+  beforeEach(() => {
+    mockedFetch.mockReset();
+  });
+
+  it('renders the empty state when there are no events', async () => {
+    mockedFetch.mockResolvedValueOnce({ events: [], nextCursor: null });
+    const { findByText } = render(<JourneyTimeline username="ayse" />);
+    expect(await findByText('No journey events yet.')).toBeTruthy();
+  });
+
+  it('renders the correct icon for each event type', async () => {
+    const events: TimelineEvent[] = [
+      makeEvent({ id: 1, event_type: 'stamp_earned', message: 'Got stamp' }),
+      makeEvent({ id: 2, event_type: 'recipe_tried', message: 'Tried Sarma' }),
+      makeEvent({ id: 3, event_type: 'story_saved', message: 'Saved story' }),
+      makeEvent({ id: 4, event_type: 'quest_completed', message: 'Quest done' }),
+      makeEvent({ id: 5, event_type: 'mystery', message: 'Strange thing' }),
+    ];
+    const { getByText } = render(<JourneyTimeline username="ayse" initialEvents={events} />);
+    expect(getByText('🏷')).toBeTruthy();
+    expect(getByText('🍴')).toBeTruthy();
+    expect(getByText('📖')).toBeTruthy();
+    expect(getByText('🏆')).toBeTruthy();
+    expect(getByText('✨')).toBeTruthy();
+    expect(getByText('Tried Sarma')).toBeTruthy();
+  });
+
+  it('skips the initial fetch when initialEvents is supplied', async () => {
+    render(
+      <JourneyTimeline
+        username="ayse"
+        initialEvents={[makeEvent({ id: 1, message: 'cached' })]}
+      />,
+    );
+    // Let any pending microtasks settle.
+    await waitFor(() => {
+      expect(mockedFetch).not.toHaveBeenCalled();
+    });
+  });
+
+  it('fetches on mount when no initialEvents are supplied', async () => {
+    mockedFetch.mockResolvedValueOnce({
+      events: [makeEvent({ id: 11, message: 'fresh' })],
+      nextCursor: null,
+    });
+    const { findByText } = render(<JourneyTimeline username="ayse" />);
+    expect(await findByText('fresh')).toBeTruthy();
+    expect(mockedFetch).toHaveBeenCalledWith('ayse');
+  });
+
+  it('renders a time-ago label for recent events', async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-05-12T12:00:00Z'));
+    try {
+      const ev = makeEvent({ created_at: '2026-05-12T11:55:00Z', message: 'just now' });
+      const { getByText } = render(
+        <JourneyTimeline username="ayse" initialEvents={[ev]} />,
+      );
+      expect(getByText('5m')).toBeTruthy();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});

--- a/app/mobile/__tests__/services/passportTimelineService.test.ts
+++ b/app/mobile/__tests__/services/passportTimelineService.test.ts
@@ -1,0 +1,120 @@
+jest.mock('../../src/services/httpClient', () => ({
+  apiGetJson: jest.fn(),
+  nextPagePath: (next: string | null | undefined): string | null => {
+    if (!next) return null;
+    try {
+      const u = new URL(next);
+      return `${u.pathname}${u.search}`;
+    } catch {
+      return null;
+    }
+  },
+}));
+
+import { apiGetJson } from '../../src/services/httpClient';
+import {
+  __resetTimelineCacheForTests,
+  fetchTimeline,
+  normalizeEvent,
+} from '../../src/services/passportTimelineService';
+
+const mockedGet = apiGetJson as jest.MockedFunction<typeof apiGetJson>;
+
+beforeEach(() => {
+  mockedGet.mockReset();
+  __resetTimelineCacheForTests();
+});
+
+describe('normalizeEvent', () => {
+  it('maps backend description+timestamp into message+created_at', () => {
+    const out = normalizeEvent({
+      id: 7,
+      event_type: 'recipe_tried',
+      description: 'Tried Sarma',
+      timestamp: '2026-05-10T12:00:00Z',
+      related_recipe: 42,
+    });
+    expect(out).not.toBeNull();
+    expect(out!.id).toBe(7);
+    expect(out!.event_type).toBe('recipe_tried');
+    expect(out!.message).toBe('Tried Sarma');
+    expect(out!.created_at).toBe('2026-05-10T12:00:00Z');
+    expect(out!.payload).toEqual({ related_recipe: 42 });
+  });
+
+  it('falls back to `type` when `event_type` is absent', () => {
+    const out = normalizeEvent({ id: 1, type: 'level_up', message: 'Up!', created_at: 'x' });
+    expect(out!.event_type).toBe('level_up');
+    expect(out!.message).toBe('Up!');
+  });
+
+  it('returns null when id is missing', () => {
+    expect(normalizeEvent({ event_type: 'recipe_tried' } as any)).toBeNull();
+  });
+});
+
+describe('fetchTimeline — dedicated endpoint path', () => {
+  it('returns events and walks the DRF `next` link as the cursor', async () => {
+    mockedGet.mockResolvedValueOnce({
+      next: 'https://api.example.com/api/users/ayse/passport/timeline/?cursor=abc',
+      results: [
+        { id: 1, event_type: 'stamp_earned', description: 'Got a stamp', timestamp: 't1' },
+        { id: 2, event_type: 'recipe_tried', description: 'Tried Sarma', timestamp: 't2' },
+      ],
+    } as any);
+
+    const page = await fetchTimeline('ayse');
+
+    expect(mockedGet).toHaveBeenCalledWith('/api/users/ayse/passport/timeline/');
+    expect(page.events).toHaveLength(2);
+    expect(page.events[0].message).toBe('Got a stamp');
+    expect(page.nextCursor).toBe('/api/users/ayse/passport/timeline/?cursor=abc');
+  });
+
+  it('returns nextCursor null when there is no more data', async () => {
+    mockedGet.mockResolvedValueOnce({ next: null, results: [] } as any);
+    const page = await fetchTimeline('ayse');
+    expect(page.events).toEqual([]);
+    expect(page.nextCursor).toBeNull();
+  });
+});
+
+describe('fetchTimeline — fallback to full passport', () => {
+  it('falls back to the passport endpoint on 404 and chunks 20 per page', async () => {
+    // First call: dedicated endpoint 404s.
+    mockedGet.mockRejectedValueOnce(new Error('HTTP 404 Not Found'));
+    // Second call: full passport with 25 timeline events.
+    const big = Array.from({ length: 25 }, (_, i) => ({
+      id: i + 1,
+      event_type: 'recipe_tried',
+      description: `Recipe ${i + 1}`,
+      timestamp: '2026-05-10T12:00:00Z',
+    }));
+    mockedGet.mockResolvedValueOnce({ timeline: big } as any);
+
+    const page1 = await fetchTimeline('ayse');
+    expect(mockedGet).toHaveBeenNthCalledWith(1, '/api/users/ayse/passport/timeline/');
+    expect(mockedGet).toHaveBeenNthCalledWith(2, '/api/users/ayse/passport/');
+    expect(page1.events).toHaveLength(20);
+    expect(page1.nextCursor).toBe('passport:20');
+
+    // Second page reuses the cache and slices the remainder.
+    const page2 = await fetchTimeline('ayse', { cursor: page1.nextCursor! });
+    expect(mockedGet).toHaveBeenCalledTimes(2); // no extra fetch
+    expect(page2.events).toHaveLength(5);
+    expect(page2.nextCursor).toBeNull();
+  });
+
+  it('returns an empty page when the passport has no timeline', async () => {
+    mockedGet.mockRejectedValueOnce(new Error('HTTP 404'));
+    mockedGet.mockResolvedValueOnce({} as any);
+    const page = await fetchTimeline('ayse');
+    expect(page.events).toEqual([]);
+    expect(page.nextCursor).toBeNull();
+  });
+
+  it('propagates non-404 errors from the dedicated endpoint', async () => {
+    mockedGet.mockRejectedValueOnce(new Error('HTTP 500 boom'));
+    await expect(fetchTimeline('ayse')).rejects.toThrow('HTTP 500 boom');
+  });
+});

--- a/app/mobile/src/components/passport/JourneyTimeline.tsx
+++ b/app/mobile/src/components/passport/JourneyTimeline.tsx
@@ -1,0 +1,354 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { FlatList, Pressable, RefreshControl, StyleSheet, Text, View } from 'react-native';
+import { tokens } from '../../theme';
+import { ErrorView } from '../ui/ErrorView';
+import { LoadingView } from '../ui/LoadingView';
+import {
+  fetchTimeline,
+  type TimelineEvent,
+} from '../../services/passportTimelineService';
+
+type Props = {
+  username: string;
+  /**
+   * Bypass the initial fetch entirely. Useful when the parent already has the
+   * passport response in hand (e.g. PassportScreen prefetched it) and just
+   * wants to mount the list without flashing a spinner. Infinite scroll still
+   * works — once the parent-supplied page runs out we fall back to the
+   * service's pagination.
+   */
+  initialEvents?: TimelineEvent[];
+};
+
+const ICONS: Record<string, string> = {
+  stamp_earned: '🏷',
+  recipe_tried: '🍴',
+  story_saved: '📖',
+  quest_completed: '🏆',
+  heritage_shared: '🌍',
+  level_up: '⭐',
+};
+
+const UNKNOWN_ICON = '✨';
+
+function iconFor(eventType: string): string {
+  return ICONS[eventType] ?? UNKNOWN_ICON;
+}
+
+const MONTH_LABELS = [
+  'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+  'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+];
+
+/**
+ * Render a compact "time ago" string without pulling in a date library. The
+ * tiers are: `now` (<60s), `Nm`, `Nh`, `Yesterday`, then a static `Mon D`
+ * label once we cross 7 days. Anything we can't parse falls back to an empty
+ * string rather than `NaN`-ing on screen.
+ */
+export function formatTimeAgo(input: string, now: Date = new Date()): string {
+  if (!input) return '';
+  const then = new Date(input);
+  const ms = then.getTime();
+  if (Number.isNaN(ms)) return '';
+  const diff = now.getTime() - ms;
+  if (diff < 0) return 'now';
+  const sec = Math.floor(diff / 1000);
+  if (sec < 60) return 'now';
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h`;
+  const day = Math.floor(hr / 24);
+  if (day === 1) return 'Yesterday';
+  if (day < 7) return `${day}d`;
+  return `${MONTH_LABELS[then.getMonth()]} ${then.getDate()}`;
+}
+
+/**
+ * Build a user-readable headline for a single event. The backend already
+ * sends a `description` (mapped to `message`) for every choice in
+ * `PassportEvent.TYPE_CHOICES`, so this composer is mostly defensive — it
+ * only fires when `message` is missing (e.g. an older build or a brand-new
+ * event type the server rolled out without filling description).
+ */
+export function composeTitle(event: TimelineEvent): string {
+  if (event.message && event.message.trim()) return event.message;
+  const payload = event.payload ?? {};
+  const pick = (k: string): string | undefined =>
+    typeof payload[k] === 'string' ? (payload[k] as string) : undefined;
+  switch (event.event_type) {
+    case 'recipe_tried':
+      return `Tried ${pick('recipe_title') ?? 'a recipe'}`;
+    case 'story_saved':
+      return `Saved ${pick('story_title') ?? 'a story'}`;
+    case 'stamp_earned':
+      return `Earned ${pick('culture') ?? 'a'} stamp`;
+    case 'quest_completed':
+      return `Completed ${pick('quest_name') ?? 'a quest'}`;
+    case 'heritage_shared':
+      return `Shared a heritage story`;
+    case 'level_up':
+      return `Levelled up`;
+    default:
+      return 'New journey event';
+  }
+}
+
+type RowProps = {
+  event: TimelineEvent;
+  isFirst: boolean;
+  isLast: boolean;
+};
+
+function TimelineRow({ event, isFirst, isLast }: RowProps) {
+  const title = composeTitle(event);
+  const time = formatTimeAgo(event.created_at);
+  const icon = iconFor(event.event_type);
+  const a11y = `${event.event_type.replace(/_/g, ' ')}: ${title}${time ? `, ${time}` : ''}`;
+  return (
+    <View style={styles.row} accessible accessibilityLabel={a11y}>
+      <View style={styles.rail}>
+        <View style={[styles.railLine, isFirst && styles.railLineFirst]} />
+        <View style={styles.dot}>
+          <Text style={styles.dotIcon}>{icon}</Text>
+        </View>
+        <View style={[styles.railLine, isLast && styles.railLineLast]} />
+      </View>
+      <View style={styles.body}>
+        <Text style={styles.title} numberOfLines={2}>
+          {title}
+        </Text>
+        {time ? <Text style={styles.time}>{time}</Text> : null}
+      </View>
+    </View>
+  );
+}
+
+export function JourneyTimeline({ username, initialEvents }: Props) {
+  const seedEvents = useMemo(() => initialEvents ?? [], [initialEvents]);
+
+  const [events, setEvents] = useState<TimelineEvent[]>(seedEvents);
+  const [cursor, setCursor] = useState<string | null>(null);
+  const [hasMore, setHasMore] = useState<boolean>(
+    initialEvents !== undefined ? false : true,
+  );
+  const [loading, setLoading] = useState<boolean>(initialEvents === undefined);
+  const [refreshing, setRefreshing] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Guard against firing a second `onEndReached` while one is in flight —
+  // FlatList likes to fire it twice during fast scrolls.
+  const loadingMoreRef = useRef(false);
+
+  const loadFirstPage = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const page = await fetchTimeline(username);
+      setEvents(page.events);
+      setCursor(page.nextCursor);
+      setHasMore(page.nextCursor !== null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load timeline');
+    } finally {
+      setLoading(false);
+    }
+  }, [username]);
+
+  useEffect(() => {
+    if (initialEvents !== undefined) return;
+    void loadFirstPage();
+  }, [initialEvents, loadFirstPage]);
+
+  const onRefresh = useCallback(async () => {
+    setRefreshing(true);
+    setError(null);
+    try {
+      const page = await fetchTimeline(username);
+      setEvents(page.events);
+      setCursor(page.nextCursor);
+      setHasMore(page.nextCursor !== null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to refresh timeline');
+    } finally {
+      setRefreshing(false);
+    }
+  }, [username]);
+
+  const onEndReached = useCallback(async () => {
+    if (loadingMoreRef.current) return;
+    if (!hasMore) return;
+    if (!cursor) return;
+    loadingMoreRef.current = true;
+    setLoadingMore(true);
+    try {
+      const page = await fetchTimeline(username, { cursor });
+      setEvents((prev) => [...prev, ...page.events]);
+      setCursor(page.nextCursor);
+      setHasMore(page.nextCursor !== null);
+    } catch {
+      // Soft-fail pagination: keep the existing list, drop hasMore so we don't
+      // hammer the failing endpoint on every scroll wiggle.
+      setHasMore(false);
+    } finally {
+      loadingMoreRef.current = false;
+      setLoadingMore(false);
+    }
+  }, [cursor, hasMore, username]);
+
+  if (loading && events.length === 0) {
+    return <LoadingView message="Loading journey…" />;
+  }
+
+  if (error && events.length === 0) {
+    return (
+      <ErrorView
+        message={error}
+        onRetry={() => {
+          void loadFirstPage();
+        }}
+      />
+    );
+  }
+
+  if (events.length === 0) {
+    return (
+      <View style={styles.empty} accessibilityLabel="Empty journey">
+        <Text style={styles.emptyTitle}>No journey events yet.</Text>
+        <Text style={styles.emptyBody}>
+          Start exploring recipes and cultures to fill your passport.
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <FlatList
+      data={events}
+      keyExtractor={(item) => String(item.id)}
+      renderItem={({ item, index }) => (
+        <TimelineRow
+          event={item}
+          isFirst={index === 0}
+          isLast={index === events.length - 1}
+        />
+      )}
+      refreshControl={
+        <RefreshControl
+          refreshing={refreshing}
+          onRefresh={() => {
+            void onRefresh();
+          }}
+          tintColor={tokens.colors.surfaceDark}
+        />
+      }
+      onEndReached={() => {
+        void onEndReached();
+      }}
+      onEndReachedThreshold={0.4}
+      ListFooterComponent={
+        loadingMore ? (
+          <View style={styles.footer}>
+            <LoadingView message="Loading more…" />
+          </View>
+        ) : error ? (
+          <View style={styles.footer}>
+            <Pressable
+              onPress={() => {
+                void onEndReached();
+              }}
+            >
+              <Text style={styles.footerError}>Couldn't load more — tap to retry</Text>
+            </Pressable>
+          </View>
+        ) : null
+      }
+      contentContainerStyle={styles.list}
+    />
+  );
+}
+
+const RAIL_WIDTH = 32;
+const DOT_SIZE = 28;
+
+const styles = StyleSheet.create({
+  list: {
+    paddingVertical: 8,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'stretch',
+    paddingHorizontal: 12,
+  },
+  rail: {
+    width: RAIL_WIDTH,
+    alignItems: 'center',
+  },
+  railLine: {
+    flex: 1,
+    width: 2,
+    backgroundColor: tokens.colors.primaryBorder,
+  },
+  railLineFirst: {
+    backgroundColor: 'transparent',
+  },
+  railLineLast: {
+    backgroundColor: 'transparent',
+  },
+  dot: {
+    width: DOT_SIZE,
+    height: DOT_SIZE,
+    borderRadius: DOT_SIZE / 2,
+    backgroundColor: tokens.colors.primaryTint,
+    borderWidth: 1,
+    borderColor: tokens.colors.primaryBorder,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  dotIcon: {
+    fontSize: 14,
+  },
+  body: {
+    flex: 1,
+    paddingVertical: 10,
+    paddingLeft: 12,
+  },
+  title: {
+    fontSize: 15,
+    color: tokens.colors.text,
+    fontWeight: '600',
+  },
+  time: {
+    marginTop: 2,
+    fontSize: 12,
+    color: tokens.colors.textMuted,
+  },
+  empty: {
+    paddingVertical: 24,
+    paddingHorizontal: 20,
+    alignItems: 'center',
+    gap: 6,
+  },
+  emptyTitle: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: tokens.colors.text,
+    textAlign: 'center',
+  },
+  emptyBody: {
+    fontSize: 13,
+    color: tokens.colors.textMuted,
+    textAlign: 'center',
+  },
+  footer: {
+    paddingVertical: 12,
+  },
+  footerError: {
+    fontSize: 13,
+    color: tokens.colors.error,
+    textAlign: 'center',
+    paddingVertical: 8,
+  },
+});

--- a/app/mobile/src/services/passportTimelineService.ts
+++ b/app/mobile/src/services/passportTimelineService.ts
@@ -1,0 +1,221 @@
+import { apiGetJson, nextPagePath } from './httpClient';
+
+/**
+ * Discriminator for journey timeline entries. The first four are the known
+ * backend choices (`recipe_tried`, `story_saved`, `stamp_earned`,
+ * `quest_completed`) plus `heritage_shared` and `level_up`. Anything else is
+ * tolerated as a string so a server-side rollout of a new event type does not
+ * crash older mobile builds — the component just falls back to the generic
+ * `✨` icon for unknown values.
+ */
+export type TimelineEventType =
+  | 'stamp_earned'
+  | 'recipe_tried'
+  | 'story_saved'
+  | 'quest_completed'
+  | 'heritage_shared'
+  | 'level_up'
+  | string;
+
+/**
+ * Normalised timeline event shape consumed by the UI.
+ *
+ * The backend currently emits `description` + `timestamp`, but we accept any
+ * of `message`/`description` and `created_at`/`timestamp` from the wire and
+ * collapse them here so future renames don't break the screen.
+ */
+export type TimelineEvent = {
+  id: number | string;
+  event_type: TimelineEventType;
+  message?: string;
+  payload?: Record<string, unknown>;
+  created_at: string;
+};
+
+type RawTimelineEvent = {
+  id?: number | string;
+  event_type?: string;
+  type?: string;
+  description?: string;
+  message?: string;
+  timestamp?: string;
+  created_at?: string;
+  payload?: Record<string, unknown>;
+  // backend extras that we fold into payload for the title composer
+  related_recipe?: number | string | null;
+  related_story?: number | string | null;
+  stamp_rarity?: string | null;
+};
+
+type RawTimelinePage = {
+  results?: RawTimelineEvent[];
+  next?: string | null;
+};
+
+type RawPassportResponse = {
+  timeline?: RawTimelineEvent[];
+};
+
+const PAGE_SIZE = 20;
+
+/**
+ * Map a raw wire event into the canonical UI shape. Tolerates key drift
+ * (`type` ↔ `event_type`, `description` ↔ `message`, `timestamp` ↔
+ * `created_at`). Backend "side channel" fields like `related_recipe`,
+ * `related_story` and `stamp_rarity` get folded into `payload` so the row
+ * title composer can read them without caring about the wire layout.
+ */
+export function normalizeEvent(raw: RawTimelineEvent | null | undefined): TimelineEvent | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const id = raw.id;
+  if (id === undefined || id === null) return null;
+  const eventType =
+    (typeof raw.event_type === 'string' && raw.event_type) ||
+    (typeof raw.type === 'string' && raw.type) ||
+    'unknown';
+  const message =
+    typeof raw.message === 'string' && raw.message
+      ? raw.message
+      : typeof raw.description === 'string' && raw.description
+        ? raw.description
+        : undefined;
+  const createdAt =
+    (typeof raw.created_at === 'string' && raw.created_at) ||
+    (typeof raw.timestamp === 'string' && raw.timestamp) ||
+    '';
+  const payload: Record<string, unknown> = { ...(raw.payload ?? {}) };
+  if (raw.related_recipe !== undefined && raw.related_recipe !== null) {
+    payload.related_recipe = raw.related_recipe;
+  }
+  if (raw.related_story !== undefined && raw.related_story !== null) {
+    payload.related_story = raw.related_story;
+  }
+  if (raw.stamp_rarity !== undefined && raw.stamp_rarity !== null) {
+    payload.stamp_rarity = raw.stamp_rarity;
+  }
+  return {
+    id,
+    event_type: eventType,
+    message,
+    payload: Object.keys(payload).length ? payload : undefined,
+    created_at: createdAt,
+  };
+}
+
+export type TimelineFetchResult = {
+  events: TimelineEvent[];
+  nextCursor: string | null;
+};
+
+type FetchOpts = {
+  cursor?: string | null;
+};
+
+/**
+ * Tracks the synthesized client-side cursor for the fallback path. When the
+ * backend has no dedicated paginated timeline endpoint we ask for the full
+ * passport once and slice it into 20-item pages, encoding the slice offset
+ * inside the cursor as `passport:<offset>` so subsequent calls don't refetch
+ * if we already cached the slice.
+ */
+const PASSPORT_CURSOR_PREFIX = 'passport:';
+
+let cachedPassportEvents: { username: string; events: TimelineEvent[] } | null = null;
+
+function isHttpStatus(err: unknown, status: number): boolean {
+  if (!err || typeof err !== 'object') return false;
+  const message = (err as { message?: unknown }).message;
+  if (typeof message !== 'string') return false;
+  return message.includes(`HTTP ${status}`) || message.includes(`status ${status}`);
+}
+
+async function fetchDedicatedEndpoint(
+  username: string,
+  cursor: string | null | undefined,
+): Promise<TimelineFetchResult> {
+  const path = cursor
+    ? `/api/users/${encodeURIComponent(username)}/passport/timeline/?cursor=${encodeURIComponent(cursor)}`
+    : `/api/users/${encodeURIComponent(username)}/passport/timeline/`;
+  const raw = await apiGetJson<RawTimelinePage>(path);
+  const results = Array.isArray(raw?.results) ? raw!.results : [];
+  const events = results
+    .map(normalizeEvent)
+    .filter((e): e is TimelineEvent => Boolean(e));
+  const nextCursor = nextPagePath(raw?.next ?? null);
+  // The path-style cursor returned from nextPagePath may include the full
+  // `?cursor=…` slug. We hand it back as-is so the next call can pass it
+  // through `apiGetJson` directly.
+  return { events, nextCursor };
+}
+
+async function fetchPassportFallback(
+  username: string,
+  cursor: string | null | undefined,
+): Promise<TimelineFetchResult> {
+  const offset = (() => {
+    if (!cursor) return 0;
+    if (!cursor.startsWith(PASSPORT_CURSOR_PREFIX)) return 0;
+    const n = Number(cursor.slice(PASSPORT_CURSOR_PREFIX.length));
+    return Number.isFinite(n) && n >= 0 ? n : 0;
+  })();
+
+  let events: TimelineEvent[];
+  if (cachedPassportEvents && cachedPassportEvents.username === username && offset > 0) {
+    events = cachedPassportEvents.events;
+  } else {
+    const raw = await apiGetJson<RawPassportResponse>(
+      `/api/users/${encodeURIComponent(username)}/passport/`,
+    );
+    const list = Array.isArray(raw?.timeline) ? raw!.timeline : [];
+    events = list.map(normalizeEvent).filter((e): e is TimelineEvent => Boolean(e));
+    cachedPassportEvents = { username, events };
+  }
+
+  const slice = events.slice(offset, offset + PAGE_SIZE);
+  const nextOffset = offset + slice.length;
+  const hasMore = nextOffset < events.length;
+  return {
+    events: slice,
+    nextCursor: hasMore ? `${PASSPORT_CURSOR_PREFIX}${nextOffset}` : null,
+  };
+}
+
+/**
+ * Fetch a page of journey timeline events for a user.
+ *
+ * Strategy: prefer the dedicated `…/passport/timeline/` endpoint (so the
+ * server can paginate properly), but earlier probes returned 404 there. On a
+ * 404 we fall back to slicing the inline `timeline` array embedded in the
+ * full passport response — currently the backend caps that list at 50 most
+ * recent events.
+ *
+ * The two paths are kept inside this one function so the component never has
+ * to care which one is live.
+ */
+export async function fetchTimeline(
+  username: string,
+  opts: FetchOpts = {},
+): Promise<TimelineFetchResult> {
+  const cursor = opts.cursor ?? null;
+  // Once we've started a fallback paginated session the cursor itself carries
+  // the `passport:` prefix — keep walking that path instead of re-probing.
+  if (cursor && cursor.startsWith(PASSPORT_CURSOR_PREFIX)) {
+    return fetchPassportFallback(username, cursor);
+  }
+  try {
+    return await fetchDedicatedEndpoint(username, cursor);
+  } catch (err) {
+    if (isHttpStatus(err, 404)) {
+      return fetchPassportFallback(username, cursor);
+    }
+    throw err;
+  }
+}
+
+/**
+ * Test-only hook to reset the fallback cache between cases. Exposed because
+ * jest doesn't isolate module state across `describe` blocks by default.
+ */
+export function __resetTimelineCacheForTests(): void {
+  cachedPassportEvents = null;
+}


### PR DESCRIPTION
## Summary
- Adds `JourneyTimeline` (mobile) — vertical FlatList timeline with icon-per-event-type, time-ago, dot/connector rail, pull-to-refresh and infinite scroll.
- Adds `passportTimelineService.fetchTimeline(username, { cursor })` with paginated cursor returns and a defensive `normalizeEvent` helper that absorbs `description`/`message` and `timestamp`/`created_at` key drift.
- Plugs in trivially via `<JourneyTimeline username={u} />` (or with `initialEvents` to skip the first fetch); `PassportScreen.tsx` is intentionally untouched per the issue.
- Covers `stamp_earned` (🏷), `recipe_tried` (🍴), `story_saved` (📖), `quest_completed` (🏆), plus `heritage_shared` (🌍) and `level_up` (⭐) from the backend's `PassportEvent.TYPE_CHOICES`; anything unknown falls back to ✨.
- 22 jest cases (services + component) green, `tsc --noEmit` clean, iOS metro bundle returns HTTP 200.

## Timeline fetch path
The dedicated endpoint `/api/users/<username>/passport/timeline/?cursor=…` was probed first (preferred — lets DRF paginate). Earlier reconnaissance and the current backend code in `apps/passport/urls.py` confirm there is **no such route today**; the service therefore catches the 404 and falls back to fetching the full passport (`/api/users/<username>/passport/`) and slicing the inline `timeline` array into 20-item pages client-side. The cursor for the fallback path is `passport:<offset>` so subsequent pages reuse the cached list instead of refetching. When the backend later adds the dedicated route, the dedicated branch will start succeeding automatically with zero client changes.

## Test plan
- [x] `cd app/mobile && npx tsc --noEmit` — clean
- [x] `cd app/mobile && npx jest __tests__/services/passportTimelineService.test.ts __tests__/components/JourneyTimeline.test.tsx` — 22/22 pass
- [x] Metro bundle: `GET /index.bundle?platform=ios` → HTTP 200 (~2.3 MB)
- [ ] Manual smoke: mount `<JourneyTimeline username="ayse" />` once #781's Timeline tab lands, verify empty state, pull-to-refresh, infinite scroll on a user with >20 events

Closes #604