### PR TITLE
chore(mobile): Jest + RTL setup follow-up review — add TESTING.md (closes #724)

### DIFF
--- a/app/mobile/TESTING.md
+++ b/app/mobile/TESTING.md
@@ -1,0 +1,112 @@
+# Mobile testing guide
+
+Quick reference for the Jest + React Native Testing Library setup in `app/mobile/`.
+
+## Stack
+
+- **Runner:** `jest` 29 via the `jest-expo` preset (Expo SDK 54, RN 0.81, React 19).
+- **Renderer:** `@testing-library/react-native` 13 (+ `react-test-renderer` 19).
+- **Config:** `jest` block in `package.json` — no separate `jest.config.js`.
+- **Coverage scope:** `src/**/*.{ts,tsx}`, excluding `src/mocks/**`.
+- **Test layout:** all tests live under `__tests__/` mirroring `src/` (`__tests__/components/`, `__tests__/screens/`, `__tests__/services/`, `__tests__/utils/`).
+
+`__tests__/smoke.test.tsx` is the harness sanity check — keep it green.
+
+## Running tests
+
+```bash
+cd app/mobile
+
+# Whole suite
+npx jest
+
+# A single file
+npx jest __tests__/services/passportActionService.test.ts
+
+# By test name (regex)
+npx jest -t "POSTs to the passport try endpoint"
+
+# Watch mode while editing
+npx jest --watch
+
+# Coverage report (writes to coverage/)
+npx jest --coverage
+
+# Update snapshots after intentional UI changes
+npx jest -u
+```
+
+## Debugging
+
+Attach a Node inspector (Chrome DevTools → `chrome://inspect`, or VS Code):
+
+```bash
+node --inspect-brk node_modules/.bin/jest --runInBand __tests__/components/PassportWorldMap.test.tsx
+```
+
+`--runInBand` keeps everything on one worker so breakpoints behave. Add `debugger;` statements or set breakpoints in the inspector once it attaches.
+
+For noisy failures, `npx jest --verbose <path>` prints each `it()` line.
+
+## Mocking conventions
+
+We mock per-file (no global `__mocks__/` directory) so each test owns its boundaries explicitly. Patterns currently in use:
+
+### `httpClient`
+
+Service tests stub the HTTP layer rather than hitting the network:
+
+```ts
+import { apiPostJson } from '../../src/services/httpClient';
+
+jest.mock('../../src/services/httpClient', () => ({
+  apiPostJson: jest.fn(),
+  apiGetJson: jest.fn(),
+}));
+
+const mockedPost = apiPostJson as jest.MockedFunction<typeof apiPostJson>;
+beforeEach(() => mockedPost.mockReset());
+```
+
+This also sidesteps `AsyncStorage` (which `httpClient` reaches for to load the auth token), so service tests do not need an `AsyncStorage` mock.
+
+### `react-native-maps`
+
+The native module cannot load under Jest. Tests that render map components mock it inline with plain RN views and forward the props they assert on:
+
+```ts
+jest.mock('react-native-maps', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  const MapView = React.forwardRef(({ children, ...rest }: any, ref: any) =>
+    React.createElement(View, { ref, ...rest, testID: rest.testID ?? 'mock-map' }, children),
+  );
+  const Marker = (props: any) =>
+    React.createElement(View, { testID: props.testID ?? `marker-${props.title ?? ''}` });
+  return { __esModule: true, default: MapView, Marker, Callout: View };
+});
+```
+
+See `__tests__/components/PassportWorldMap.test.tsx` for the full pattern.
+
+### Expo modules (`expo-av`, `expo-image-picker`, `expo-clipboard`)
+
+`jest-expo` handles most Expo modules out of the box. If a new test pulls in one of these and crashes on a native call, mock the specific function inline:
+
+```ts
+jest.mock('expo-clipboard', () => ({ setStringAsync: jest.fn() }));
+```
+
+Prefer narrow mocks over replacing the whole module.
+
+## Writing new tests
+
+- One test file per service / component / util, mirroring the `src/` path.
+- Pure utilities (`src/utils/*`) get unit tests against the function directly — no rendering.
+- Components: render with `@testing-library/react-native` and assert against `getByText` / `getByTestId` / accessibility roles rather than snapshotting whole trees.
+- Service tests: mock `httpClient` exports as above and assert on URL + payload + parsed return value, including the empty-body fallback case where relevant.
+- Reset mocks between cases (`beforeEach(() => fn.mockReset())`) so order does not leak state.
+
+## CI
+
+`npx jest` runs in CI from `app/mobile`. Keep it green; a failing mobile suite blocks merge.


### PR DESCRIPTION
## Summary

Followed up on the Jest + RTL setup landed in #532/#726 now that many more PRs have written tests against it. Audited `jest` config (in `package.json`), the per-file mock patterns (`react-native-maps`, `httpClient`, expo modules), the `__tests__/` layout, the smoke test, and coverage scoping. Suite is green and the setup is in good shape — no config, mock, or test changes were needed.

Captured the conventions in a new `app/mobile/TESTING.md` (how to run a single file, debug with `--inspect-brk`, update snapshots, plus the per-file mocking patterns) so future contributors do not have to re-derive them by reading other tests.

## Before / after — `npx jest`

Identical (no source changes):

```
Test Suites: 24 passed, 24 total
Tests:       150 passed, 150 total
Snapshots:   0 total
Time:        ~6s
```

`npx tsc --noEmit` clean. Metro `index.bundle?platform=ios` returns HTTP 200 (~2.3 MB).

## Notes from the review (no action taken)

- Coverage already scopes to `src/**/*.{ts,tsx}` with `!src/mocks/**`. `__tests__/` sits outside `src/`, so it is not double-counted.
- `transformIgnorePatterns` is inherited from `jest-expo` and currently covers every ESM module imported by tests — no overrides needed.
- No `__mocks__/` directory exists; tests mock per file. This is consistent across the suite and works well.
- Service tests that stub `httpClient` correctly avoid needing an `AsyncStorage` mock (the token lookup never runs).
- A couple of screen tests mock services they could otherwise assert on, but that is out of scope for this housekeeping pass.

## Test plan

- [ ] `cd app/mobile && npx jest` — 24 suites / 150 tests pass.
- [ ] `cd app/mobile && npx tsc --noEmit` — no errors.
- [ ] `cd app/mobile && npx expo start` — Metro serves `index.bundle` with HTTP 200.
- [ ] Open `app/mobile/TESTING.md` and confirm the commands and mock snippets match what tests in the repo actually do.

Closes #724