### PR TITLE
fix(mobile): show 'You can't rate your own recipe' caption under read-only star row (closes #824)

### DIFF
--- a/app/mobile/src/screens/RecipeDetailScreen.tsx
+++ b/app/mobile/src/screens/RecipeDetailScreen.tsx
@@ -492,6 +492,9 @@ export default function RecipeDetailScreen({ route, navigation }: Props) {
                 ? 'Not rated yet'
                 : `${(avgRatingNum ?? 0).toFixed(1)} ★ · ${ratingCount} rating${ratingCount === 1 ? '' : 's'}`}
             </Text>
+            {isOwnRecipe ? (
+              <Text style={styles.ratingHint}>You can't rate your own recipe</Text>
+            ) : null}
           </View>
 
           <View style={styles.actionRow}>
@@ -857,6 +860,7 @@ const styles = StyleSheet.create({
   editLinkText: { fontSize: 14, color: tokens.colors.textOnDark, fontWeight: '800', letterSpacing: 0.3 },
   ratingBlock: { marginTop: 14, gap: 4 },
   ratingCaption: { fontSize: 13, color: tokens.colors.textMuted, fontWeight: '600' },
+  ratingHint: { fontSize: 12, color: tokens.colors.textMuted, marginTop: 4 },
   actionRow: {
     marginTop: 12,
     flexDirection: 'row',


### PR DESCRIPTION
Summary
RecipeDetailScreen (mobile): On own-recipes the star row was rendered read-only with no explanation, leaving viewers wondering why taps did nothing. Added a small muted caption directly below the rating caption stating \"You can't rate your own recipe\" so the owner knows the row is intentionally non-interactive.

Visitors and anonymous viewers see no extra caption (existing behavior preserved). Component `StarRatingRow` is unchanged.

Test plan
- [ ] Open a recipe you authored on mobile: stars are read-only and the hint \"You can't rate your own recipe\" appears under the rating caption.
- [ ] Open another user's recipe while authenticated: no hint, stars remain tappable.
- [ ] Open a recipe while anonymous: no hint, no rating interaction.

Closes #824