### PR TITLE
feat(frontend): render and edit recipe steps (#805)

### DIFF
--- a/app/frontend/src/__tests__/RecipeCreatePage.test.jsx
+++ b/app/frontend/src/__tests__/RecipeCreatePage.test.jsx
@@ -227,4 +227,85 @@ describe('RecipeCreatePage — draft auto-save', () => {
     fireEvent.click(screen.getByRole('button', { name: /discard/i }));
     expect(screen.queryByText(/unsaved draft found/i)).not.toBeInTheDocument();
   });
+
+  it('includes typed steps in the create payload (trimmed, empties dropped)', async () => {
+    recipeService.createRecipe.mockResolvedValue({ id: 9 });
+    renderPage();
+    await waitFor(() => screen.getByLabelText(/title/i));
+    fireEvent.change(screen.getByLabelText(/title/i), { target: { value: 'With Steps' } });
+    fireEvent.change(screen.getByLabelText(/description/i), { target: { value: 'A recipe.' } });
+
+    // Add three step rows (1 + 2 clicks of "Add step")
+    fireEvent.click(screen.getByRole('button', { name: /add step/i }));
+    fireEvent.click(screen.getByRole('button', { name: /add step/i }));
+    fireEvent.click(screen.getByRole('button', { name: /add step/i }));
+    fireEvent.change(screen.getByLabelText('Step 1'), { target: { value: 'Boil water' } });
+    fireEvent.change(screen.getByLabelText('Step 2'), { target: { value: '   ' } }); // whitespace-only — should be dropped
+    fireEvent.change(screen.getByLabelText('Step 3'), { target: { value: '  Add pasta  ' } }); // trimmed
+
+    const ingredientInput = screen.getByPlaceholderText('Ingredient');
+    fireEvent.focus(ingredientInput);
+    fireEvent.change(ingredientInput, { target: { value: 'Salt' } });
+    await waitFor(() => screen.getByText('Salt'));
+    fireEvent.click(screen.getByText('Salt'));
+    fireEvent.change(screen.getByPlaceholderText('Amount'), { target: { value: '1' } });
+    const unitInput = screen.getByPlaceholderText('Unit');
+    fireEvent.focus(unitInput);
+    fireEvent.change(unitInput, { target: { value: 'cup' } });
+    await waitFor(() => screen.getByText('cup'));
+    fireEvent.click(screen.getByText('cup'));
+
+    fireEvent.click(screen.getByRole('button', { name: /publish recipe/i }));
+    await waitFor(() =>
+      expect(recipeService.createRecipe).toHaveBeenCalledWith(
+        expect.objectContaining({ steps: ['Boil water', 'Add pasta'] })
+      )
+    );
+  });
+
+  it('sends an empty steps array when no steps are added', async () => {
+    recipeService.createRecipe.mockResolvedValue({ id: 10 });
+    renderPage();
+    await waitFor(() => screen.getByLabelText(/title/i));
+    fireEvent.change(screen.getByLabelText(/title/i), { target: { value: 'Stepless' } });
+    fireEvent.change(screen.getByLabelText(/description/i), { target: { value: 'A recipe.' } });
+
+    const ingredientInput = screen.getByPlaceholderText('Ingredient');
+    fireEvent.focus(ingredientInput);
+    fireEvent.change(ingredientInput, { target: { value: 'Salt' } });
+    await waitFor(() => screen.getByText('Salt'));
+    fireEvent.click(screen.getByText('Salt'));
+    fireEvent.change(screen.getByPlaceholderText('Amount'), { target: { value: '1' } });
+    const unitInput = screen.getByPlaceholderText('Unit');
+    fireEvent.focus(unitInput);
+    fireEvent.change(unitInput, { target: { value: 'cup' } });
+    await waitFor(() => screen.getByText('cup'));
+    fireEvent.click(screen.getByText('cup'));
+
+    fireEvent.click(screen.getByRole('button', { name: /publish recipe/i }));
+    await waitFor(() =>
+      expect(recipeService.createRecipe).toHaveBeenCalledWith(
+        expect.objectContaining({ steps: [] })
+      )
+    );
+  });
+
+  it('restores draft steps when Restore is clicked', async () => {
+    localStorage.setItem(
+      'draft:recipe:new',
+      JSON.stringify({
+        title: 'With drafted steps',
+        description: '',
+        region: '',
+        qaEnabled: true,
+        rows: [],
+        steps: ['Step one', 'Step two'],
+      })
+    );
+    renderPage();
+    await waitFor(() => screen.getByText(/unsaved draft found/i));
+    fireEvent.click(screen.getByRole('button', { name: /restore/i }));
+    expect(screen.getByLabelText('Step 1')).toHaveValue('Step one');
+    expect(screen.getByLabelText('Step 2')).toHaveValue('Step two');
+  });
 });

