### PR TITLE
fix(frontend): auth race on hard refresh + linked_recipe integer crash (#694, #695)

### DIFF
--- a/app/frontend/src/pages/ModerationPage.jsx
+++ b/app/frontend/src/pages/ModerationPage.jsx
@@ -19,7 +19,7 @@ function formatDate(iso) {
 }
 
 export default function ModerationPage() {
-  const { user } = useContext(AuthContext);
+  const { user, loading: authLoading } = useContext(AuthContext);
   const navigate = useNavigate();
   const [queue, setQueue] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -28,12 +28,13 @@ export default function ModerationPage() {
   const [rejectReasons, setRejectReasons] = useState({});
 
   useEffect(() => {
+    if (authLoading) return;
     if (!user) { navigate('/login'); return; }
     if (!user.is_staff) { setLoading(false); return; }
     fetchModerationQueue()
       .then(setQueue)
       .finally(() => setLoading(false));
-  }, [user, navigate]);
+  }, [user, authLoading, navigate]);
 
   const handle = async (typeKey, id, action, reason = '') => {
     setProcessing(id);

--- a/app/frontend/src/pages/StoryEditPage.jsx
+++ b/app/frontend/src/pages/StoryEditPage.jsx
@@ -11,7 +11,7 @@ import './StoryEditPage.css';
 export default function StoryEditPage() {
   const { id } = useParams();
   const navigate = useNavigate();
-  const { user } = useContext(AuthContext);
+  const { user, loading: authLoading } = useContext(AuthContext);
 
   const [story, setStory] = useState(null);
   const [title, setTitle] = useState('');
@@ -42,7 +42,13 @@ export default function StoryEditPage() {
         setTitle(storyData.title);
         setBody(storyData.body || '');
         setLanguage(storyData.language || 'en');
-        setLinkedRecipe(storyData.linked_recipe || null);
+        const linkedId = storyData.linked_recipe;
+        if (linkedId) {
+          const found = recipes.find((r) => r.id === linkedId);
+          setLinkedRecipe(found ?? { id: linkedId, title: `Recipe #${linkedId}` });
+        } else {
+          setLinkedRecipe(null);
+        }
         setAllRecipes(recipes);
       })
       .catch(() => { if (!cancelled) setLoadError('Could not load story.'); })
@@ -80,7 +86,10 @@ export default function StoryEditPage() {
     formData.append('body', body);
     formData.append('language', language);
     formData.append('is_published', publish ? 'true' : 'false');
-    if (linkedRecipe) formData.append('linked_recipe', linkedRecipe.id);
+    if (linkedRecipe) {
+      const recipeId = typeof linkedRecipe === 'object' ? linkedRecipe.id : linkedRecipe;
+      formData.append('linked_recipe', recipeId);
+    }
     if (image) formData.append('image', image);
 
     try {
@@ -101,7 +110,7 @@ export default function StoryEditPage() {
     };
   }, []);
 
-  if (loading) return <p className="page-status">Loading…</p>;
+  if (loading || authLoading) return <p className="page-status">Loading…</p>;
   if (loadError) return <p className="page-status page-error">{loadError}</p>;
   const storyAuthorId = story?.author && typeof story.author === 'object' ? story.author.id : story?.author;
   const isAuthor = user && story && storyAuthorId != null && user.id === storyAuthorId;


### PR DESCRIPTION
## Summary

- **StoryEditPage, ModerationPage**: Both pages evaluated user-based guards before `AuthContext.loading` resolved. On hard refresh, `user` is `null` for a frame — story authors were redirected to the read-only detail page, and admins were sent to `/login`. Fixed by consuming `loading` from `AuthContext` and showing a loading state until auth settles.
- **StoryEditPage**: `linked_recipe` is returned as an integer pk by the backend. The page stored the raw integer in state and then read `.id` and `.title` from it (both `undefined`), causing the linked recipe label to render blank and the link to be silently cleared on every save. Fixed by resolving the pk to a full `{id, title}` object on load using the already-fetched recipes list. The save call now safely extracts the pk regardless of type.

## Test plan

 [ ] Hard-refresh `/stories/<id>/edit` as the story author — stays on the edit page, no redirect to detail
 [ ] Hard-refresh `/admin/moderation` as an admin — stays on the moderation queue, no redirect to login
 [ ] Open edit page for a story with a linked recipe — recipe title appears in the linked badge
 [ ] Save without changing the linked recipe — linked recipe survives in the API response
 [ ] Pick a new recipe from the picker, save — backend reflects the new link
 [ ] Remove the linked recipe, save — link is cleared correctly