### PR TITLE
fix(frontend): null username crash, video validation, submitting guard, orphan recipe (#693, #696, #703, #704)

### DIFF
--- a/app/frontend/src/pages/InboxPage.jsx
+++ b/app/frontend/src/pages/InboxPage.jsx
@@ -117,7 +117,7 @@ export default function InboxPage() {
             <li key={thread.id}>
               <Link to={`/inbox/${thread.id}`} className="thread-row">
                 <div className="thread-avatar" aria-hidden="true">
-                  {thread.otherUser.username[0].toUpperCase()}
+                  {thread.otherUser.username?.[0]?.toUpperCase() ?? '?'}
                 </div>
                 <div className="thread-info">
                   <div className="thread-header-row">

--- a/app/frontend/src/pages/LoginPage.jsx
+++ b/app/frontend/src/pages/LoginPage.jsx
@@ -13,6 +13,7 @@ export default function LoginPage() {
   const [password, setPassword] = useState('');
   const [errors, setErrors] = useState({});
   const [apiError, setApiError] = useState('');
+  const [submitting, setSubmitting] = useState(false);
 
   const animationClass = location.state?.from === 'register' ? 'auth-enter-left' : 'auth-enter-right';
 
@@ -25,6 +26,7 @@ export default function LoginPage() {
 
   async function handleSubmit(e) {
     e.preventDefault();
+    if (submitting) return;
     const errs = validate();
     if (Object.keys(errs).length > 0) {
       setErrors(errs);
@@ -32,12 +34,15 @@ export default function LoginPage() {
     }
     setErrors({});
     setApiError('');
+    setSubmitting(true);
     try {
       const data = await loginRequest(email, password);
       login(data.user, data.access, data.refresh);
       navigate('/');
     } catch (err) {
       setApiError(extractApiError(err, 'Invalid email or password.'));
+    } finally {
+      setSubmitting(false);
     }
   }
 
@@ -66,7 +71,9 @@ export default function LoginPage() {
           {errors.password && <span className="field-error">{errors.password}</span>}
         </div>
         {apiError && <p className="api-error">{apiError}</p>}
-        <button type="submit" className="btn btn-primary auth-submit">Log In</button>
+        <button type="submit" className="btn btn-primary auth-submit" disabled={submitting}>
+          {submitting ? 'Logging in…' : 'Log In'}
+        </button>
       </form>
       <p className="auth-footer">Don't have an account? <Link to="/register" state={{ from: 'login' }}>Register</Link></p>
     </main>

--- a/app/frontend/src/pages/RecipeCreatePage.jsx
+++ b/app/frontend/src/pages/RecipeCreatePage.jsx
@@ -57,6 +57,7 @@ export default function RecipeCreatePage() {
   const [regions, setRegions] = useState([]);
 
   const [errors, setErrors] = useState({});
+  const [submitting, setSubmitting] = useState(false);
   const [toast, setToast] = useState({ message: '', type: 'success' });
 
   const draftState = { title, description, region, qaEnabled, rows };
@@ -137,6 +138,7 @@ export default function RecipeCreatePage() {
   }
 
   async function submit(publish) {
+    if (submitting) return;
     if (!validate()) {
       document.getElementById('error-summary')?.focus();
       return;
@@ -156,13 +158,22 @@ export default function RecipeCreatePage() {
       })),
     };
 
+    setSubmitting(true);
     try {
       const created = await createRecipe(payload);
       if (video || thumbnail) {
         const mediaData = new FormData();
         if (video) mediaData.append('video', video);
         if (thumbnail) mediaData.append('image', thumbnail);
-        await updateRecipe(created.id, mediaData);
+        try {
+          await updateRecipe(created.id, mediaData);
+        } catch {
+          clearDraft();
+          isDirty.current = false;
+          showToast('Recipe published but media upload failed — open it to retry.', 'error');
+          setTimeout(() => navigate(`/recipes/${created.id}`), 1500);
+          return;
+        }
       }
       clearDraft();
       isDirty.current = false;
@@ -173,6 +184,7 @@ export default function RecipeCreatePage() {
         publish ? 'Failed to publish recipe. Please try again.' : 'Failed to save draft. Please try again.',
         'error'
       );
+      setSubmitting(false);
     }
   }
 
@@ -370,6 +382,7 @@ export default function RecipeCreatePage() {
           <button
             type="button"
             className="btn btn-outline"
+            disabled={submitting}
             onClick={() => submit(false)}
           >
             Save as draft
@@ -377,9 +390,10 @@ export default function RecipeCreatePage() {
           <button
             type="button"
             className="btn btn-primary publish-btn"
+            disabled={submitting}
             onClick={() => submit(true)}
           >
-            Publish Recipe
+            {submitting ? 'Publishing…' : 'Publish Recipe'}
           </button>
           <p className="publish-note">
             Drafts stay private to you. Published recipes are visible to everyone.

--- a/app/frontend/src/pages/RecipeEditPage.jsx
+++ b/app/frontend/src/pages/RecipeEditPage.jsx
@@ -130,7 +130,7 @@ export default function RecipeEditPage() {
   function validate() {
     const e = {};
     if (!title.trim()) e.title = 'Title is required.';
-    if (!description.trim() && !video) e.content = 'A description or video is required.';
+    if (!description.trim() && !video && !recipe?.video) e.content = 'A description or video is required.';
     for (const row of rows) {
       if (row.amount !== '' && (isNaN(Number(row.amount)) || Number(row.amount) <= 0)) {
         e.amount = 'Amount must be a positive number.';

--- a/app/frontend/src/pages/RegisterPage.jsx
+++ b/app/frontend/src/pages/RegisterPage.jsx
@@ -14,6 +14,7 @@ export default function RegisterPage() {
   const [password, setPassword] = useState('');
   const [errors, setErrors] = useState({});
   const [apiError, setApiError] = useState('');
+  const [submitting, setSubmitting] = useState(false);
 
   const animationClass = location.state?.from === 'login' ? 'auth-enter-right' : 'auth-enter-left';
 
@@ -27,6 +28,7 @@ export default function RegisterPage() {
 
   async function handleSubmit(e) {
     e.preventDefault();
+    if (submitting) return;
     const errs = validate();
     if (Object.keys(errs).length > 0) {
       setErrors(errs);
@@ -34,12 +36,15 @@ export default function RegisterPage() {
     }
     setErrors({});
     setApiError('');
+    setSubmitting(true);
     try {
       const data = await registerRequest(username, email, password);
       login(data.user, data.access, data.refresh);
       navigate('/onboarding');
     } catch (err) {
       setApiError(extractApiError(err, 'Registration failed. Please try again.'));
+    } finally {
+      setSubmitting(false);
     }
   }
 
@@ -78,7 +83,9 @@ export default function RegisterPage() {
           {errors.password && <span className="field-error">{errors.password}</span>}
         </div>
         {apiError && <p className="api-error">{apiError}</p>}
-        <button type="submit" className="btn btn-primary auth-submit">Register</button>
+        <button type="submit" className="btn btn-primary auth-submit" disabled={submitting}>
+          {submitting ? 'Registering…' : 'Register'}
+        </button>
       </form>
       <p className="auth-footer">Already have an account? <Link to="/login" state={{ from: 'register' }}>Log In</Link></p>
     </main>

--- a/app/frontend/src/pages/StoryCreatePage.jsx
+++ b/app/frontend/src/pages/StoryCreatePage.jsx
@@ -20,6 +20,7 @@ export default function StoryCreatePage() {
   const [recipeSearch, setRecipeSearch] = useState('');
   const [allRecipes, setAllRecipes] = useState([]);
   const [errors, setErrors] = useState({});
+  const [submitting, setSubmitting] = useState(false);
   const [toast, setToast] = useState({ message: '', type: 'success' });
 
   const draftState = { title, body, language, linkedRecipe };
@@ -51,7 +52,7 @@ export default function StoryCreatePage() {
   }
 
   async function submit(publish) {
-    if (!validate()) return;
+    if (submitting || !validate()) return;
 
     const formData = new FormData();
     formData.append('title', title);
@@ -61,6 +62,7 @@ export default function StoryCreatePage() {
     if (linkedRecipe) formData.append('linked_recipe', linkedRecipe.id);
     if (image) formData.append('image', image);
 
+    setSubmitting(true);
     try {
       const created = await createStory(formData);
       clearDraft();
@@ -71,6 +73,8 @@ export default function StoryCreatePage() {
         publish ? 'Failed to publish story. Please try again.' : 'Failed to save draft. Please try again.',
         'error'
       );
+    } finally {
+      setSubmitting(false);
     }
   }
 
@@ -178,6 +182,7 @@ export default function StoryCreatePage() {
           <button
             type="button"
             className="btn btn-outline"
+            disabled={submitting}
             onClick={() => submit(false)}
           >
             Save as draft
@@ -185,9 +190,10 @@ export default function StoryCreatePage() {
           <button
             type="button"
             className="btn btn-primary"
+            disabled={submitting}
             onClick={() => submit(true)}
           >
-            Publish Story
+            {submitting ? 'Publishing…' : 'Publish Story'}
           </button>
         </div>
       </form>

--- a/app/frontend/src/pages/ThreadPage.jsx
+++ b/app/frontend/src/pages/ThreadPage.jsx
@@ -93,7 +93,7 @@ export default function ThreadPage() {
                 <div key={msg.id} className={`bubble-row ${isMine ? 'mine' : 'theirs'}`}>
                   {!isMine && (
                     <div className="bubble-avatar" aria-hidden="true">
-                      {msg.sender.username[0].toUpperCase()}
+                      {msg.sender.username?.[0]?.toUpperCase() ?? '?'}
                     </div>
                   )}
                   <div className="bubble-wrap">


### PR DESCRIPTION
## Summary

- **InboxPage, ThreadPage**: `username[0]` calls crash on null/empty usernames — replaced with `username?.[0]?.toUpperCase() ?? '?'` in both files. Navbar was already guarded.
- **RecipeEditPage**: Video validation checked only the newly selected file (`!video`), ignoring an already-uploaded server video (`recipe.video`). Fix adds `!recipe?.video` to the condition so existing videos satisfy the rule.
- **RecipeCreatePage**: On successful JSON POST but failed media PATCH, the page showed a generic error and left an orphan recipe. Now navigates to the new recipe immediately with a distinct toast ("published but media upload failed"), preventing duplicate submissions on retry.
- **Login, Register, StoryCreate, RecipeCreate**: No submitting guard existed — rapid clicks fired concurrent requests. Added `submitting` boolean state; buttons are disabled and handler is gated while in-flight.

## Test plan

 [ ] Open Inbox as a user whose conversation partner has a null/empty username — no white screen, `?` initial shows
 [ ] Edit a recipe that already has a video, clear the description, save — validation passes
 [ ] Edit a recipe with neither a remote video nor a description — validation still rejects
 [ ] On Recipe Create, spam-click Publish — only one POST in the network log, button goes grey
 [ ] On Login, spam-click Log In — only one auth request fires
 [ ] On Register, spam-click Register — only one registration request fires
 [ ] On Story Create, spam-click Publish — only one POST fires