--- a/app/frontend/src/__tests__/RecipeDetailPage.test.jsx
+++ b/app/frontend/src/__tests__/RecipeDetailPage.test.jsx
@@ -345,3 +345,36 @@ describe('RecipeDetailPage cultural facts', () => {
     expect(culturalFactService.fetchCulturalFacts).not.toHaveBeenCalled();
   });
 });
+
+describe('RecipeDetailPage steps section', () => {
+  it('renders a numbered Steps section when recipe.steps has items', async () => {
+    recipeService.fetchRecipe.mockResolvedValueOnce({
+      ...mockRecipe,
+      steps: ['Boil the water', 'Add the pasta', 'Drain and serve'],
+    });
+    renderPage();
+    await screen.findByText('Baklava');
+    expect(screen.getByRole('heading', { name: /^steps$/i })).toBeInTheDocument();
+    expect(screen.getByText('Boil the water')).toBeInTheDocument();
+    expect(screen.getByText('Add the pasta')).toBeInTheDocument();
+    expect(screen.getByText('Drain and serve')).toBeInTheDocument();
+  });
+
+  it('hides the Steps section when recipe.steps is empty', async () => {
+    recipeService.fetchRecipe.mockResolvedValueOnce({
+      ...mockRecipe,
+      steps: [],
+    });
+    renderPage();
+    await screen.findByText('Baklava');
+    expect(screen.queryByRole('heading', { name: /^steps$/i })).not.toBeInTheDocument();
+  });
+
+  it('hides the Steps section when recipe.steps is missing entirely', async () => {
+    const { steps: _omit, ...recipeWithoutSteps } = { ...mockRecipe, steps: undefined };
+    recipeService.fetchRecipe.mockResolvedValueOnce(recipeWithoutSteps);
+    renderPage();
+    await screen.findByText('Baklava');
+    expect(screen.queryByRole('heading', { name: /^steps$/i })).not.toBeInTheDocument();
+  });
+});

--- a/app/frontend/src/__tests__/RecipeEditPage.test.jsx
+++ b/app/frontend/src/__tests__/RecipeEditPage.test.jsx
@@ -220,3 +220,45 @@ describe('RecipeEditPage — draft auto-save', () => {
     expect(screen.getByLabelText(/title/i).value).toBe('Restored Title');
   });
 });
+
+describe('RecipeEditPage — steps', () => {
+  it('pre-fills the StepsEditor from recipe.steps on load', async () => {
+    recipeService.fetchRecipe.mockResolvedValue({
+      ...mockRecipe,
+      steps: ['First do this', 'Then that'],
+    });
+    renderPage();
+    await waitFor(() => expect(screen.getByLabelText('Step 1')).toHaveValue('First do this'));
+    expect(screen.getByLabelText('Step 2')).toHaveValue('Then that');
+  });
+
+  it('renders no step rows when recipe.steps is missing', async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByLabelText(/title/i)).toHaveValue('Baklava'));
+    expect(screen.queryByLabelText('Step 1')).not.toBeInTheDocument();
+  });
+
+  it('PATCHes the recipe with the trimmed steps array on save', async () => {
+    recipeService.fetchRecipe.mockResolvedValue({
+      ...mockRecipe,
+      steps: ['Old step'],
+    });
+    recipeService.updateRecipe.mockResolvedValue({});
+    renderPage();
+    await waitFor(() => screen.getByLabelText('Step 1'));
+
+    fireEvent.change(screen.getByLabelText('Step 1'), { target: { value: '  Updated step  ' } });
+    fireEvent.click(screen.getByRole('button', { name: /add step/i }));
+    fireEvent.change(screen.getByLabelText('Step 2'), { target: { value: 'Second step' } });
+    fireEvent.click(screen.getByRole('button', { name: /add step/i }));
+    // leave Step 3 blank — should be dropped
+
+    fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+    await waitFor(() =>
+      expect(recipeService.updateRecipe).toHaveBeenCalledWith(
+        '1',
+        expect.objectContaining({ steps: ['Updated step', 'Second step'] })
+      )
+    );
+  });
+});

