### PR TITLE
fix(frontend): MapPage crash/race/error handling + RecipeDetailPage 4 bugs (#697, #698)

### DIFF
--- a/app/frontend/src/pages/MapPage.jsx
+++ b/app/frontend/src/pages/MapPage.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { Link } from 'react-router-dom';
 import { MapContainer, TileLayer, CircleMarker, Tooltip } from 'react-leaflet';
 import 'leaflet/dist/leaflet.css';
@@ -10,7 +10,9 @@ export default function MapPage() {
   const [selected, setSelected] = useState(null);
   const [content, setContent] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState('');
   const [contentLoading, setContentLoading] = useState(false);
+  const currentRegionId = useRef(null);
 
   useEffect(() => {
     fetchMapRegions()
@@ -18,15 +20,25 @@ export default function MapPage() {
         setRegions(data);
         if (data.length > 0) selectRegion(data[0]);
       })
+      .catch(() => setLoadError('Could not load regions.'))
       .finally(() => setLoading(false));
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   function selectRegion(region) {
     setSelected(region);
     setContentLoading(true);
+    currentRegionId.current = region.id;
     fetchMapRegionContent(region.id)
-      .then(setContent)
-      .finally(() => setContentLoading(false));
+      .then((data) => {
+        if (currentRegionId.current === region.id) setContent(data);
+      })
+      .catch(() => {
+        if (currentRegionId.current === region.id) setContent([]);
+      })
+      .finally(() => {
+        if (currentRegionId.current === region.id) setContentLoading(false);
+      });
   }
 
   const recipes = content.filter((c) => c.content_type === 'recipe');
@@ -75,6 +87,7 @@ export default function MapPage() {
             </MapContainer>
           )}
           {loading && <div className="map-loading">Loading map…</div>}
+          {loadError && <div className="map-loading map-error">{loadError}</div>}
         </div>
 
         <aside className="map-panel">
@@ -82,8 +95,8 @@ export default function MapPage() {
             <>
               <h2 className="map-panel-title">{selected.name}</h2>
               <div className="map-panel-counts">
-                <span>{selected.content_count.recipes} recipes</span>
-                <span>{selected.content_count.stories} stories</span>
+                <span>{selected.content_count?.recipes ?? 0} recipes</span>
+                <span>{selected.content_count?.stories ?? 0} stories</span>
               </div>
 
               {contentLoading && <p className="map-panel-empty">Loading…</p>}

--- a/app/frontend/src/pages/RecipeDetailPage.jsx
+++ b/app/frontend/src/pages/RecipeDetailPage.jsx
@@ -50,6 +50,14 @@ export default function RecipeDetailPage() {
   const [recipeFacts, setRecipeFacts] = useState([]);
 
   useEffect(() => {
+    setChecked(new Set());
+    setShowShoppingList(false);
+    setOpenSubPanel(null);
+    setSubstitutes({});
+    setAppliedSubs({});
+  }, [id]);
+
+  useEffect(() => {
     let cancelled = false;
     fetchRegions().then((r) => { if (!cancelled) setRegions(r); }).catch(() => {});
     fetchRecipe(id)
@@ -145,10 +153,10 @@ export default function RecipeDetailPage() {
   const isAuthor = user && user.id === recipe.author;
   const regionName = regions.find((r) => r.id === recipe.region)?.name;
 
-  const hasConverted = recipe.ingredients.some((ri) => ri.converted_amount);
+  const hasConverted = (recipe.ingredients ?? []).some((ri) => ri.converted_amount);
 
   // Shopping list: unchecked ingredients with substitutions applied
-  const shoppingItems = recipe.ingredients
+  const shoppingItems = (recipe.ingredients ?? [])
     .filter((ri) => !checked.has(ri.ingredient))
     .map((ri) => {
       const sub = appliedSubs[ri.ingredient];
@@ -197,7 +205,7 @@ export default function RecipeDetailPage() {
               className="btn btn-outline btn-sm"
               onClick={() =>
                 navigate(
-                  `/inbox?compose=true&to=${recipe.author}&toUsername=${recipe.author_username}` +
+                  `/inbox?compose=true&to=${recipe.author}&toUsername=${encodeURIComponent(recipe.author_username)}` +
                   `&recipeId=${recipe.id}&recipeTitle=${encodeURIComponent(recipe.title)}`
                 )
               }
@@ -253,7 +261,7 @@ export default function RecipeDetailPage() {
         </div>
 
         <ul className="ingredients-list">
-          {recipe.ingredients.map((ri) => {
+          {(recipe.ingredients ?? []).map((ri, index) => {
             const isChecked = checked.has(ri.ingredient);
             const sub = appliedSubs[ri.ingredient];
             const amount = useConverted && ri.converted_amount ? ri.converted_amount : ri.amount;
@@ -261,7 +269,7 @@ export default function RecipeDetailPage() {
             const isSubOpen = openSubPanel === ri.ingredient;
 
             return (
-              <li key={ri.ingredient} className={`ingredient-item${isChecked ? ' checked' : ''}`}>
+              <li key={`${ri.ingredient}-${index}`} className={`ingredient-item${isChecked ? ' checked' : ''}`}>
                 <div className="ingredient-row">
                   {user && (
                     <input


### PR DESCRIPTION
## Summary

**MapPage (#697)**
- `content_count.recipes` / `.stories` crashed when `content_count` was null — replaced with `?.` optional chaining and `?? 0` fallback.
- Rapid region clicks caused a stale fetch to overwrite newer content — a `currentRegionId` ref now discards responses that no longer match the selected region.
- Region list fetch had no `.catch()` — failure rendered a blank map with no feedback. Added error state with a visible message.
- Per-region content fetch had no `.catch()` — failure was silent. Content is now cleared and loading ends cleanly on error.

**RecipeDetailPage (#698)**
- Navigating from recipe A to recipe B carried over A's check-offs, shopping list, and substitutions — added a `useEffect` on `id` that resets all per-recipe state.
- `recipe.ingredients` being null/undefined crashed the page — guarded with `?? []` in all three usages.
- Same ingredient appearing twice caused React duplicate-key warning — key is now `ingredient-index`.
- `toUsername` in the message compose link was not URL-encoded — usernames with spaces or unicode broke the route.

## Test plan

 [ ] Open Map page, kill the backend — clear error message appears instead of a blank screen
 [ ] Click region A, immediately click region B — B's content renders (not A's)
 [ ] Click any region whose `content_count` is null — panel renders without crash
 [ ] Open recipe A, check off ingredients, navigate to recipe B — B starts with a clean shopping list
 [ ] Open a recipe with `ingredients: null` — page renders without crash
 [ ] Open a recipe whose author has a unicode/space username, click Message — compose URL is valid