### PR TITLE
chore(devops): harden signed APK build pipeline and document it (#365)

### DIFF
--- a/.github/workflows/mobile-apk.yml
+++ b/.github/workflows/mobile-apk.yml
@@ -3,6 +3,12 @@ name: Mobile APK (EAS)
 on:
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      attach_to_release:
+        description: "Attach the built APK to the latest GitHub release"
+        type: boolean
+        default: false
 
 concurrency:
   group: mobile-apk-main
@@ -11,6 +17,8 @@ concurrency:
 jobs:
   build-android-apk:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     defaults:
       run:
         working-directory: app/mobile
@@ -64,6 +72,16 @@ jobs:
         with:
           name: app-release.apk
           path: app/mobile/app-release.apk
+
+      # Optional: when manually dispatched with attach_to_release, attach the APK to the latest GitHub release.
+      - name: Attach APK to latest release
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.attach_to_release && hashFiles('app/mobile/app-release.apk') != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="$(gh release view --json tagName -q .tagName)"
+          echo "Attaching app-release.apk to release $tag"
+          gh release upload "$tag" app-release.apk --clobber
 
       - name: Job summary
         if: always()

--- a/app/mobile/eas.json
+++ b/app/mobile/eas.json
@@ -9,7 +9,10 @@
       "distribution": "internal"
     },
     "preview": {
-      "distribution": "internal"
+      "distribution": "internal",
+      "android": {
+        "buildType": "apk"
+      }
     },
     "production": {
       "autoIncrement": true

--- a/docs/signed-apk-build.md
+++ b/docs/signed-apk-build.md
@@ -1,0 +1,61 @@
+# Signed APK build
+
+The Genipe mobile app is a managed Expo project (no `android/` directory in the
+repo). Android builds are produced by [EAS Build](https://docs.expo.dev/build/introduction/),
+which also owns the signing keystore. Every APK that comes out of EAS is signed.
+
+## Where the signing keystore lives
+
+The upload/release keystore is stored as **managed credentials** in the EAS
+project (`projectId` in `app/mobile/app.json`). EAS generated it on the first
+Android build and reuses it for every subsequent build, so APKs are reproducibly
+signed with the same certificate. Nothing keystore-related is committed to the
+repo and there are no keystore secrets in GitHub Actions; the only secret the CI
+needs is `EXPO_TOKEN` (an Expo access token).
+
+To inspect or rotate the credentials: `cd app/mobile && eas credentials`.
+
+## CI pipeline
+
+`.github/workflows/mobile-apk.yml` (`Mobile APK (EAS)`):
+
+1. Runs on push to `main` and on manual `workflow_dispatch`.
+2. `npm ci` in `app/mobile`, then `eas build --platform android --profile preview --non-interactive --wait`.
+   The `preview` profile in `app/mobile/eas.json` uses `distribution: internal`
+   and `android.buildType: apk`, so the output is a directly installable `.apk`
+   (not an `.aab`).
+3. Best-effort: downloads the finished build artifact (`eas build:list ... --json`
+   → `buildUrl`) as `app-release.apk` and uploads it as a GitHub Actions artifact
+   named `app-release.apk`.
+4. Writes the EAS build URL to the job summary.
+5. If dispatched manually with the `attach_to_release` input checked, also runs
+   `gh release upload <latest-tag> app-release.apk --clobber` to attach the APK
+   to the latest GitHub release.
+
+## How to trigger a build
+
+- **Automatically:** any push to `main` triggers it.
+- **Manually (release candidate):** GitHub → Actions → `Mobile APK (EAS)` → *Run
+  workflow*. Tick `attach_to_release` if you also want the APK attached to the
+  latest release.
+
+## Where reviewers download the APK
+
+- **GitHub Actions artifact:** open the latest `Mobile APK (EAS)` run → Artifacts
+  → `app-release.apk`.
+- **EAS dashboard:** the build URL printed in the job summary links to the build
+  page on `expo.dev`, which has a download button and a QR code.
+- **GitHub release:** if the build was dispatched with `attach_to_release`, the
+  APK is attached to the latest release on the Releases page.
+
+## Verifying the signature
+
+```bash
+# unzip the artifact first if needed
+apksigner verify --print-certs app-release.apk
+```
+
+This prints the signing certificate (subject, SHA-256 digest, etc.). All APKs
+from the same EAS keystore share one certificate, so the digest should be stable
+across builds. `apksigner` ships with the Android SDK build-tools; alternatively
+`keytool -printcert -jarfile app-release.apk` works without the SDK.


### PR DESCRIPTION
## Summary
- app/mobile/eas.json: the `preview` build profile now sets `android.buildType: apk`, so EAS produces a directly sideloadable `.apk` (not an `.aab`) for reviewer devices.
- .github/workflows/mobile-apk.yml: added a `workflow_dispatch` trigger (with an optional `attach_to_release` input) so a release-candidate APK can be built on demand, not only on push to `main`. When dispatched with that input, the run also attaches the downloaded `app-release.apk` to the latest GitHub release via `gh release upload --clobber` (job granted `contents: write`).
- docs/signed-apk-build.md: documents the EAS-managed signing keystore, how the CI pipeline works, how to trigger a build, where reviewers download the APK, and how to verify the signature with `apksigner verify --print-certs`. Seeds the wiki page asked for in the issue.

## Test plan
- [x] `mobile-apk.yml` parses as valid YAML; `eas.json` parses as valid JSON (checked locally)
- [ ] After merge to `main`: GitHub > Actions > `Mobile APK (EAS)` > Run workflow with `attach_to_release` ticked > confirm the run produces the `app-release.apk` artifact and attaches it to the `v1.0-mvp` release
- [ ] `apksigner verify --print-certs app-release.apk` on the artifact prints a valid signing certificate

## Notes
- This is a managed Expo project; the signing keystore is held in EAS managed credentials. No keystore secrets are committed; CI only needs the existing `EXPO_TOKEN` secret.
- The pre-existing pipeline (EAS build + best-effort artifact download + job-summary build URL) already covered the bulk of #365; this PR closes the remaining gaps (explicit APK output, manual dispatch, release attachment, docs).
- The `Mobile APK (EAS)` workflow runs on push to `main` / dispatch, not on PRs, so it does not gate this PR; the dispatch test above can only run once this is on `main`.

Closes #365.