--- a/app/frontend/src/__tests__/StepsEditor.test.jsx
+++ b/app/frontend/src/__tests__/StepsEditor.test.jsx
@@ -1,0 +1,67 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import StepsEditor from '../components/StepsEditor';
+
+describe('StepsEditor', () => {
+  it('renders with an empty list when value is []', () => {
+    render(<StepsEditor value={[]} onChange={() => {}} />);
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /add step/i })).toBeInTheDocument();
+  });
+
+  it('renders one numbered textarea per step', () => {
+    render(<StepsEditor value={['First', 'Second', 'Third']} onChange={() => {}} />);
+    expect(screen.getByLabelText('Step 1')).toHaveValue('First');
+    expect(screen.getByLabelText('Step 2')).toHaveValue('Second');
+    expect(screen.getByLabelText('Step 3')).toHaveValue('Third');
+  });
+
+  it('calls onChange with the new array when "Add step" is clicked', async () => {
+    const onChange = jest.fn();
+    render(<StepsEditor value={['First']} onChange={onChange} />);
+    await userEvent.click(screen.getByRole('button', { name: /add step/i }));
+    expect(onChange).toHaveBeenCalledWith(['First', '']);
+  });
+
+  it('calls onChange with the row removed when "Remove" is clicked', async () => {
+    const onChange = jest.fn();
+    render(<StepsEditor value={['First', 'Second', 'Third']} onChange={onChange} />);
+    await userEvent.click(screen.getByRole('button', { name: /remove step 2/i }));
+    expect(onChange).toHaveBeenCalledWith(['First', 'Third']);
+  });
+
+  it('moves a step up when "Move step N up" is clicked', async () => {
+    const onChange = jest.fn();
+    render(<StepsEditor value={['First', 'Second', 'Third']} onChange={onChange} />);
+    await userEvent.click(screen.getByRole('button', { name: /move step 2 up/i }));
+    expect(onChange).toHaveBeenCalledWith(['Second', 'First', 'Third']);
+  });
+
+  it('moves a step down when "Move step N down" is clicked', async () => {
+    const onChange = jest.fn();
+    render(<StepsEditor value={['First', 'Second', 'Third']} onChange={onChange} />);
+    await userEvent.click(screen.getByRole('button', { name: /move step 2 down/i }));
+    expect(onChange).toHaveBeenCalledWith(['First', 'Third', 'Second']);
+  });
+
+  it('disables "up" on the first row and "down" on the last row', () => {
+    render(<StepsEditor value={['Only one', 'Two', 'Three']} onChange={() => {}} />);
+    expect(screen.getByRole('button', { name: /move step 1 up/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /move step 3 down/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /move step 2 up/i })).not.toBeDisabled();
+    expect(screen.getByRole('button', { name: /move step 2 down/i })).not.toBeDisabled();
+  });
+
+  it('calls onChange with the typed value when the textarea content changes', () => {
+    const onChange = jest.fn();
+    render(<StepsEditor value={['First']} onChange={onChange} />);
+    fireEvent.change(screen.getByLabelText('Step 1'), { target: { value: 'First updated' } });
+    expect(onChange).toHaveBeenCalledWith(['First updated']);
+  });
+
+  it('treats non-array values as an empty list', () => {
+    render(<StepsEditor value={null} onChange={() => {}} />);
+    expect(screen.getByRole('button', { name: /add step/i })).toBeInTheDocument();
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+  });
+});

