### PR TITLE
feat(mobile): render and edit recipe steps — detail section + create/edit repeater (closes #806)

### DIFF
--- a/app/mobile/__tests__/components/RecipeStepsRepeater.test.tsx
+++ b/app/mobile/__tests__/components/RecipeStepsRepeater.test.tsx
@@ -1,0 +1,111 @@
+import React, { useState } from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import {
+  RecipeStepsRepeater,
+  trimStepsForPayload,
+} from '../../src/components/recipe/RecipeStepsRepeater';
+
+/**
+ * Tiny harness so we can drive the controlled repeater through React state
+ * and assert what the consumer ultimately holds — closer to how the screens
+ * actually use it than re-rendering with a fresh `steps` prop each tap.
+ */
+function Harness({
+  initial,
+  onCommit,
+}: {
+  initial: string[];
+  onCommit: (steps: string[]) => void;
+}) {
+  const [steps, setSteps] = useState<string[]>(initial);
+  return (
+    <RecipeStepsRepeater
+      steps={steps}
+      onChange={(next) => {
+        setSteps(next);
+        onCommit(next);
+      }}
+    />
+  );
+}
+
+describe('trimStepsForPayload', () => {
+  it('trims whitespace and drops empty rows', () => {
+    expect(trimStepsForPayload(['  one  ', '', '\n\t', 'two'])).toEqual(['one', 'two']);
+  });
+
+  it('returns an empty array when nothing survives the trim', () => {
+    expect(trimStepsForPayload(['', '   ', '\n'])).toEqual([]);
+  });
+});
+
+describe('RecipeStepsRepeater', () => {
+  it('renders the empty hint and no rows when steps is empty', () => {
+    const onCommit = jest.fn();
+    const { getByText, queryByLabelText } = render(
+      <Harness initial={[]} onCommit={onCommit} />,
+    );
+    expect(getByText(/No steps yet/i)).toBeTruthy();
+    expect(queryByLabelText('Step 1 description')).toBeNull();
+  });
+
+  it('adds a step when "Add step" is pressed', () => {
+    const onCommit = jest.fn();
+    const { getByLabelText } = render(<Harness initial={[]} onCommit={onCommit} />);
+    fireEvent.press(getByLabelText('Add step'));
+    expect(onCommit).toHaveBeenLastCalledWith(['']);
+    expect(getByLabelText('Step 1 description')).toBeTruthy();
+  });
+
+  it('removes the targeted row', () => {
+    const onCommit = jest.fn();
+    const { getByLabelText, queryByLabelText } = render(
+      <Harness initial={['a', 'b', 'c']} onCommit={onCommit} />,
+    );
+    fireEvent.press(getByLabelText('Remove step 2'));
+    expect(onCommit).toHaveBeenLastCalledWith(['a', 'c']);
+    // Renumbered: there are now two rows total.
+    expect(getByLabelText('Step 1 description')).toBeTruthy();
+    expect(getByLabelText('Step 2 description')).toBeTruthy();
+    expect(queryByLabelText('Step 3 description')).toBeNull();
+  });
+
+  it('reorders rows with the up control', () => {
+    const onCommit = jest.fn();
+    const { getByLabelText } = render(
+      <Harness initial={['a', 'b', 'c']} onCommit={onCommit} />,
+    );
+    fireEvent.press(getByLabelText('Move step 3 up'));
+    expect(onCommit).toHaveBeenLastCalledWith(['a', 'c', 'b']);
+  });
+
+  it('reorders rows with the down control', () => {
+    const onCommit = jest.fn();
+    const { getByLabelText } = render(
+      <Harness initial={['a', 'b', 'c']} onCommit={onCommit} />,
+    );
+    fireEvent.press(getByLabelText('Move step 1 down'));
+    expect(onCommit).toHaveBeenLastCalledWith(['b', 'a', 'c']);
+  });
+
+  it('disables move-up on the first row and move-down on the last row', () => {
+    const { getByLabelText } = render(
+      <Harness initial={['a', 'b']} onCommit={jest.fn()} />,
+    );
+    expect(getByLabelText('Move step 1 up').props.accessibilityState).toEqual(
+      expect.objectContaining({ disabled: true }),
+    );
+    expect(getByLabelText('Move step 2 down').props.accessibilityState).toEqual(
+      expect.objectContaining({ disabled: true }),
+    );
+  });
+
+  it('forwards text edits through onChange', () => {
+    const onCommit = jest.fn();
+    const { getByLabelText } = render(
+      <Harness initial={['initial']} onCommit={onCommit} />,
+    );
+    fireEvent.changeText(getByLabelText('Step 1 description'), 'updated');
+    expect(onCommit).toHaveBeenLastCalledWith(['updated']);
+  });
+});

--- a/app/mobile/__tests__/components/RecipeStepsSection.test.tsx
+++ b/app/mobile/__tests__/components/RecipeStepsSection.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { RecipeStepsSection } from '../../src/components/recipe/RecipeStepsSection';
+
+describe('RecipeStepsSection', () => {
+  it('renders nothing when steps is empty', () => {
+    const { toJSON } = render(<RecipeStepsSection steps={[]} />);
+    expect(toJSON()).toBeNull();
+  });
+
+  it('renders nothing when steps is undefined (defensive)', () => {
+    const { toJSON } = render(<RecipeStepsSection steps={undefined as unknown as string[]} />);
+    expect(toJSON()).toBeNull();
+  });
+
+  it('renders the heading and a numbered list when steps are present', () => {
+    const { getByText } = render(
+      <RecipeStepsSection steps={['Chop onions.', 'Sauté until golden.', 'Add tomatoes.']} />,
+    );
+    expect(getByText('Steps')).toBeTruthy();
+    expect(getByText('1')).toBeTruthy();
+    expect(getByText('2')).toBeTruthy();
+    expect(getByText('3')).toBeTruthy();
+    expect(getByText('Chop onions.')).toBeTruthy();
+    expect(getByText('Sauté until golden.')).toBeTruthy();
+    expect(getByText('Add tomatoes.')).toBeTruthy();
+  });
+
+  it('preserves embedded newlines inside a single step', () => {
+    const stepWithBreaks = 'Line one.\nLine two.';
+    const { getByText } = render(<RecipeStepsSection steps={[stepWithBreaks]} />);
+    expect(getByText(stepWithBreaks)).toBeTruthy();
+  });
+});

--- a/app/mobile/__tests__/services/recipeServiceSteps.test.ts
+++ b/app/mobile/__tests__/services/recipeServiceSteps.test.ts
@@ -1,0 +1,59 @@
+import { patchRecipeJson } from '../../src/services/recipeService';
+import { apiPatchJson } from '../../src/services/httpClient';
+import { buildRecipePatchJsonBody } from '../../src/components/recipe/buildRecipeUpdateFormData';
+
+jest.mock('../../src/services/httpClient', () => ({
+  apiGetJson: jest.fn(),
+  apiPatchJson: jest.fn(),
+  apiPatchFormData: jest.fn(),
+  nextPagePath: jest.fn(),
+}));
+
+const mockedPatch = apiPatchJson as jest.MockedFunction<typeof apiPatchJson>;
+
+describe('patchRecipeJson — steps payload (#806)', () => {
+  beforeEach(() => mockedPatch.mockReset());
+
+  it('forwards a `steps` array on the JSON PATCH body', async () => {
+    mockedPatch.mockResolvedValueOnce(undefined);
+    const body = buildRecipePatchJsonBody({
+      title: 'Soup',
+      description: 'Warm.',
+      qaEnabled: true,
+      rows: [],
+      steps: ['Boil water.', 'Add salt.'],
+    });
+    await patchRecipeJson('42', body);
+    expect(mockedPatch).toHaveBeenCalledTimes(1);
+    const [path, sent] = mockedPatch.mock.calls[0];
+    expect(path).toBe('/api/recipes/42/');
+    expect((sent as { steps?: unknown }).steps).toEqual(['Boil water.', 'Add salt.']);
+  });
+
+  it('omits `steps` from the body when caller does not pass it (so server value stays)', async () => {
+    mockedPatch.mockResolvedValueOnce(undefined);
+    const body = buildRecipePatchJsonBody({
+      title: 'Soup',
+      description: 'Warm.',
+      qaEnabled: true,
+      rows: [],
+    });
+    await patchRecipeJson('42', body);
+    const [, sent] = mockedPatch.mock.calls[0];
+    expect(Object.prototype.hasOwnProperty.call(sent, 'steps')).toBe(false);
+  });
+
+  it('sends an empty `steps: []` when caller explicitly clears all rows', async () => {
+    mockedPatch.mockResolvedValueOnce(undefined);
+    const body = buildRecipePatchJsonBody({
+      title: 'Soup',
+      description: 'Warm.',
+      qaEnabled: true,
+      rows: [],
+      steps: [],
+    });
+    await patchRecipeJson('42', body);
+    const [, sent] = mockedPatch.mock.calls[0];
+    expect((sent as { steps?: unknown }).steps).toEqual([]);
+  });
+});

--- a/app/mobile/src/components/recipe/RecipeStepsRepeater.tsx
+++ b/app/mobile/src/components/recipe/RecipeStepsRepeater.tsx
@@ -1,0 +1,229 @@
+import React from 'react';
+import { Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
+import { tokens } from '../../theme';
+import { recipeFormStyles } from './recipeFormStyles';
+
+export type RecipeStepsRepeaterProps = {
+  steps: string[];
+  onChange: (steps: string[]) => void;
+};
+
+/**
+ * Trim every step and drop rows that are blank after trimming. Used by the
+ * Create/Edit submit handlers to build the final payload for backend
+ * `Recipe.steps` (a JSONField of strings, #806). Exported so tests can
+ * exercise the helper without mounting the component.
+ */
+export function trimStepsForPayload(steps: string[]): string[] {
+  return steps.map((s) => s.trim()).filter((s) => s.length > 0);
+}
+
+/**
+ * Controlled repeater for editing the ordered `steps` array (#806). Pure —
+ * no side effects, all state lives in the parent. Adding, removing, and
+ * reordering happen through `onChange` so Create and Edit can share the same
+ * component while keeping their own submit pipelines.
+ *
+ * An empty list is valid; submit handlers send `steps: []` rather than
+ * forcing one mandatory row.
+ */
+export function RecipeStepsRepeater({ steps, onChange }: RecipeStepsRepeaterProps) {
+  function updateAt(index: number, value: string) {
+    const next = steps.slice();
+    next[index] = value;
+    onChange(next);
+  }
+
+  function addStep() {
+    onChange([...steps, '']);
+  }
+
+  function removeAt(index: number) {
+    const next = steps.slice();
+    next.splice(index, 1);
+    onChange(next);
+  }
+
+  function moveUp(index: number) {
+    if (index <= 0) return;
+    const next = steps.slice();
+    [next[index - 1], next[index]] = [next[index], next[index - 1]];
+    onChange(next);
+  }
+
+  function moveDown(index: number) {
+    if (index >= steps.length - 1) return;
+    const next = steps.slice();
+    [next[index + 1], next[index]] = [next[index], next[index + 1]];
+    onChange(next);
+  }
+
+  return (
+    <View style={recipeFormStyles.section} accessibilityLabel="Recipe steps">
+      <Text style={recipeFormStyles.sectionTitle}>Steps</Text>
+      {steps.length === 0 ? (
+        <Text style={styles.emptyHint}>
+          No steps yet. Tap “Add step” to add the first one — leaving this empty is fine too.
+        </Text>
+      ) : null}
+      {steps.map((step, idx) => {
+        const isFirst = idx === 0;
+        const isLast = idx === steps.length - 1;
+        return (
+          <View key={`step-row-${idx}`} style={styles.rowCard}>
+            <View style={styles.rowHeader}>
+              <Text style={styles.rowTitle}>Step {idx + 1}</Text>
+              <View style={styles.controls}>
+                <Pressable
+                  onPress={() => moveUp(idx)}
+                  disabled={isFirst}
+                  style={({ pressed }) => [
+                    styles.iconBtn,
+                    isFirst && styles.iconBtnDisabled,
+                    pressed && !isFirst && styles.iconBtnPressed,
+                  ]}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Move step ${idx + 1} up`}
+                  accessibilityState={{ disabled: isFirst }}
+                  hitSlop={6}
+                >
+                  <Text style={[styles.iconText, isFirst && styles.iconTextDisabled]}>▲</Text>
+                </Pressable>
+                <Pressable
+                  onPress={() => moveDown(idx)}
+                  disabled={isLast}
+                  style={({ pressed }) => [
+                    styles.iconBtn,
+                    isLast && styles.iconBtnDisabled,
+                    pressed && !isLast && styles.iconBtnPressed,
+                  ]}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Move step ${idx + 1} down`}
+                  accessibilityState={{ disabled: isLast }}
+                  hitSlop={6}
+                >
+                  <Text style={[styles.iconText, isLast && styles.iconTextDisabled]}>▼</Text>
+                </Pressable>
+                <Pressable
+                  onPress={() => removeAt(idx)}
+                  style={({ pressed }) => [styles.iconBtn, pressed && styles.iconBtnPressed]}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Remove step ${idx + 1}`}
+                  hitSlop={6}
+                >
+                  <Text style={styles.iconTextRemove}>✕</Text>
+                </Pressable>
+              </View>
+            </View>
+            <TextInput
+              value={step}
+              onChangeText={(t) => updateAt(idx, t)}
+              placeholder={`Describe step ${idx + 1}…`}
+              placeholderTextColor="#94a3b8"
+              style={styles.input}
+              multiline
+              numberOfLines={3}
+              accessibilityLabel={`Step ${idx + 1} description`}
+            />
+          </View>
+        );
+      })}
+      <Pressable
+        onPress={addStep}
+        style={({ pressed }) => [styles.addBtn, pressed && recipeFormStyles.buttonPressed]}
+        accessibilityRole="button"
+        accessibilityLabel="Add step"
+      >
+        <Text style={styles.addBtnText}>+ Add step</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  emptyHint: {
+    fontSize: 14,
+    color: tokens.colors.textMuted,
+    fontStyle: 'italic',
+    marginBottom: 10,
+  },
+  rowCard: {
+    borderWidth: 1,
+    borderColor: tokens.colors.border,
+    borderRadius: tokens.radius.lg,
+    padding: 12,
+    backgroundColor: tokens.colors.surface,
+    marginBottom: 12,
+  },
+  rowHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 8,
+  },
+  rowTitle: {
+    fontSize: 15,
+    fontWeight: '700',
+    color: tokens.colors.text,
+  },
+  controls: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  iconBtn: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1.5,
+    borderColor: tokens.colors.surfaceDark,
+    backgroundColor: tokens.colors.surface,
+  },
+  iconBtnDisabled: {
+    opacity: 0.4,
+  },
+  iconBtnPressed: {
+    opacity: 0.7,
+  },
+  iconText: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: tokens.colors.text,
+  },
+  iconTextDisabled: {
+    color: tokens.colors.textMuted,
+  },
+  iconTextRemove: {
+    fontSize: 14,
+    fontWeight: '800',
+    color: tokens.colors.error,
+  },
+  input: {
+    borderWidth: 2,
+    borderColor: tokens.colors.border,
+    borderRadius: tokens.radius.md,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    fontSize: 16,
+    backgroundColor: tokens.colors.surfaceInput,
+    minHeight: 88,
+    textAlignVertical: 'top',
+    color: tokens.colors.text,
+  },
+  addBtn: {
+    alignSelf: 'flex-start',
+    borderWidth: 2,
+    borderColor: tokens.colors.surfaceDark,
+    paddingVertical: 10,
+    paddingHorizontal: 14,
+    borderRadius: tokens.radius.pill,
+    backgroundColor: 'transparent',
+  },
+  addBtnText: {
+    color: tokens.colors.text,
+    fontSize: 15,
+    fontWeight: '700',
+  },
+});

--- a/app/mobile/src/components/recipe/RecipeStepsSection.tsx
+++ b/app/mobile/src/components/recipe/RecipeStepsSection.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { tokens } from '../../theme';
+
+/**
+ * Read-only numbered list of cooking steps for the recipe detail screen
+ * (#806). Backend `Recipe.steps` is a JSONField of plain strings. The whole
+ * section hides itself when the array is empty / null / undefined — we never
+ * render a "No steps yet" placeholder, mirroring how the description block
+ * stays silent when the field is missing.
+ */
+export function RecipeStepsSection({ steps }: { steps: string[] }) {
+  if (!Array.isArray(steps) || steps.length === 0) return null;
+
+  return (
+    <View style={styles.wrap} accessibilityLabel="Recipe steps">
+      <Text style={styles.heading} accessibilityRole="header">
+        Steps
+      </Text>
+      <View style={styles.list}>
+        {steps.map((step, idx) => (
+          <View key={`step-${idx}`} style={styles.row}>
+            <View style={styles.badge}>
+              <Text style={styles.badgeText}>{idx + 1}</Text>
+            </View>
+            <Text style={styles.body}>{step}</Text>
+          </View>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrap: {
+    marginTop: 18,
+    gap: 10,
+  },
+  heading: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: tokens.colors.text,
+    fontFamily: tokens.typography.display.fontFamily,
+  },
+  list: { gap: 10 },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 10,
+    paddingVertical: 8,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: tokens.colors.surfaceDark,
+  },
+  badge: {
+    width: 26,
+    height: 26,
+    borderRadius: 13,
+    backgroundColor: tokens.colors.accentMustard,
+    borderWidth: 1.5,
+    borderColor: tokens.colors.surfaceDark,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginTop: 2,
+  },
+  badgeText: {
+    fontSize: 13,
+    fontWeight: '800',
+    color: tokens.colors.text,
+  },
+  body: {
+    flex: 1,
+    fontSize: 16,
+    color: tokens.colors.text,
+    lineHeight: 22,
+  },
+});

--- a/app/mobile/src/components/recipe/buildRecipeUpdateFormData.ts
+++ b/app/mobile/src/components/recipe/buildRecipeUpdateFormData.ts
@@ -10,6 +10,15 @@ export function buildRecipePatchJsonBody(input: {
   description: string;
   qaEnabled: boolean;
   rows: AuthoringIngredientRow[];
+  /**
+   * Already-trimmed cooking steps (#806). Caller is responsible for trimming
+   * and dropping empty rows via `trimStepsForPayload` so this builder stays
+   * dumb. Backend `Recipe.steps` is a JSONField, so it rides the JSON PATCH
+   * path alongside `ingredients_write` rather than the multipart upload used
+   * for media files. Omitted from the body when undefined so callers that
+   * don't touch steps don't accidentally clear the server value.
+   */
+  steps?: string[];
 }): Record<string, unknown> {
   // Require an ingredient + a non-empty amount. The unit is *not* required —
   // backend accepts `null` and we no longer silently drop unit-less rows
@@ -25,7 +34,7 @@ export function buildRecipePatchJsonBody(input: {
   // Including it here used to silently null the region on every edit because
   // `Number("Aegean")` is `NaN`. Until a proper region picker lands, leaving
   // the field out of the payload keeps the existing region untouched.
-  return {
+  const body: Record<string, unknown> = {
     title: input.title.trim(),
     description: input.description.trim(),
     qa_enabled: input.qaEnabled,
@@ -36,6 +45,10 @@ export function buildRecipePatchJsonBody(input: {
       unit: r.unit.id ?? null,
     })),
   };
+  if (input.steps !== undefined) {
+    body.steps = input.steps;
+  }
+  return body;
 }
 
 /** Multipart PATCH with only a new video file (after JSON patch saved other fields). */

--- a/app/mobile/src/screens/RecipeCreateScreen.tsx
+++ b/app/mobile/src/screens/RecipeCreateScreen.tsx
@@ -5,6 +5,10 @@ import { Image, Pressable, ScrollView, Switch, Text, TextInput, View } from 'rea
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { InlineFieldError } from '../components/recipe/InlineFieldError';
 import { RecipeIngredientRowsSection } from '../components/recipe/RecipeIngredientRowsSection';
+import {
+  RecipeStepsRepeater,
+  trimStepsForPayload,
+} from '../components/recipe/RecipeStepsRepeater';
 import { RecipeVideoSection } from '../components/recipe/RecipeVideoSection';
 import {
   isPositiveNumberString,
@@ -40,6 +44,7 @@ export default function RecipeCreateScreen({ navigation }: Props) {
     const r = makeEmptyIngredientRow();
     return [{ ...r, key: 'row-1' }];
   });
+  const [steps, setSteps] = useState<string[]>([]);
 
   const [attemptedSubmit, setAttemptedSubmit] = useState(false);
   const [submitting, setSubmitting] = useState(false);
@@ -155,6 +160,7 @@ export default function RecipeCreateScreen({ navigation }: Props) {
         ingredient: r.ingredient,
         unit: r.unit,
       })),
+      steps: trimStepsForPayload(steps),
     };
 
     void (async () => {
@@ -171,6 +177,7 @@ export default function RecipeCreateScreen({ navigation }: Props) {
             ingredient: x.ingredient?.id ?? x.ingredient,
             unit: x.unit?.id ?? x.unit,
           })),
+          steps: payload.steps,
         });
         createdId = created.id;
       } catch {
@@ -295,6 +302,8 @@ export default function RecipeCreateScreen({ navigation }: Props) {
             />
             {attemptedSubmit ? <InlineFieldError message={errors.description} /> : null}
           </View>
+
+          <RecipeStepsRepeater steps={steps} onChange={setSteps} />
 
           <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 18 }}>
             <Switch

--- a/app/mobile/src/screens/RecipeDetailScreen.tsx
+++ b/app/mobile/src/screens/RecipeDetailScreen.tsx
@@ -15,6 +15,7 @@ import { removeRating, submitRating } from '../services/ratingService';
 import { EndangeredHeritageSection } from '../components/heritage/EndangeredHeritageSection';
 import { HeritageBadge } from '../components/heritage/HeritageBadge';
 import { RecipeCommentsSection } from '../components/recipe/RecipeCommentsSection';
+import { RecipeStepsSection } from '../components/recipe/RecipeStepsSection';
 import { DidYouKnowSection } from '../components/cultural/DidYouKnowSection';
 import { fetchCulturalFactsByRegion, type CulturalFact } from '../services/culturalFactService';
 import type { RootStackParamList } from '../navigation/types';
@@ -571,6 +572,8 @@ export default function RecipeDetailScreen({ route, navigation }: Props) {
           ) : (
             <Text style={styles.muted}>No description.</Text>
           )}
+
+          <RecipeStepsSection steps={recipe.steps ?? []} />
 
           <View style={styles.ingredientsHeader}>
             <Text style={styles.sectionTitle}>Ingredients</Text>

--- a/app/mobile/src/screens/RecipeEditScreen.tsx
+++ b/app/mobile/src/screens/RecipeEditScreen.tsx
@@ -10,6 +10,10 @@ import {
 } from '../components/recipe/buildRecipeUpdateFormData';
 import { InlineFieldError } from '../components/recipe/InlineFieldError';
 import { RecipeIngredientRowsSection } from '../components/recipe/RecipeIngredientRowsSection';
+import {
+  RecipeStepsRepeater,
+  trimStepsForPayload,
+} from '../components/recipe/RecipeStepsRepeater';
 import { RecipeVideoSection } from '../components/recipe/RecipeVideoSection';
 import {
   authoringRowsFromRecipe,
@@ -57,6 +61,7 @@ export default function RecipeEditScreen({ route, navigation }: Props) {
   const [region, setRegion] = useState('');
   const [qaEnabled, setQaEnabled] = useState(true);
   const [rows, setRows] = useState<AuthoringIngredientRow[]>([makeEmptyIngredientRow()]);
+  const [steps, setSteps] = useState<string[]>([]);
   const [localImage, setLocalImage] = useState<{
     uri: string;
     fileName?: string;
@@ -78,6 +83,7 @@ export default function RecipeEditScreen({ route, navigation }: Props) {
     setRegion(recipe.region ?? '');
     setQaEnabled(recipe.qa_enabled ?? true);
     setRows(authoringRowsFromRecipe(recipe.ingredients));
+    setSteps(Array.isArray(recipe.steps) ? recipe.steps.slice() : []);
     setLocalImage(null);
     setLocalVideo(null);
     setRemoteVideoUrl(recipe.video ?? null);
@@ -224,6 +230,7 @@ export default function RecipeEditScreen({ route, navigation }: Props) {
       description,
       qaEnabled,
       rows,
+      steps: trimStepsForPayload(steps),
     });
 
     void (async () => {
@@ -398,6 +405,8 @@ export default function RecipeEditScreen({ route, navigation }: Props) {
           />
           {attemptedSubmit ? <InlineFieldError message={validation.description} /> : null}
         </View>
+
+        <RecipeStepsRepeater steps={steps} onChange={setSteps} />
 
         <View style={styles.section}>
           <Text style={styles.sectionTitle}>Region</Text>

--- a/app/mobile/src/types/recipe.ts
+++ b/app/mobile/src/types/recipe.ts
@@ -21,6 +21,12 @@ export type RecipeDetail = {
   /** Normalized to `{ id, username }`; raw API may send `author` as user pk only. */
   author?: number | { id: number; username?: string };
   ingredients?: RecipeIngredientRow[];
+  /**
+   * Ordered cooking steps surfaced by backend (#806). Each entry is a plain
+   * string; embedded newlines are preserved on render. Optional because older
+   * payloads omit the field — UI treats `undefined`/empty as "no steps".
+   */
+  steps?: string[];
   /** Matches web `RecipeEditPage` (`qa_enabled`). */
   qa_enabled?: boolean;
   rank_score?: number;


### PR DESCRIPTION
## Summary
- Mobile now surfaces backend `Recipe.steps` (JSONField of strings) — Detail screen renders a numbered "Steps" section between description and ingredients, hiding itself entirely when the array is empty / null / undefined.
- Create and Edit forms get a shared `RecipeStepsRepeater` (multiline input per step, ▲/▼ reorder, ✕ remove, "Add step" pill) placed between description and ingredients. Auto-renumbers as rows shift.
- Steps state is trimmed on submit (`trimStepsForPayload`) so empty rows are dropped; the empty list is a valid payload.
- Edit pre-fills rows from `recipe.steps` and clears to empty when the field is missing.
- Adds `steps?: string[]` to `RecipeDetail` and threads it through `buildRecipePatchJsonBody` so the field rides the existing JSON PATCH (not multipart) — see notes below.

## Payload path
- **Create**: `apiPostJson('/api/recipes/', { …, steps })` — single JSON POST, same call that already carries `ingredients_write`.
- **Edit**: `patchRecipeJson(id, body)` where `body` comes from `buildRecipePatchJsonBody({ …, steps })`. `Recipe.steps` is a JSONField, so it rides the JSON PATCH alongside `ingredients_write` — multipart is reserved for the image / video uploads, which still run as independent follow-up PATCHes. When the caller omits `steps`, the builder leaves the key off the body so the server value is preserved; when the user clears every row, `steps: []` is sent explicitly.

## Test plan
- [ ] Open a recipe with non-empty steps on mobile — verify the numbered "Steps" section appears between description and ingredients, with mustard circle badges and wrapping body text.
- [ ] Open a recipe with no `steps` (or empty array) — verify the Steps section is absent (no "No steps yet" placeholder).
- [ ] Create a new recipe with 3 steps, reorder one up, delete one, leave one row blank — submit and verify the created recipe shows the surviving trimmed steps in order.
- [ ] Edit an existing recipe — verify existing steps pre-fill, reorder works, save persists.
- [ ] Edit and clear every step row, save, reload — verify the section disappears on the detail screen.

## Verification
- `npx tsc --noEmit` clean.
- `npx jest` — **166 tests passing across 27 suites** (baseline ~155; +11 new). New suites: `RecipeStepsSection`, `RecipeStepsRepeater`, `recipeServiceSteps`.
- Metro `index.bundle?platform=ios&dev=false&minify=true` returns HTTP 200.

Closes #806