### PR TITLE
feat(mobile): EditProfileScreen — display name, bio, avatar (if backend supports), prefs link (closes #661)

### DIFF
--- a/app/mobile/__tests__/screens/EditProfileScreen.test.tsx
+++ b/app/mobile/__tests__/screens/EditProfileScreen.test.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import { render, fireEvent, waitFor, act } from '@testing-library/react-native';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
+
+jest.mock('../../src/services/profileService', () => ({
+  fetchOwnProfile: jest.fn(),
+  updateOwnProfile: jest.fn(),
+}));
+
+const mockUpdateUser = jest.fn().mockResolvedValue(undefined);
+jest.mock('../../src/context/AuthContext', () => ({
+  useAuth: () => ({
+    user: { id: '1', username: 'ayse', email: 'ayse@example.com' },
+    updateUser: mockUpdateUser,
+  }),
+}));
+
+const mockShowToast = jest.fn();
+jest.mock('../../src/context/ToastContext', () => ({
+  useToast: () => ({ showToast: mockShowToast }),
+}));
+
+import EditProfileScreen from '../../src/screens/EditProfileScreen';
+import {
+  fetchOwnProfile,
+  updateOwnProfile,
+} from '../../src/services/profileService';
+
+const mockedFetch = fetchOwnProfile as jest.MockedFunction<typeof fetchOwnProfile>;
+const mockedUpdate = updateOwnProfile as jest.MockedFunction<typeof updateOwnProfile>;
+
+function makeProps() {
+  const navigation = {
+    navigate: jest.fn(),
+    goBack: jest.fn(),
+    setOptions: jest.fn(),
+    addListener: jest.fn(() => () => undefined),
+  } as any;
+  const route = { key: 'k', name: 'EditProfile', params: undefined } as any;
+  return { navigation, route };
+}
+
+function renderScreen() {
+  const props = makeProps();
+  const utils = render(
+    <SafeAreaProvider
+      initialMetrics={{
+        frame: { x: 0, y: 0, width: 320, height: 640 },
+        insets: { top: 0, left: 0, right: 0, bottom: 0 },
+      }}
+    >
+      <EditProfileScreen {...props} />
+    </SafeAreaProvider>,
+  );
+  return { ...utils, ...props };
+}
+
+describe('EditProfileScreen', () => {
+  beforeEach(() => {
+    mockedFetch.mockReset();
+    mockedUpdate.mockReset();
+    mockUpdateUser.mockClear();
+    mockShowToast.mockClear();
+  });
+
+  it('renders the fetched profile and prefills the bio and region inputs', async () => {
+    mockedFetch.mockResolvedValueOnce({
+      id: 1,
+      username: 'ayse',
+      email: 'ayse@example.com',
+      bio: 'Black Sea cook.',
+      region: 'Black Sea',
+    });
+    const { findByDisplayValue, getByText } = renderScreen();
+    expect(await findByDisplayValue('Black Sea cook.')).toBeTruthy();
+    expect(getByText('@ayse')).toBeTruthy();
+    expect(getByText('ayse@example.com')).toBeTruthy();
+  });
+
+  it('calls updateOwnProfile with only the changed fields and navigates back on save', async () => {
+    mockedFetch.mockResolvedValueOnce({
+      id: 1,
+      username: 'ayse',
+      email: 'ayse@example.com',
+      bio: 'Old bio',
+      region: 'Aegean',
+    });
+    mockedUpdate.mockResolvedValueOnce({
+      id: 1,
+      username: 'ayse',
+      email: 'ayse@example.com',
+      bio: 'New bio',
+      region: 'Aegean',
+    });
+
+    const { findByDisplayValue, getByLabelText, navigation } = renderScreen();
+
+    const bioInput = await findByDisplayValue('Old bio');
+    await act(async () => {
+      fireEvent.changeText(bioInput, 'New bio');
+    });
+
+    const saveBtn = getByLabelText('Save profile');
+    await act(async () => {
+      fireEvent.press(saveBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockedUpdate).toHaveBeenCalledWith({ bio: 'New bio' });
+    });
+    expect(mockShowToast).toHaveBeenCalledWith('Profile updated', 'success');
+    expect(navigation.goBack).toHaveBeenCalled();
+  });
+});

--- a/app/mobile/__tests__/services/profileService.test.ts
+++ b/app/mobile/__tests__/services/profileService.test.ts
@@ -1,0 +1,61 @@
+import { fetchOwnProfile, updateOwnProfile } from '../../src/services/profileService';
+import { apiGetJson, apiPatchJson } from '../../src/services/httpClient';
+
+jest.mock('../../src/services/httpClient', () => ({
+  apiGetJson: jest.fn(),
+  apiPatchJson: jest.fn(),
+}));
+
+const mockedGet = apiGetJson as jest.MockedFunction<typeof apiGetJson>;
+const mockedPatch = apiPatchJson as jest.MockedFunction<typeof apiPatchJson>;
+
+describe('profileService', () => {
+  beforeEach(() => {
+    mockedGet.mockReset();
+    mockedPatch.mockReset();
+  });
+
+  it('fetchOwnProfile GETs /api/users/me/ and returns the profile body', async () => {
+    mockedGet.mockResolvedValueOnce({
+      id: 1,
+      username: 'ayse',
+      email: 'ayse@example.com',
+      bio: 'Hello',
+    });
+    const out = await fetchOwnProfile();
+    expect(mockedGet).toHaveBeenCalledWith('/api/users/me/');
+    expect(out).toEqual({
+      id: 1,
+      username: 'ayse',
+      email: 'ayse@example.com',
+      bio: 'Hello',
+    });
+  });
+
+  it('updateOwnProfile PATCHes /api/users/me/ with the partial body and returns the updated profile', async () => {
+    mockedPatch.mockResolvedValueOnce({
+      id: 1,
+      username: 'ayse',
+      email: 'ayse@example.com',
+      bio: 'Updated bio',
+      region: 'Aegean',
+    });
+    const out = await updateOwnProfile({ bio: 'Updated bio', region: 'Aegean' });
+    expect(mockedPatch).toHaveBeenCalledWith('/api/users/me/', {
+      bio: 'Updated bio',
+      region: 'Aegean',
+    });
+    expect(out.bio).toBe('Updated bio');
+    expect(out.region).toBe('Aegean');
+  });
+
+  it('updateOwnProfile supports an empty patch (no-op)', async () => {
+    mockedPatch.mockResolvedValueOnce({
+      id: 1,
+      username: 'ayse',
+      email: 'ayse@example.com',
+    });
+    await updateOwnProfile({});
+    expect(mockedPatch).toHaveBeenCalledWith('/api/users/me/', {});
+  });
+});

--- a/app/mobile/src/navigation/PublicStackNavigator.tsx
+++ b/app/mobile/src/navigation/PublicStackNavigator.tsx
@@ -13,6 +13,7 @@ import MapDiscoveryScreen from '../screens/MapDiscoveryScreen';
 import MessageThreadScreen from '../screens/MessageThreadScreen';
 import NotificationsScreen from '../screens/NotificationsScreen';
 import OnboardingScreen from '../screens/OnboardingScreen';
+import EditProfileScreen from '../screens/EditProfileScreen';
 import RecipeCreateScreen from '../screens/RecipeCreateScreen';
 import RecipeDetailScreen from '../screens/RecipeDetailScreen';
 import RecipeEditScreen from '../screens/RecipeEditScreen';
@@ -108,6 +109,11 @@ export function PublicStackNavigator() {
         name="Onboarding"
         component={OnboardingScreen}
         options={{ title: 'Cultural Onboarding' }}
+      />
+      <Stack.Screen
+        name="EditProfile"
+        component={EditProfileScreen}
+        options={{ title: 'Edit profile', headerShown: false }}
       />
       <Stack.Screen
         name="MapDiscovery"

--- a/app/mobile/src/navigation/types.ts
+++ b/app/mobile/src/navigation/types.ts
@@ -20,6 +20,7 @@ export type RootStackParamList = {
     otherUsername?: string;
   };
   Onboarding: undefined;
+  EditProfile: undefined;
   MapDiscovery: undefined;
   Explore: undefined;
   EventDetail: { eventId: number; eventName: string };

--- a/app/mobile/src/screens/EditProfileScreen.tsx
+++ b/app/mobile/src/screens/EditProfileScreen.tsx
@@ -1,0 +1,403 @@
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { LoadingView } from '../components/ui/LoadingView';
+import { useAuth } from '../context/AuthContext';
+import { useToast } from '../context/ToastContext';
+import {
+  fetchOwnProfile,
+  updateOwnProfile,
+  type UpdateProfilePayload,
+  type UserProfile,
+} from '../services/profileService';
+import { shadows, tokens } from '../theme';
+import type { RootStackParamList } from '../navigation/types';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'EditProfile'>;
+
+const BIO_MAX = 500;
+const REGION_MAX = 100;
+
+type FormState = {
+  bio: string;
+  region: string;
+};
+
+function toForm(profile: UserProfile | null): FormState {
+  return {
+    bio: typeof profile?.bio === 'string' ? profile.bio : '',
+    region: typeof profile?.region === 'string' ? profile.region : '',
+  };
+}
+
+export default function EditProfileScreen({ navigation }: Props) {
+  const { user, updateUser } = useAuth();
+  const { showToast } = useToast();
+
+  const [profile, setProfile] = useState<UserProfile | null>(null);
+  const [form, setForm] = useState<FormState>({ bio: '', region: '' });
+  const [initial, setInitial] = useState<FormState>({ bio: '', region: '' });
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      setLoadError(null);
+      try {
+        const data = await fetchOwnProfile();
+        if (cancelled) return;
+        const next = toForm(data);
+        setProfile(data);
+        setForm(next);
+        setInitial(next);
+      } catch (e) {
+        if (cancelled) return;
+        setLoadError(e instanceof Error ? e.message : 'Could not load profile.');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const isDirty = useMemo(
+    () => form.bio !== initial.bio || form.region !== initial.region,
+    [form, initial],
+  );
+
+  const bioOver = form.bio.length > BIO_MAX;
+  const canSave = !saving && !bioOver && isDirty;
+
+  const tryGoBack = useCallback(() => {
+    if (!isDirty) {
+      navigation.goBack();
+      return;
+    }
+    Alert.alert(
+      'Discard changes?',
+      'You have unsaved changes. Are you sure you want to leave?',
+      [
+        { text: 'Keep editing', style: 'cancel' },
+        {
+          text: 'Discard',
+          style: 'destructive',
+          onPress: () => navigation.goBack(),
+        },
+      ],
+    );
+  }, [isDirty, navigation]);
+
+  const handleSave = useCallback(async () => {
+    if (bioOver) {
+      setSaveError(`Bio must be ${BIO_MAX} characters or fewer.`);
+      return;
+    }
+    setSaving(true);
+    setSaveError(null);
+    const payload: UpdateProfilePayload = {};
+    if (form.bio !== initial.bio) payload.bio = form.bio;
+    if (form.region !== initial.region) payload.region = form.region;
+    try {
+      const updated = await updateOwnProfile(payload);
+      // Mirror the fields AuthContext cares about so the rest of the app sees
+      // the change immediately (UserProfile is a superset of AuthUser).
+      if (user) {
+        await updateUser({
+          ...user,
+          bio: updated.bio ?? null,
+          region: updated.region ?? null,
+          preferred_language: updated.preferred_language ?? user.preferred_language ?? null,
+          cultural_interests: updated.cultural_interests ?? user.cultural_interests,
+          regional_ties: updated.regional_ties ?? user.regional_ties,
+          religious_preferences: updated.religious_preferences ?? user.religious_preferences,
+          event_interests: updated.event_interests ?? user.event_interests,
+          is_contactable:
+            typeof updated.is_contactable === 'boolean'
+              ? updated.is_contactable
+              : user.is_contactable,
+        });
+      }
+      setProfile(updated);
+      const nextForm = toForm(updated);
+      setForm(nextForm);
+      setInitial(nextForm);
+      showToast('Profile updated', 'success');
+      navigation.goBack();
+    } catch (e) {
+      setSaveError(e instanceof Error ? e.message : 'Could not save profile.');
+    } finally {
+      setSaving(false);
+    }
+  }, [bioOver, form, initial, navigation, showToast, updateUser, user]);
+
+  return (
+    <SafeAreaView style={styles.safe} edges={['top', 'left', 'right']}>
+      <View style={styles.topBar}>
+        <Pressable
+          onPress={tryGoBack}
+          accessibilityRole="button"
+          accessibilityLabel="Go back"
+          style={({ pressed }) => [styles.backBtn, pressed && styles.pressed]}
+        >
+          <Text style={styles.backBtnText}>{'←'}</Text>
+        </Pressable>
+        <Text style={styles.title} accessibilityRole="header">
+          Edit profile
+        </Text>
+        <View style={styles.backBtnSpacer} />
+      </View>
+
+      <ScrollView
+        contentContainerStyle={styles.container}
+        keyboardShouldPersistTaps="handled"
+      >
+        {loading ? (
+          <LoadingView message="Loading profile…" />
+        ) : loadError ? (
+          <View style={styles.errorBox} accessibilityRole="alert">
+            <Text style={styles.errorTitle}>Couldn’t load profile</Text>
+            <Text style={styles.errorBody}>{loadError}</Text>
+          </View>
+        ) : (
+          <>
+            <View style={styles.section}>
+              <Text style={styles.sectionLabel}>Username</Text>
+              <View style={styles.readOnlyField}>
+                <Text style={styles.readOnlyText} accessibilityLabel={`Username ${profile?.username ?? ''}`}>
+                  @{profile?.username ?? ''}
+                </Text>
+              </View>
+              <Text style={styles.helpText}>
+                Contact support to change your username or email.
+              </Text>
+
+              <Text style={[styles.sectionLabel, styles.sectionLabelTop]}>Email</Text>
+              <View style={styles.readOnlyField}>
+                <Text style={styles.readOnlyText} numberOfLines={1}>
+                  {profile?.email ?? ''}
+                </Text>
+              </View>
+            </View>
+
+            <View style={styles.section}>
+              <Text style={styles.sectionLabel}>Bio</Text>
+              <TextInput
+                value={form.bio}
+                onChangeText={(v) => setForm((p) => ({ ...p, bio: v }))}
+                multiline
+                placeholder="Tell others about your cooking and cultural background…"
+                placeholderTextColor={tokens.colors.textMuted}
+                style={styles.textArea}
+                accessibilityLabel="Bio"
+                editable={!saving}
+              />
+              <Text
+                style={[styles.counter, bioOver && styles.counterOver]}
+                accessibilityLabel={`Bio character count ${form.bio.length} of ${BIO_MAX}`}
+              >
+                {form.bio.length}/{BIO_MAX}
+              </Text>
+            </View>
+
+            <View style={styles.section}>
+              <Text style={styles.sectionLabel}>Region</Text>
+              <TextInput
+                value={form.region}
+                onChangeText={(v) =>
+                  setForm((p) => ({ ...p, region: v.slice(0, REGION_MAX) }))
+                }
+                placeholder="e.g. Black Sea"
+                placeholderTextColor={tokens.colors.textMuted}
+                style={styles.input}
+                accessibilityLabel="Region"
+                editable={!saving}
+              />
+            </View>
+
+            <View style={styles.section}>
+              <Text style={styles.sectionLabel}>Cultural preferences</Text>
+              <Pressable
+                onPress={() => navigation.navigate('Onboarding')}
+                accessibilityRole="button"
+                accessibilityLabel="Edit cultural preferences"
+                style={({ pressed }) => [styles.linkRow, pressed && styles.pressed]}
+              >
+                <Text style={styles.linkRowLabel}>Edit cultural preferences</Text>
+                <Text style={styles.linkRowChevron}>{'→'}</Text>
+              </Pressable>
+              <Text style={styles.helpText}>
+                Update cultural interests, regional ties, dietary preferences, and event interests.
+              </Text>
+            </View>
+
+            {saveError ? (
+              <Text style={styles.errorText} accessibilityRole="alert">
+                {saveError}
+              </Text>
+            ) : null}
+
+            <Pressable
+              onPress={handleSave}
+              disabled={!canSave}
+              accessibilityRole="button"
+              accessibilityLabel="Save profile"
+              style={({ pressed }) => [
+                styles.saveBtn,
+                !canSave && styles.saveBtnDisabled,
+                pressed && styles.pressed,
+              ]}
+            >
+              {saving ? (
+                <ActivityIndicator color="#FAF7EF" />
+              ) : (
+                <Text style={styles.saveBtnText}>Save changes</Text>
+              )}
+            </Pressable>
+          </>
+        )}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: tokens.colors.bg },
+  topBar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 12,
+    paddingTop: 6,
+    paddingBottom: 8,
+    gap: 8,
+  },
+  backBtn: {
+    width: 40,
+    height: 40,
+    borderRadius: 999,
+    borderWidth: 2,
+    borderColor: tokens.colors.surfaceDark,
+    backgroundColor: tokens.colors.surface,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  backBtnSpacer: { width: 40, height: 40 },
+  backBtnText: { fontSize: 20, fontWeight: '900', color: tokens.colors.text },
+  title: {
+    flex: 1,
+    textAlign: 'center',
+    fontSize: 20,
+    fontWeight: '800',
+    color: tokens.colors.text,
+    fontFamily: tokens.typography.display.fontFamily,
+  },
+  container: { padding: 16, paddingBottom: 40, gap: 14 },
+  section: {
+    backgroundColor: tokens.colors.surface,
+    borderRadius: tokens.radius.xl,
+    padding: 14,
+    borderWidth: 1,
+    borderColor: tokens.colors.border,
+    gap: 8,
+    ...shadows.md,
+  },
+  sectionLabel: {
+    fontSize: 13,
+    fontWeight: '900',
+    color: tokens.colors.surfaceDark,
+    letterSpacing: 0.4,
+    textTransform: 'uppercase',
+  },
+  sectionLabelTop: { marginTop: 10 },
+  readOnlyField: {
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    borderRadius: tokens.radius.lg,
+    backgroundColor: tokens.colors.surfaceInput,
+    borderWidth: 1,
+    borderColor: tokens.colors.border,
+  },
+  readOnlyText: { fontSize: 15, fontWeight: '700', color: tokens.colors.text },
+  helpText: { fontSize: 12, color: tokens.colors.textMuted, lineHeight: 18 },
+  input: {
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    borderRadius: tokens.radius.lg,
+    backgroundColor: tokens.colors.surfaceInput,
+    borderWidth: 1,
+    borderColor: tokens.colors.border,
+    fontSize: 15,
+    color: tokens.colors.text,
+  },
+  textArea: {
+    minHeight: 110,
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    borderRadius: tokens.radius.lg,
+    backgroundColor: tokens.colors.surfaceInput,
+    borderWidth: 1,
+    borderColor: tokens.colors.border,
+    fontSize: 15,
+    color: tokens.colors.text,
+    textAlignVertical: 'top',
+  },
+  counter: {
+    alignSelf: 'flex-end',
+    fontSize: 12,
+    color: tokens.colors.textMuted,
+    fontWeight: '700',
+  },
+  counterOver: { color: tokens.colors.error },
+  linkRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 12,
+    paddingHorizontal: 12,
+    borderRadius: tokens.radius.lg,
+    borderWidth: 1,
+    borderColor: tokens.colors.border,
+    backgroundColor: tokens.colors.surfaceInput,
+  },
+  linkRowLabel: { flex: 1, fontSize: 15, fontWeight: '700', color: tokens.colors.text },
+  linkRowChevron: { fontSize: 18, fontWeight: '900', color: tokens.colors.text },
+  errorBox: {
+    padding: 14,
+    borderRadius: tokens.radius.lg,
+    backgroundColor: tokens.colors.surface,
+    borderWidth: 1,
+    borderColor: tokens.colors.error,
+    gap: 4,
+  },
+  errorTitle: { fontSize: 14, fontWeight: '800', color: tokens.colors.error },
+  errorBody: { fontSize: 13, color: tokens.colors.text },
+  errorText: { color: tokens.colors.error, fontSize: 13, fontWeight: '700' },
+  saveBtn: {
+    backgroundColor: tokens.colors.accentGreen,
+    paddingVertical: 14,
+    borderRadius: tokens.radius.pill,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 2,
+    borderColor: '#000000',
+    marginTop: 4,
+    ...shadows.md,
+  },
+  saveBtnDisabled: { opacity: 0.5 },
+  saveBtnText: { color: '#FAF7EF', fontWeight: '900', fontSize: 16, letterSpacing: 0.3 },
+  pressed: { opacity: 0.85 },
+});

--- a/app/mobile/src/screens/tabs/ProfileTabScreen.tsx
+++ b/app/mobile/src/screens/tabs/ProfileTabScreen.tsx
@@ -1,26 +1,15 @@
 import React from 'react';
 import { useNavigation } from '@react-navigation/native';
 import {
-  Alert,
-  Platform,
   Pressable,
   ScrollView,
   StyleSheet,
   Text,
-  ToastAndroid,
   View,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useAuth } from '../../context/AuthContext';
 import { shadows, tokens } from '../../theme';
-
-function showComingSoon() {
-  if (Platform.OS === 'android') {
-    ToastAndroid.show('Coming soon', ToastAndroid.SHORT);
-  } else {
-    Alert.alert('Coming soon', 'Edit profile is not available yet.');
-  }
-}
 
 type ActionRowProps = {
   icon: string;
@@ -131,7 +120,7 @@ export default function ProfileTabScreen() {
                 <ActionRow
                   icon="✏️"
                   label="Edit profile"
-                  onPress={showComingSoon}
+                  onPress={() => navigation.navigate('Feed', { screen: 'EditProfile' })}
                   accessibilityLabel="Edit profile"
                 />
                 <ActionRow

--- a/app/mobile/src/services/mockAuthService.ts
+++ b/app/mobile/src/services/mockAuthService.ts
@@ -7,6 +7,9 @@ export type AuthUser = {
   id: string;
   username: string;
   email: string;
+  bio?: string | null;
+  region?: string | null;
+  preferred_language?: string | null;
   cultural_interests?: string[];
   regional_ties?: string[];
   religious_preferences?: string[];

--- a/app/mobile/src/services/profileService.ts
+++ b/app/mobile/src/services/profileService.ts
@@ -1,0 +1,56 @@
+import { apiGetJson, apiPatchJson } from './httpClient';
+
+/**
+ * Shape mirroring the backend `UserProfileSerializer` (`/api/users/me/`).
+ *
+ * The serializer source of truth lives in
+ * `app/backend/apps/users/serializers.py::UserProfileSerializer` and
+ * `UserPreferencesUpdateSerializer` — only the fields below are writable via
+ * PATCH; `id`, `email`, `username`, `role`, `created_at` are read-only.
+ *
+ * Note: there is currently no `avatar` or `display_name` field on the User
+ * model, so the mobile edit screen omits those affordances. Add them here
+ * (and to the edit screen) once the backend exposes them.
+ */
+export type UserProfile = {
+  id: number | string;
+  username: string;
+  email: string;
+  bio?: string | null;
+  region?: string | null;
+  preferred_language?: string | null;
+  is_contactable?: boolean;
+  cultural_interests?: string[];
+  regional_ties?: string[];
+  religious_preferences?: string[];
+  event_interests?: string[];
+};
+
+/** Fields the backend accepts on `PATCH /api/users/me/`. */
+export type UpdateProfilePayload = Partial<
+  Pick<
+    UserProfile,
+    | 'bio'
+    | 'region'
+    | 'preferred_language'
+    | 'is_contactable'
+    | 'cultural_interests'
+    | 'regional_ties'
+    | 'religious_preferences'
+    | 'event_interests'
+  >
+>;
+
+const ENDPOINT = '/api/users/me/';
+
+/** Fetch the current authenticated user's profile. */
+export async function fetchOwnProfile(): Promise<UserProfile> {
+  return apiGetJson<UserProfile>(ENDPOINT);
+}
+
+/** Partial update of the current user's profile. */
+export async function updateOwnProfile(
+  patch: UpdateProfilePayload,
+): Promise<UserProfile> {
+  return apiPatchJson<UserProfile>(ENDPOINT, patch);
+}


### PR DESCRIPTION
## Summary
- Adds a real `EditProfileScreen` (mobile) wired into the Profile tab's "Edit profile" row, replacing the previous "Coming soon" toast.
- New `profileService.ts` exposes `fetchOwnProfile` (GET) and `updateOwnProfile` (PATCH) against `/api/users/me/`, matching the existing `UserProfileSerializer` / `UserPreferencesUpdateSerializer` shape.
- Form pre-fills from a fresh GET on mount; saves only changed fields via a partial PATCH, mirrors the update into `AuthContext` via `updateUser`, shows a success toast, and navigates back.
- Username and email are read-only (with "Contact support to change" hint); cultural / dietary preferences are routed through the existing Onboarding screen via a "Edit cultural preferences" link.
- Discard-confirm dialog on back button when the form is dirty; bio capped at 500 chars with a live counter; region capped at the backend's 100-char limit.

## Backend endpoint
- `PATCH /api/users/me/` (DRF; `UserPreferencesUpdateSerializer`).
- Fields wired up in this PR: **`bio`** (multiline, 500-char client cap), **`region`** (100-char cap). Username, email, role, and `created_at` are read-only per serializer. Cultural / regional / religious / event preferences are intentionally delegated to the existing Onboarding flow to avoid duplicating the chip-picker UI.
- **Avatar upload was NOT shipped:** the `User` model (`app/backend/apps/users/models.py`) has no avatar / image field and no `/api/users/me/avatar/` endpoint exists. The screen omits avatar entirely; can be added in a follow-up once the backend exposes it.
- No `display_name` field on the backend either — the spec mentioned it, but the model only has `username`, so display-name editing is also deferred.

## Test plan
- [ ] Log in as `ayse@example.com` / `StrongPassword123!`, open Profile tab → tap "Edit profile" → screen pre-fills with the user's bio and region.
- [ ] Change bio to a new string, tap Save → success toast appears, screen pops back, ProfileTab still shows the same `@username`.
- [ ] Type more than 500 chars into bio → counter turns red, Save is disabled.
- [ ] Edit a field, tap back arrow → discard confirm dialog appears; tap "Keep editing" returns to form, "Discard" pops back without saving.
- [ ] Tap "Edit cultural preferences" → routes to the existing Onboarding screen.
- [ ] Username and email rows are visibly read-only with the support hint.

## Quality gates
- `npx tsc --noEmit` — clean.
- `npx jest` — **155/155 passing** (26 suites), including:
  - `__tests__/services/profileService.test.ts` (3 cases: GET path, PATCH with changed fields, empty patch).
  - `__tests__/screens/EditProfileScreen.test.tsx` (2 cases: renders fetched profile, save sends only changed fields and navigates back).
- Metro bundle (`/index.bundle?platform=ios&dev=false&minify=true`) returned HTTP 200.

Closes #661