--- a/app/frontend/src/components/StepsEditor.css
+++ b/app/frontend/src/components/StepsEditor.css
@@ -1,0 +1,94 @@
+.steps-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.steps-editor-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.steps-editor-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  grid-template-areas:
+    'label   controls'
+    'input   controls';
+  column-gap: 0.75rem;
+  row-gap: 0.35rem;
+  align-items: start;
+  background: #FAF7EF;
+  border: 1px solid #EADCBB;
+  border-radius: 10px;
+  padding: 0.75rem 1rem;
+}
+
+.steps-editor-label {
+  grid-area: label;
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: #8C4A1C;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.steps-editor-input {
+  grid-area: input;
+  font-family: inherit;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  padding: 0.55rem 0.75rem;
+  border: 1px solid #EADCBB;
+  border-radius: 8px;
+  background: white;
+  color: #3A2613;
+  resize: vertical;
+  width: 100%;
+}
+
+.steps-editor-input:focus-visible {
+  outline: 2px solid #C4521E;
+  outline-offset: 1px;
+}
+
+.steps-editor-controls {
+  grid-area: controls;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.steps-editor-controls button {
+  min-width: 2.25rem;
+  padding: 0.35rem 0.6rem;
+  background: white;
+  border: 1px solid #EADCBB;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  color: #4A2208;
+  cursor: pointer;
+}
+
+.steps-editor-controls button:hover:not(:disabled),
+.steps-editor-controls button:focus-visible:not(:disabled) {
+  border-color: #C4521E;
+  color: #A3401A;
+}
+
+.steps-editor-controls button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.steps-editor-remove {
+  color: #B33A1A !important;
+}
+
+.steps-editor-add {
+  align-self: flex-start;
+}

--- a/app/frontend/src/components/StepsEditor.jsx
+++ b/app/frontend/src/components/StepsEditor.jsx
@@ -1,0 +1,96 @@
+import './StepsEditor.css';
+
+/**
+ * Controlled editor for an ordered list of recipe steps (#805).
+ *
+ * Steps are plain strings; the editor renders one textarea per step plus
+ * up / down / remove buttons and an "Add step" button at the bottom. Parent
+ * owns the array and re-renders us via `value`; we surface every mutation
+ * through `onChange(nextArray)`.
+ */
+export default function StepsEditor({ value, onChange }) {
+  const steps = Array.isArray(value) ? value : [];
+
+  function update(index, nextValue) {
+    const next = steps.slice();
+    next[index] = nextValue;
+    onChange(next);
+  }
+
+  function remove(index) {
+    const next = steps.slice();
+    next.splice(index, 1);
+    onChange(next);
+  }
+
+  function move(index, delta) {
+    const target = index + delta;
+    if (target < 0 || target >= steps.length) return;
+    const next = steps.slice();
+    [next[index], next[target]] = [next[target], next[index]];
+    onChange(next);
+  }
+
+  function add() {
+    onChange([...steps, '']);
+  }
+
+  return (
+    <div className="steps-editor">
+      <ol className="steps-editor-list">
+        {steps.map((step, index) => {
+          const stepNumber = index + 1;
+          const inputId = `step-${stepNumber}`;
+          return (
+            <li key={index} className="steps-editor-row">
+              <label htmlFor={inputId} className="steps-editor-label">
+                Step {stepNumber}
+              </label>
+              <textarea
+                id={inputId}
+                className="steps-editor-input"
+                value={step}
+                rows={3}
+                onChange={(e) => update(index, e.target.value)}
+                placeholder={`Describe step ${stepNumber}…`}
+              />
+              <div className="steps-editor-controls">
+                <button
+                  type="button"
+                  onClick={() => move(index, -1)}
+                  disabled={index === 0}
+                  aria-label={`Move step ${stepNumber} up`}
+                >
+                  ↑
+                </button>
+                <button
+                  type="button"
+                  onClick={() => move(index, 1)}
+                  disabled={index === steps.length - 1}
+                  aria-label={`Move step ${stepNumber} down`}
+                >
+                  ↓
+                </button>
+                <button
+                  type="button"
+                  onClick={() => remove(index)}
+                  aria-label={`Remove step ${stepNumber}`}
+                  className="steps-editor-remove"
+                >
+                  Remove
+                </button>
+              </div>
+            </li>
+          );
+        })}
+      </ol>
+      <button
+        type="button"
+        className="btn btn-outline btn-sm steps-editor-add"
+        onClick={add}
+      >
+        + Add Step
+      </button>
+    </div>
+  );
+}

--- a/app/frontend/src/pages/RecipeCreatePage.jsx
+++ b/app/frontend/src/pages/RecipeCreatePage.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import IngredientRow from '../components/IngredientRow';
+import StepsEditor from '../components/StepsEditor';
 import Toast from '../components/Toast';
 import DraftRestoreBanner from '../components/DraftRestoreBanner';
 import useDraftAutosave from '../hooks/useDraftAutosave';
@@ -51,6 +52,7 @@ export default function RecipeCreatePage() {
   const [thumbnail, setThumbnail] = useState(null);
   const [qaEnabled, setQaEnabled] = useState(true);
   const [rows, setRows] = useState([makeRow()]);
+  const [steps, setSteps] = useState([]);
 
   const [ingredients, setIngredients] = useState([]);
   const [units, setUnits] = useState([]);
@@ -60,7 +62,7 @@ export default function RecipeCreatePage() {
   const [submitting, setSubmitting] = useState(false);
   const [toast, setToast] = useState({ message: '', type: 'success' });
 
-  const draftState = { title, description, region, qaEnabled, rows };
+  const draftState = { title, description, region, qaEnabled, rows, steps };
   const { savedDraft, clearDraft } = useDraftAutosave(DRAFT_KEY, draftState, { enabled: true });
 
   const isDirty = useRef(false);
@@ -95,8 +97,14 @@ export default function RecipeCreatePage() {
     if (draft.region !== undefined) setRegion(draft.region);
     if (draft.qaEnabled !== undefined) setQaEnabled(draft.qaEnabled);
     if (Array.isArray(draft.rows) && draft.rows.length > 0) setRows(draft.rows);
+    if (Array.isArray(draft.steps)) setSteps(draft.steps);
     clearDraft();
   }
+
+  const handleStepsChange = useCallback((next) => {
+    markDirty();
+    setSteps(next);
+  }, []);
 
   const handleRowChange = useCallback((rowId, field, value) => {
     markDirty();
@@ -145,12 +153,16 @@ export default function RecipeCreatePage() {
     }
 
     const validRows = rows.filter((r) => r.ingredientId && r.amount && r.unitId);
+    const cleanedSteps = steps
+      .map((s) => (typeof s === 'string' ? s.trim() : ''))
+      .filter((s) => s.length > 0);
     const payload = {
       title,
       description,
       region: region ? Number(region) : null,
       qa_enabled: qaEnabled,
       is_published: publish,
+      steps: cleanedSteps,
       ingredients_write: validRows.map((r) => ({
         ingredient: r.ingredientId,
         amount: r.amount,
@@ -322,10 +334,20 @@ export default function RecipeCreatePage() {
           </button>
         </section>
 
-        {/* ── Step 3: Media & options ── */}
+        {/* ── Step 3: Cooking steps ── */}
         <section className="form-step">
           <StepHeader
             number="3"
+            title="Steps"
+            hint="Walk readers through the recipe one step at a time. Order matters — use the arrows to reorder. Empty steps are skipped on save."
+          />
+          <StepsEditor value={steps} onChange={handleStepsChange} />
+        </section>
+
+        {/* ── Step 4: Media & options ── */}
+        <section className="form-step">
+          <StepHeader
+            number="4"
             title="Media & Options"
             hint="Upload a photo or video, and choose your settings."
           />

--- a/app/frontend/src/pages/RecipeDetailPage.css
+++ b/app/frontend/src/pages/RecipeDetailPage.css
@@ -404,3 +404,56 @@
   color: var(--color-error);
   margin: 0;
 }
+
+/* ── Steps (#805) ── */
+.recipe-steps {
+  margin: 1.5rem 0;
+}
+
+.recipe-steps h2 {
+  font-size: 1.25rem;
+  margin: 0 0 0.75rem;
+  color: var(--color-text);
+}
+
+.recipe-steps-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.recipe-steps-item {
+  display: flex;
+  gap: 0.85rem;
+  align-items: flex-start;
+  background: #FAF7EF;
+  border: 1px solid #EADCBB;
+  border-radius: 10px;
+  padding: 0.75rem 1rem;
+}
+
+.recipe-steps-number {
+  flex-shrink: 0;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  background: #C4521E;
+  color: white;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.95rem;
+}
+
+.recipe-steps-body {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.55;
+  color: #3A2613;
+  white-space: pre-wrap;
+  flex: 1;
+}

--- a/app/frontend/src/pages/RecipeDetailPage.jsx
+++ b/app/frontend/src/pages/RecipeDetailPage.jsx
@@ -261,6 +261,21 @@ export default function RecipeDetailPage() {
         <p className="recipe-description">{recipe.description}</p>
       )}
 
+      {/* ── Steps (#805) ── */}
+      {Array.isArray(recipe.steps) && recipe.steps.length > 0 && (
+        <section className="recipe-steps">
+          <h2>Steps</h2>
+          <ol className="recipe-steps-list">
+            {recipe.steps.map((step, index) => (
+              <li key={index} className="recipe-steps-item">
+                <span className="recipe-steps-number" aria-hidden="true">{index + 1}</span>
+                <p className="recipe-steps-body">{step}</p>
+              </li>
+            ))}
+          </ol>
+        </section>
+      )}
+
       {/* ── Ingredients (#372 check-off, #370 substitution, #377 unit toggle) ── */}
       <section className="recipe-ingredients">
         <div className="ingredients-header">

--- a/app/frontend/src/pages/RecipeEditPage.jsx
+++ b/app/frontend/src/pages/RecipeEditPage.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useContext } from 'react';
 import { useParams, useNavigate, Navigate } from 'react-router-dom';
 import { AuthContext } from '../context/AuthContext';
 import IngredientRow from '../components/IngredientRow';
+import StepsEditor from '../components/StepsEditor';
 import Toast from '../components/Toast';
 import DraftRestoreBanner from '../components/DraftRestoreBanner';
 import useDraftAutosave from '../hooks/useDraftAutosave';
@@ -51,6 +52,7 @@ export default function RecipeEditPage() {
   const [thumbnail, setThumbnail] = useState(null);
   const [qaEnabled, setQaEnabled] = useState(false);
   const [rows, setRows] = useState([]);
+  const [steps, setSteps] = useState([]);
   const [ingredients, setIngredients] = useState([]);
   const [units, setUnits] = useState([]);
   const [regions, setRegions] = useState([]);
@@ -60,7 +62,7 @@ export default function RecipeEditPage() {
   const [toast, setToast] = useState({ message: '', type: 'success' });
 
   const draftKey = `draft:recipe:${id}`;
-  const draftState = { title, description, region, qaEnabled, rows };
+  const draftState = { title, description, region, qaEnabled, rows, steps };
   const { savedDraft, clearDraft } = useDraftAutosave(draftKey, draftState, { enabled: !loading });
 
   useEffect(() => {
@@ -79,6 +81,7 @@ export default function RecipeEditPage() {
             ? recipeData.ingredients.map(makeRowFromIngredient)
             : [makeEmptyRow()]
         );
+        setSteps(Array.isArray(recipeData.steps) ? recipeData.steps : []);
         setIngredients(ings);
         setUnits(uns);
       })
@@ -102,6 +105,7 @@ export default function RecipeEditPage() {
     if (draft.region !== undefined) setRegion(draft.region);
     if (draft.qaEnabled !== undefined) setQaEnabled(draft.qaEnabled);
     if (Array.isArray(draft.rows) && draft.rows.length > 0) setRows(draft.rows);
+    if (Array.isArray(draft.steps)) setSteps(draft.steps);
     clearDraft();
   }
 
@@ -147,12 +151,16 @@ export default function RecipeEditPage() {
     if (!validate()) return;
 
     const validRows = rows.filter((r) => r.ingredientId && r.amount && r.unitId);
+    const cleanedSteps = steps
+      .map((s) => (typeof s === 'string' ? s.trim() : ''))
+      .filter((s) => s.length > 0);
     const payload = {
       title,
       description,
       region: region ? Number(region) : null,
       qa_enabled: qaEnabled,
       is_published: publish,
+      steps: cleanedSteps,
       ingredients_write: validRows.map((r) => ({
         ingredient: r.ingredientId,
         amount: r.amount,
@@ -283,6 +291,14 @@ export default function RecipeEditPage() {
           >
             + Add Ingredient
           </button>
+        </section>
+
+        <section className="recipe-edit-steps-section">
+          <h2>Steps</h2>
+          <p className="field-hint">
+            Walk readers through the recipe one step at a time. Order matters — use the arrows to reorder. Empty steps are skipped on save.
+          </p>
+          <StepsEditor value={steps} onChange={setSteps} />
         </section>
 
         <div className="recipe-form-actions">


### PR DESCRIPTION
Closes #805.

## Summary

Surface the `Recipe.steps` backend field that has been on the API for some time but never rendered or editable on web. Today a recipe shows description text only; this PR adds the numbered cooking steps as a proper section on the detail page and gives authors a repeater editor on Create and Edit.

- **New `StepsEditor` component** (`src/components/StepsEditor.jsx` + `.css`)
  - Controlled — parent owns the array, child surfaces `onChange(nextArray)` for every mutation.
  - One `<textarea>` per step plus per-row Up / Down / Remove buttons and an "Add Step" button at the bottom.
  - `aria-label` on every control (`Move step N up`, `Remove step N`, …) — keyboard- and screen-reader-friendly.
  - Up arrow disabled on the first row; down arrow disabled on the last row.
  - Treats non-array `value` (null / undefined) as an empty list — safe to mount before async hydration finishes.
- **`RecipeDetailPage`** — new "Steps" section between description and ingredients. Numbered `<ol>`, one row per step, with a circular step-number badge and `white-space: pre-wrap` so multi-line steps render readably. Section is hidden when `recipe.steps` is empty, missing, or not an array.
- **`RecipeCreatePage`** — new "Steps" form step (renumbered the Media section to 4). Wired into the existing `useDraftAutosave` flow so steps survive page reloads alongside title / description / ingredients. On submit: each step is trimmed and empty rows are dropped before the payload is sent. The payload now includes `steps: [...]`.
- **`RecipeEditPage`** — `StepsEditor` pre-fills from `recipe.steps` on load (treats missing as zero rows). Save sends the trimmed array. Steps are added to the draft state too.

## Backend contract

No backend changes needed — already shipped:
- `Recipe.steps = models.JSONField(default=list, blank=True)` (`app/backend/apps/recipes/models.py:155`)
- Included on both read and write in `RecipeSerializer` (`app/backend/apps/recipes/serializers.py:226`)

## Tests

- `StepsEditor.test.jsx` — 9 new tests cover the empty list, render-per-step, add, remove, move up, move down, disabled boundaries, textarea-driven `onChange`, and null/non-array fallback.
- `RecipeDetailPage.test.jsx` — 3 new tests cover steps rendered, hidden on empty, hidden when missing.
- `RecipeCreatePage.test.jsx` — 3 new tests cover steps in the payload (trimmed + empties dropped), empty array when no steps, and draft restore including steps.
- `RecipeEditPage.test.jsx` — 3 new tests cover pre-fill, missing-steps render, and PATCH payload.

Local: `CI=true npm test` → **625 passed, 625 total** (was 619 before this PR).
Local: `npm run build` clean.

## Out of scope

- Per-step images / videos (not modelled on backend).
- Drag-to-reorder via HTML5 DnD (up / down arrows cover the same need without a new dep).
- A markdown editor inside each step — plain textarea is enough for v1.

## Pairs with

- Mobile equivalent: #806