### PR TITLE
feat(frontend): region-centric pins, top-region center, region panel (#668)

### DIFF
--- a/app/frontend/src/__tests__/HeritageMapPage.test.jsx
+++ b/app/frontend/src/__tests__/HeritageMapPage.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import HeritageMapPage from '../pages/HeritageMapPage';
 import * as heritageService from '../services/heritageService';
@@ -12,7 +12,7 @@ jest.mock('react-leaflet', () => ({
   TileLayer: () => null,
   CircleMarker: ({ children, center, eventHandlers }) => (
     <div
-      data-testid="circle-marker"
+      data-testid="region-pin"
       data-center={JSON.stringify(center)}
       onClick={eventHandlers?.click}
     >{children}</div>
@@ -30,14 +30,16 @@ jest.mock('react-leaflet', () => ({
   Tooltip: ({ children }) => <span>{children}</span>,
 }));
 
+// Black Sea: 2 recipes (top region), Konya: 1 story, Unknown: null coords (skipped)
 const GROUP = {
   id: 1,
   name: 'Sarma / Dolma',
   description: '',
   members: [
-    { content_type: 'recipe', id: 11, title: 'Black Sea Sarma', author: 'zeynep', region: 'Black Sea', latitude: 41.0, longitude: 39.7 },
-    { content_type: 'story',  id: 22, title: 'Wedding sarma',    author: 'fatma',  region: 'Konya',     latitude: 37.9, longitude: 32.5 },
-    { content_type: 'recipe', id: 33, title: 'Located somewhere', author: 'x',     region: 'Unknown',   latitude: null, longitude: null },
+    { content_type: 'recipe', id: 11, title: 'Black Sea Sarma',   author: 'zeynep', region: 'Black Sea', latitude: 41.0, longitude: 39.7 },
+    { content_type: 'recipe', id: 12, title: 'Black Sea Dolma',   author: 'ali',    region: 'Black Sea', latitude: 41.2, longitude: 39.9 },
+    { content_type: 'story',  id: 22, title: 'Wedding sarma',     author: 'fatma',  region: 'Konya',     latitude: 37.9, longitude: 32.5 },
+    { content_type: 'recipe', id: 33, title: 'Unlocated recipe',  author: 'x',      region: 'Unknown',   latitude: null, longitude: null },
   ],
   journey_steps: [],
 };
@@ -58,29 +60,61 @@ beforeEach(() => {
 });
 
 describe('HeritageMapPage', () => {
-  it('renders one circle marker per locatable member (unlocatable members are skipped)', async () => {
-    renderPage();
-    await waitFor(() => expect(screen.getAllByTestId('circle-marker')).toHaveLength(2));
-  });
-
-  it('centres the map on the midpoint of locatable members', async () => {
+  it('centres the map on the top region (most recipes)', async () => {
     renderPage();
     await screen.findByTestId('map-container');
     const center = JSON.parse(screen.getByTestId('map-container').getAttribute('data-center'));
-    expect(center[0]).toBeCloseTo((41.0 + 37.9) / 2, 3);
-    expect(center[1]).toBeCloseTo((39.7 + 32.5) / 2, 3);
+    // Black Sea centroid: avg of (41.0, 39.7) and (41.2, 39.9)
+    expect(center[0]).toBeCloseTo((41.0 + 41.2) / 2, 3);
+    expect(center[1]).toBeCloseTo((39.7 + 39.9) / 2, 3);
   });
 
-  it('renders a polyline from the midpoint to each locatable member', async () => {
+  it('renders one region pin per non-center region (no per-member duplicates)', async () => {
     renderPage();
-    await waitFor(() => expect(screen.getAllByTestId('polyline')).toHaveLength(2));
+    await waitFor(() => expect(screen.getAllByTestId('region-pin')).toHaveLength(1));
+    const pin = screen.getByTestId('region-pin');
+    const coords = JSON.parse(pin.getAttribute('data-center'));
+    expect(coords[0]).toBeCloseTo(37.9, 3);
   });
 
-  it('renders a central building marker at the midpoint', async () => {
+  it('renders one polyline per non-center region', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getAllByTestId('polyline')).toHaveLength(1));
+  });
+
+  it('renders no polylines for a single-region heritage', async () => {
+    heritageService.fetchHeritageGroup.mockResolvedValue({
+      ...GROUP,
+      members: GROUP.members.filter((m) => m.region === 'Black Sea'),
+    });
     renderPage();
     await screen.findByTestId('center-marker');
-    const center = JSON.parse(screen.getByTestId('center-marker').getAttribute('data-center'));
-    expect(center[0]).toBeCloseTo((41.0 + 37.9) / 2, 3);
+    expect(screen.queryByTestId('polyline')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('region-pin')).not.toBeInTheDocument();
+  });
+
+  it('clicking the center marker opens the panel for the center region', async () => {
+    renderPage();
+    const marker = await screen.findByTestId('center-marker');
+    fireEvent.click(marker);
+    // findByRole('heading') matches only <h2>, not tooltip <span>
+    expect(await screen.findByRole('heading', { name: 'Black Sea' })).toBeInTheDocument();
+    expect(screen.getByText('Black Sea Sarma')).toBeInTheDocument();
+    expect(screen.getByText('Black Sea Dolma')).toBeInTheDocument();
+  });
+
+  it('clicking a region pin opens the panel for that region', async () => {
+    renderPage();
+    const pin = await screen.findByTestId('region-pin');
+    fireEvent.click(pin);
+    expect(await screen.findByRole('heading', { name: 'Konya' })).toBeInTheDocument();
+    expect(screen.getByText('Wedding sarma')).toBeInTheDocument();
+  });
+
+  it('panel shows placeholder text when no region is selected', async () => {
+    renderPage();
+    await screen.findByTestId('center-marker');
+    expect(screen.getByText(/select a region pin/i)).toBeInTheDocument();
   });
 
   it('links "Back to Heritage Page" to /heritage/:id', async () => {
@@ -96,6 +130,6 @@ describe('HeritageMapPage', () => {
     });
     renderPage();
     expect(await screen.findByText(/no locations to plot/i)).toBeInTheDocument();
-    expect(screen.queryByTestId('circle-marker')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('map-container')).not.toBeInTheDocument();
   });
 });

--- a/app/frontend/src/__tests__/heritageMidpoint.test.js
+++ b/app/frontend/src/__tests__/heritageMidpoint.test.js
@@ -1,4 +1,4 @@
-import { computeHeritageMidpoint, locatableMembers } from '../utils/heritageMidpoint';
+import { locatableMembers, groupByRegion, topRegion } from '../utils/heritageMidpoint';
 
 describe('locatableMembers', () => {
   it('keeps members with numeric lat/lng', () => {
@@ -23,30 +23,81 @@ describe('locatableMembers', () => {
   });
 });
 
-describe('computeHeritageMidpoint', () => {
-  it('returns null when there are no locatable members', () => {
-    expect(computeHeritageMidpoint([])).toBeNull();
-    expect(computeHeritageMidpoint([{ latitude: null, longitude: null }])).toBeNull();
-  });
-
-  it('returns the only member when one is locatable', () => {
-    expect(computeHeritageMidpoint([{ latitude: 41, longitude: 29 }])).toEqual([41, 29]);
-  });
-
-  it('averages latitude and longitude across locatable members', () => {
+describe('groupByRegion', () => {
+  it('returns one group per distinct region', () => {
     const members = [
-      { latitude: 40, longitude: 30 },
-      { latitude: 42, longitude: 28 },
+      { id: 1, region: 'Aegean',    content_type: 'recipe', latitude: 38, longitude: 27 },
+      { id: 2, region: 'Black Sea', content_type: 'story',  latitude: 41, longitude: 36 },
+      { id: 3, region: 'Aegean',    content_type: 'story',  latitude: 37, longitude: 28 },
     ];
-    expect(computeHeritageMidpoint(members)).toEqual([41, 29]);
+    const groups = groupByRegion(members);
+    expect(groups).toHaveLength(2);
+    const aegean = groups.find((g) => g.region === 'Aegean');
+    expect(aegean.members).toHaveLength(2);
+    expect(aegean.coords[0]).toBeCloseTo((38 + 37) / 2, 5);
+    expect(aegean.coords[1]).toBeCloseTo((27 + 28) / 2, 5);
   });
 
-  it('ignores members with missing coordinates when averaging', () => {
+  it('drops members with null coordinates', () => {
     const members = [
-      { latitude: 40, longitude: 30 },
-      { latitude: null, longitude: 0 },
-      { latitude: 42, longitude: 28 },
+      { id: 1, region: 'Aegean', content_type: 'recipe', latitude: 38, longitude: 27 },
+      { id: 2, region: 'Aegean', content_type: 'recipe', latitude: null, longitude: null },
     ];
-    expect(computeHeritageMidpoint(members)).toEqual([41, 29]);
+    const groups = groupByRegion(members);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].members).toHaveLength(1);
+  });
+
+  it('returns empty array when all members lack coordinates', () => {
+    expect(groupByRegion([{ id: 1, region: 'X', latitude: null, longitude: null }])).toEqual([]);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(groupByRegion([])).toEqual([]);
+  });
+
+  it('preserves insertion order for tie-break', () => {
+    const members = [
+      { id: 1, region: 'B', content_type: 'recipe', latitude: 40, longitude: 30 },
+      { id: 2, region: 'A', content_type: 'recipe', latitude: 41, longitude: 29 },
+    ];
+    const groups = groupByRegion(members);
+    expect(groups[0].region).toBe('B');
+    expect(groups[1].region).toBe('A');
+  });
+});
+
+describe('topRegion', () => {
+  it('returns null for empty array', () => {
+    expect(topRegion([])).toBeNull();
+  });
+
+  it('returns the only group when there is one', () => {
+    const groups = [{ region: 'X', coords: [40, 30], members: [{ content_type: 'recipe' }] }];
+    expect(topRegion(groups)).toBe(groups[0]);
+  });
+
+  it('picks the group with the most recipes', () => {
+    const groups = [
+      { region: 'A', coords: [40, 30], members: [{ content_type: 'story' }] },
+      { region: 'B', coords: [41, 29], members: [{ content_type: 'recipe' }, { content_type: 'recipe' }] },
+    ];
+    expect(topRegion(groups)).toBe(groups[1]);
+  });
+
+  it('tie-breaks to the first group (lower index)', () => {
+    const groups = [
+      { region: 'A', coords: [40, 30], members: [{ content_type: 'recipe' }] },
+      { region: 'B', coords: [41, 29], members: [{ content_type: 'recipe' }] },
+    ];
+    expect(topRegion(groups)).toBe(groups[0]);
+  });
+
+  it('falls back to first group when all groups have only stories', () => {
+    const groups = [
+      { region: 'A', coords: [40, 30], members: [{ content_type: 'story' }] },
+      { region: 'B', coords: [41, 29], members: [{ content_type: 'story' }] },
+    ];
+    expect(topRegion(groups)).toBe(groups[0]);
   });
 });

--- a/app/frontend/src/pages/HeritageMapPage.css
+++ b/app/frontend/src/pages/HeritageMapPage.css
@@ -33,16 +33,61 @@
   color: #4A2208;
 }
 
+.heritage-map-layout {
+  display: grid;
+  grid-template-columns: 1fr 320px;
+  gap: 1.5rem;
+  align-items: start;
+}
+
+@media (max-width: 700px) {
+  .heritage-map-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
 .heritage-map-wrap {
   border: 1px solid #EADCBB;
   border-radius: 12px;
   overflow: hidden;
+  height: 420px;
 }
 
 .heritage-map-leaflet {
-  height: 70vh;
-  min-height: 480px;
+  height: 100%;
   width: 100%;
+}
+
+.heritage-map-panel {
+  background: var(--color-surface);
+  border: 1.5px solid var(--color-border);
+  border-radius: 12px;
+  padding: 1.5rem;
+  min-height: 420px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.heritage-map-panel-title {
+  font-size: 1.375rem;
+  color: var(--color-text);
+  margin: 0;
+}
+
+.heritage-map-panel-subtitle {
+  font-size: 0.875rem;
+  color: var(--color-text-muted);
+  margin: 0;
+}
+
+.heritage-map-panel-section h3 {
+  font-size: 0.8125rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--color-primary);
+  margin-bottom: 0.5rem;
 }
 
 .heritage-center-icon {

--- a/app/frontend/src/pages/HeritageMapPage.jsx
+++ b/app/frontend/src/pages/HeritageMapPage.jsx
@@ -1,10 +1,10 @@
 import { useEffect, useState } from 'react';
-import { Link, useNavigate, useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
 import { MapContainer, TileLayer, CircleMarker, Marker, Polyline, Tooltip } from 'react-leaflet';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import { fetchHeritageGroup } from '../services/heritageService';
-import { computeHeritageMidpoint, locatableMembers } from '../utils/heritageMidpoint';
+import { groupByRegion, topRegion } from '../utils/heritageMidpoint';
 import './HeritageMapPage.css';
 
 const centerIcon = L.divIcon({
@@ -16,10 +16,10 @@ const centerIcon = L.divIcon({
 
 export default function HeritageMapPage() {
   const { id } = useParams();
-  const navigate = useNavigate();
   const [group, setGroup] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
+  const [selectedRegion, setSelectedRegion] = useState(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -34,8 +34,12 @@ export default function HeritageMapPage() {
   if (error) return <p className="page-status page-error">{error}</p>;
   if (!group) return null;
 
-  const located = locatableMembers(group.members);
-  const midpoint = computeHeritageMidpoint(group.members);
+  const regionGroups = groupByRegion(group.members);
+  const center = topRegion(regionGroups);
+  const otherRegions = center ? regionGroups.filter((rg) => rg !== center) : [];
+
+  const recipes = selectedRegion?.members.filter((m) => m.content_type === 'recipe') ?? [];
+  const stories = selectedRegion?.members.filter((m) => m.content_type === 'story') ?? [];
 
   return (
     <main className="heritage-map-page">
@@ -49,58 +53,102 @@ export default function HeritageMapPage() {
         </div>
       </header>
 
-      {midpoint ? (
-        <div className="heritage-map-wrap">
-          <MapContainer
-            center={midpoint}
-            zoom={4}
-            className="heritage-map-leaflet"
-            scrollWheelZoom={false}
-          >
-            <TileLayer
-              url="https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png"
-              attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>'
-            />
-            {located.map((member) => (
-              <Polyline
-                key={`line-${member.content_type}-${member.id}`}
-                positions={[midpoint, [member.latitude, member.longitude]]}
-                pathOptions={{ color: '#C4521E', weight: 2, opacity: 0.65, dashArray: '4 4' }}
-              />
-            ))}
-            <Marker
-              position={midpoint}
-              icon={centerIcon}
-              eventHandlers={{ click: () => navigate(`/heritage/${group.id}`) }}
+      {center ? (
+        <div className="heritage-map-layout">
+          <div className="heritage-map-wrap">
+            <MapContainer
+              center={center.coords}
+              zoom={4}
+              className="heritage-map-leaflet"
+              scrollWheelZoom={false}
             >
-              <Tooltip direction="top" offset={[0, -12]} opacity={0.95}>
-                {group.name}
-              </Tooltip>
-            </Marker>
-            {located.map((member) => (
-              <CircleMarker
-                key={`pin-${member.content_type}-${member.id}`}
-                center={[member.latitude, member.longitude]}
-                radius={10}
-                pathOptions={{
-                  color: '#A3401A',
-                  fillColor: member.content_type === 'recipe' ? '#C4521E' : '#8C4A1C',
-                  fillOpacity: 0.9,
-                  weight: 2,
-                }}
-                eventHandlers={{
-                  click: () =>
-                    navigate(
-                      `/${member.content_type === 'recipe' ? 'recipes' : 'stories'}/${member.id}`,
-                    ),
-                }}
+              <TileLayer
+                url="https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png"
+                attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>'
+              />
+              {otherRegions.map((rg) => (
+                <Polyline
+                  key={`line-${rg.region}`}
+                  positions={[center.coords, rg.coords]}
+                  pathOptions={{ color: '#C4521E', weight: 2, opacity: 0.65, dashArray: '4 4' }}
+                />
+              ))}
+              <Marker
+                position={center.coords}
+                icon={centerIcon}
+                eventHandlers={{ click: () => setSelectedRegion(center) }}
               >
-                <Tooltip direction="top" offset={[0, -8]} opacity={0.95}>
-                  {member.content_type === 'recipe' ? '🍲 ' : '📖 '}{member.title}
+                <Tooltip direction="top" offset={[0, -12]} opacity={0.95}>
+                  {center.region}
                 </Tooltip>
-              </CircleMarker>
-            ))}
-          </MapContainer>
+              </Marker>
+              {otherRegions.map((rg) => (
+                <CircleMarker
+                  key={`pin-${rg.region}`}
+                  center={rg.coords}
+                  radius={10}
+                  pathOptions={{
+                    color: '#A3401A',
+                    fillColor: '#FAF7EF',
+                    fillOpacity: 0.85,
+                    weight: 2,
+                  }}
+                  eventHandlers={{ click: () => setSelectedRegion(rg) }}
+                >
+                  <Tooltip direction="top" offset={[0, -8]} opacity={0.95}>
+                    {rg.region}
+                  </Tooltip>
+                </CircleMarker>
+              ))}
+            </MapContainer>
+          </div>
+
+          <aside className="heritage-map-panel">
+            {selectedRegion ? (
+              <>
+                <h2 className="heritage-map-panel-title">{selectedRegion.region}</h2>
+                <p className="heritage-map-panel-subtitle">in {group.name}</p>
+
+                {recipes.length > 0 && (
+                  <section className="heritage-map-panel-section">
+                    <h3>Recipes</h3>
+                    <ul className="map-content-list">
+                      {recipes.map((r) => (
+                        <li key={r.id}>
+                          <Link to={`/recipes/${r.id}`} className="map-content-item">
+                            <span className="map-content-title">{r.title}</span>
+                            <span className="map-content-author">@{r.author}</span>
+                          </Link>
+                        </li>
+                      ))}
+                    </ul>
+                  </section>
+                )}
+
+                {stories.length > 0 && (
+                  <section className="heritage-map-panel-section">
+                    <h3>Stories</h3>
+                    <ul className="map-content-list">
+                      {stories.map((s) => (
+                        <li key={s.id}>
+                          <Link to={`/stories/${s.id}`} className="map-content-item">
+                            <span className="map-content-title">{s.title}</span>
+                            <span className="map-content-author">@{s.author}</span>
+                          </Link>
+                        </li>
+                      ))}
+                    </ul>
+                  </section>
+                )}
+
+                {recipes.length === 0 && stories.length === 0 && (
+                  <p className="map-panel-empty">No content for this region yet.</p>
+                )}
+              </>
+            ) : (
+              <p className="map-panel-empty">Select a region pin to explore its heritage content.</p>
+            )}
+          </aside>
         </div>
       ) : (
         <p className="heritage-map-empty">No locations to plot for this heritage group yet.</p>

--- a/app/frontend/src/utils/heritageMidpoint.js
+++ b/app/frontend/src/utils/heritageMidpoint.js
@@ -5,10 +5,26 @@ export function locatableMembers(members) {
   );
 }
 
-export function computeHeritageMidpoint(members) {
+export function groupByRegion(members) {
   const located = locatableMembers(members);
-  if (located.length === 0) return null;
-  const sumLat = located.reduce((acc, m) => acc + m.latitude, 0);
-  const sumLng = located.reduce((acc, m) => acc + m.longitude, 0);
-  return [sumLat / located.length, sumLng / located.length];
+  const map = new Map();
+  for (const m of located) {
+    const key = m.region ?? '';
+    if (!map.has(key)) map.set(key, []);
+    map.get(key).push(m);
+  }
+  return Array.from(map.entries()).map(([region, ms]) => {
+    const lat = ms.reduce((s, m) => s + m.latitude, 0) / ms.length;
+    const lng = ms.reduce((s, m) => s + m.longitude, 0) / ms.length;
+    return { region, coords: [lat, lng], members: ms };
+  });
+}
+
+export function topRegion(regionGroups) {
+  if (regionGroups.length === 0) return null;
+  return regionGroups.reduce((best, rg) => {
+    const count = rg.members.filter((m) => m.content_type === 'recipe').length;
+    const bestCount = best.members.filter((m) => m.content_type === 'recipe').length;
+    return count > bestCount ? rg : best;
+  }, regionGroups[0]);
 }


### PR DESCRIPTION
## Summary

heritageMidpoint.js: Replaced `computeHeritageMidpoint` (geometric centroid of all members) with `groupByRegion` and `topRegion`. `groupByRegion` collapses locatable members into per-region buckets with averaged coordinates. `topRegion` picks the region with the most recipes as the semantic center, first-occurrence wins on ties.

HeritageMapPage: Replaced per-member CircleMarkers with per-region pins. Map centers on the top region's coordinates. Polylines fan out from that center to each other region. Clicking any pin (including the center 🏛 marker) opens an in-page region panel that lists the heritage's recipes and stories tagged to that region, with row links to `/recipes/:id` and `/stories/:id`.

HeritageMapPage.css: Added split-grid layout (map left, 320 px panel right, stacks on mobile ≤ 700 px) and panel component styles consistent with the existing MapPage panel.

Tests: Rewrote `heritageMidpoint.test.js` (13 cases covering `groupByRegion` and `topRegion`) and `HeritageMapPage.test.jsx` (9 cases covering center position, pin/polyline counts, single-region and zero-region edge cases, and panel open/content on click).

## Test plan
- [ ] `/heritage/:id/map` — map loads, center 🏛 marker sits on the most-recipe region
- [ ] Other regions each have one CircleMarker (no per-member stacking)
- [ ] Polylines connect center → each other region
- [ ] Click center marker → panel opens showing that region's recipes/stories
- [ ] Click a region pin → panel switches to that region's content
- [ ] Row link in panel routes to `/recipes/:id` or `/stories/:id`
- [ ] Heritage with one region only → no polylines, panel still works
- [ ] Heritage with no plottable coordinates → empty-state message, no map
- [ ] `CI=true npm test` → 599/599 pass

Closes #668