### PR TITLE
fix(frontend): timer leaks, keyboard shortcut re-register, notification cascade renders (#702)

### DIFF
--- a/app/frontend/src/context/NotificationContext.jsx
+++ b/app/frontend/src/context/NotificationContext.jsx
@@ -17,6 +17,8 @@ export function NotificationProvider({ children }) {
   const [notifications, setNotifications] = useState([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
+  const notificationsRef = useRef([]);
+  useEffect(() => { notificationsRef.current = notifications; }, [notifications]);
 
   const refreshNotifications = useCallback(async () => {
     if (!token) {
@@ -41,7 +43,7 @@ export function NotificationProvider({ children }) {
   }, [refreshNotifications]);
 
   const markRead = useCallback(async (id) => {
-    const current = notifications.find((item) => item.id === id);
+    const current = notificationsRef.current.find((item) => item.id === id);
     if (!current || current.isRead) return;
     setNotifications((prev) => prev.map((n) => (n.id === id ? { ...n, isRead: true } : n)));
     try {
@@ -52,7 +54,7 @@ export function NotificationProvider({ children }) {
     } catch {
       setNotifications((prev) => prev.map((n) => (n.id === id ? { ...n, isRead: false } : n)));
     }
-  }, [notifications]);
+  }, []);
 
   const markAllRead = useCallback(async () => {
     setNotifications((prev) => prev.map((n) => (n.isRead ? n : { ...n, isRead: true })));

--- a/app/frontend/src/context/NotificationContext.jsx
+++ b/app/frontend/src/context/NotificationContext.jsx
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { AuthContext } from './AuthContext';
 import { fetchNotifications, markAllAsRead, markNotificationAsRead } from '../services/notificationService';
 

--- a/app/frontend/src/hooks/useKeyboardShortcuts.js
+++ b/app/frontend/src/hooks/useKeyboardShortcuts.js
@@ -1,15 +1,17 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 export default function useKeyboardShortcuts(shortcuts) {
+  const shortcutsRef = useRef(shortcuts);
+  useEffect(() => { shortcutsRef.current = shortcuts; });
+
   useEffect(() => {
     function handler(e) {
-      // Ignore when typing in an input/textarea/select
       const tag = document.activeElement?.tagName;
       if (['INPUT', 'TEXTAREA', 'SELECT'].includes(tag)) return;
-      const fn = shortcuts[e.key];
+      const fn = shortcutsRef.current[e.key];
       if (fn) { e.preventDefault(); fn(e); }
     }
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, [shortcuts]);
+  }, []); // registered once; shortcutsRef always holds the latest map
 }

--- a/app/frontend/src/pages/RecipeCreatePage.jsx
+++ b/app/frontend/src/pages/RecipeCreatePage.jsx
@@ -64,6 +64,8 @@ export default function RecipeCreatePage() {
   const { savedDraft, clearDraft } = useDraftAutosave(DRAFT_KEY, draftState, { enabled: true });
 
   const isDirty = useRef(false);
+  const toastTimerRef = useRef(null);
+  const navTimerRef = useRef(null);
 
   useEffect(() => {
     fetchIngredients().then(setIngredients).catch(() => {});
@@ -82,11 +84,19 @@ export default function RecipeCreatePage() {
     return () => window.removeEventListener('beforeunload', handleBeforeUnload);
   }, []);
 
+  useEffect(() => {
+    return () => {
+      if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
+      if (navTimerRef.current) clearTimeout(navTimerRef.current);
+    };
+  }, []);
+
   function markDirty() { isDirty.current = true; }
 
   function showToast(message, type) {
+    if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
     setToast({ message, type });
-    setTimeout(() => setToast({ message: '', type: 'success' }), 3000);
+    toastTimerRef.current = setTimeout(() => setToast({ message: '', type: 'success' }), 3000);
   }
 
   function handleRestore(draft) {
@@ -171,14 +181,14 @@ export default function RecipeCreatePage() {
           clearDraft();
           isDirty.current = false;
           showToast('Recipe published but media upload failed — open it to retry.', 'error');
-          setTimeout(() => navigate(`/recipes/${created.id}`), 1500);
+          navTimerRef.current = setTimeout(() => navigate(`/recipes/${created.id}`), 1500);
           return;
         }
       }
       clearDraft();
       isDirty.current = false;
       showToast(publish ? 'Recipe published!' : 'Draft saved!', 'success');
-      setTimeout(() => navigate(`/recipes/${created.id}`), 1500);
+      navTimerRef.current = setTimeout(() => navigate(`/recipes/${created.id}`), 1500);
     } catch {
       showToast(
         publish ? 'Failed to publish recipe. Please try again.' : 'Failed to save draft. Please try again.',

--- a/app/frontend/src/pages/RecipeEditPage.jsx
+++ b/app/frontend/src/pages/RecipeEditPage.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useContext } from 'react';
+import { useState, useEffect, useCallback, useContext, useRef } from 'react';
 import { useParams, useNavigate, Navigate } from 'react-router-dom';
 import { AuthContext } from '../context/AuthContext';
 import IngredientRow from '../components/IngredientRow';
@@ -62,6 +62,8 @@ export default function RecipeEditPage() {
   const draftKey = `draft:recipe:${id}`;
   const draftState = { title, description, region, qaEnabled, rows };
   const { savedDraft, clearDraft } = useDraftAutosave(draftKey, draftState, { enabled: !loading });
+  const toastTimerRef = useRef(null);
+  const navTimerRef = useRef(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -91,9 +93,17 @@ export default function RecipeEditPage() {
     return () => { cancelled = true; };
   }, [id]);
 
+  useEffect(() => {
+    return () => {
+      if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
+      if (navTimerRef.current) clearTimeout(navTimerRef.current);
+    };
+  }, []);
+
   function showToast(message, type) {
+    if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
     setToast({ message, type });
-    setTimeout(() => setToast({ message: '', type: 'success' }), 3000);
+    toastTimerRef.current = setTimeout(() => setToast({ message: '', type: 'success' }), 3000);
   }
 
   function handleRestore(draft) {
@@ -172,7 +182,7 @@ export default function RecipeEditPage() {
 
       clearDraft();
       showToast(publish ? 'Recipe updated!' : 'Draft saved!', 'success');
-      setTimeout(() => navigate(`/recipes/${id}`), 1500);
+      navTimerRef.current = setTimeout(() => navigate(`/recipes/${id}`), 1500);
     } catch {
       showToast('Failed to save changes. Please try again.', 'error');
     }


### PR DESCRIPTION
## Summary

- **useKeyboardShortcuts**: listener was re-registered on every render because callers pass a new object literal each time. Now uses a ref to always hold the latest shortcuts map; the listener registers exactly once.
- **NotificationContext**: `markRead` had `notifications` in its `useCallback` deps, causing the callback to be re-created on every notification state update and cascading re-renders. Fixed by reading the current notifications via a `notificationsRef` instead.
- **RecipeCreatePage / RecipeEditPage**: `setTimeout` IDs for toast auto-dismiss and post-save navigation were not stored, so they couldn't be cleared on unmount. Both now use `toastTimerRef` and `navTimerRef`, cleared in a cleanup `useEffect`.

references #702

## Test plan

- [ ] Open React DevTools profiler, mark a notification as read — confirm no cascade re-renders from `NotificationContext`
- [ ] Type while focused on an input on any page — confirm keyboard shortcuts don't fire
- [ ] Create a recipe, immediately navigate away before the 1.5 s nav timer fires — no "Can't perform a React state update on an unmounted component" warning in console
- [ ] Edit a recipe, same unmount-during-timer test
- [ ] Verify keyboard shortcuts still work normally when no input is focused