### PR TITLE
fix(frontend): align passport tabs with real backend contract + real world map

### DIFF
--- a/app/frontend/.npmrc
+++ b/app/frontend/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/app/frontend/Dockerfile
+++ b/app/frontend/Dockerfile
@@ -5,7 +5,10 @@ FROM node:20-alpine AS build
 WORKDIR /app
 
 COPY package*.json ./
-RUN npm ci
+# react-simple-maps@3 declares its peer as react 16/17/18 only, but runs
+# fine against react 19 (the wrapper only uses refs + useState). Use
+# --legacy-peer-deps so `npm ci` doesn't reject the resolved tree.
+RUN npm ci --legacy-peer-deps
 
 COPY . .
 

--- a/app/frontend/README.md
+++ b/app/frontend/README.md
@@ -2,6 +2,17 @@
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
+## Peer dependencies note
+
+The project uses React 19, but `react-simple-maps@3.0.0` (used by the passport
+world map) only declares peer compatibility up to React 18. Versions 3.1+ that
+support React 19 are not published yet, so we accept the unmet peer for now.
+
+To keep `npm install` / `npm ci` working without surprises, a local `.npmrc`
+sets `legacy-peer-deps=true`. The Docker build (`Dockerfile`) passes the same
+flag explicitly. If you ever bypass the `.npmrc` (e.g. running npm from a
+different cwd), use `npm install --legacy-peer-deps`.
+
 ## Available Scripts
 
 In the project directory, you can run:

--- a/app/frontend/package-lock.json
+++ b/app/frontend/package-lock.json
@@ -20,7 +20,9 @@
         "react-leaflet": "^5.0.0",
         "react-router-dom": "^6.30.3",
         "react-scripts": "5.0.1",
-        "web-vitals": "^2.1.4"
+        "react-simple-maps": "^3.0.0",
+        "web-vitals": "^2.1.4",
+        "world-atlas": "^2.0.2"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -6336,6 +6338,102 @@
       "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
+      "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-dispatch": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-2.0.0.tgz",
+      "integrity": "sha512-S/m2VsXI7gAti2pBoLClFFTMOO1HTtT0j99AuXLoGFKO6deHDdnv6ZGTxSTTUTgO1zVcv82fCOtDjYK4EECmWA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-drag": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-2.0.0.tgz",
+      "integrity": "sha512-g9y9WbMnF5uqB9qKqwIIa/921RYWzlUDv9Jl1/yONQwxbOfszAWTCm8u7HOTgJgRDXiRZN56cHT9pd24dmXs8w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-dispatch": "1 - 2",
+        "d3-selection": "2"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-2.0.0.tgz",
+      "integrity": "sha512-68/n9JWarxXkOWMshcT5IcjbB+agblQUaIsbnXmrzejn2O82n3p2A9R2zEB9HIEFWKFwPAEDDN8gR0VdSAyyAQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-geo": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-2.0.2.tgz",
+      "integrity": "sha512-8pM1WGMLGFuhq9S+FpPURxic+gKzjluCD/CHTuUF3mXMeiCo0i6R0tO1s4+GArRFde96SLcW/kOFRjoAosPsFA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "^2.5.0"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-2.0.1.tgz",
+      "integrity": "sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-color": "1 - 2"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-2.0.0.tgz",
+      "integrity": "sha512-XoGGqhLUN/W14NmaqcO/bb1nqjDAw5WtSYb2X8wiuQWvSZUsUVYsOSkOybUrNvcBjaywBdYPy03eXHMXjk9nZA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-timer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-2.0.0.tgz",
+      "integrity": "sha512-TO4VLh0/420Y/9dO3+f9abDEFYeCUr2WZRlxJvbp4HPTQcSylXNiL6yZa9FIUvV1yRiFufl1bszTCLDqv9PWNA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-transition": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-2.0.0.tgz",
+      "integrity": "sha512-42ltAGgJesfQE3u9LuuBHNbGrI/AJjNL2OAUdclE70UE6Vy239GCBEYD38uBPoLeNsOhFStGpPI0BAOV+HMxog==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-color": "1 - 2",
+        "d3-dispatch": "1 - 2",
+        "d3-ease": "1 - 2",
+        "d3-interpolate": "1 - 2",
+        "d3-timer": "1 - 2"
+      },
+      "peerDependencies": {
+        "d3-selection": "2"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-2.0.0.tgz",
+      "integrity": "sha512-fFg7aoaEm9/jf+qfstak0IYpnesZLiMX6GZvXtUSdv8RH2o4E2qeelgdU09eKS6wGuiGMfcnMI0nTIqWzRHGpw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-dispatch": "1 - 2",
+        "d3-drag": "2",
+        "d3-interpolate": "1 - 2",
+        "d3-selection": "2",
+        "d3-transition": "2"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -9237,6 +9335,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "license": "ISC"
     },
     "node_modules/ipaddr.js": {
       "version": "2.3.0",
@@ -13955,6 +14059,23 @@
         }
       }
     },
+    "node_modules/react-simple-maps": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/react-simple-maps/-/react-simple-maps-3.0.0.tgz",
+      "integrity": "sha512-vKNFrvpPG8Vyfdjnz5Ne1N56rZlDfHXv5THNXOVZMqbX1rWZA48zQuYT03mx6PAKanqarJu/PDLgshIZAfHHqw==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-geo": "^2.0.2",
+        "d3-selection": "^2.0.0",
+        "d3-zoom": "^2.0.0",
+        "topojson-client": "^3.1.0"
+      },
+      "peerDependencies": {
+        "prop-types": "^15.7.2",
+        "react": "^16.8.0 || 17.x || 18.x",
+        "react-dom": "^16.8.0 || 17.x || 18.x"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -15714,23 +15835,6 @@
         }
       }
     },
-    "node_modules/tailwindcss/node_modules/yaml": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
-      "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
     "node_modules/tapable": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
@@ -15981,6 +16085,26 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/topojson-client": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
+      "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "2"
+      },
+      "bin": {
+        "topo2geo": "bin/topo2geo",
+        "topomerge": "bin/topomerge",
+        "topoquantize": "bin/topoquantize"
+      }
+    },
+    "node_modules/topojson-client/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
+    },
     "node_modules/tough-cookie": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
@@ -16216,20 +16340,6 @@
       "license": "MIT",
       "dependencies": {
         "is-typedarray": "^1.0.0"
-      }
-    },
-    "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
       }
     },
     "node_modules/unbox-primitive": {
@@ -17261,6 +17371,12 @@
         "@types/trusted-types": "^2.0.2",
         "workbox-core": "6.6.0"
       }
+    },
+    "node_modules/world-atlas": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/world-atlas/-/world-atlas-2.0.2.tgz",
+      "integrity": "sha512-IXfV0qwlKXpckz1FhwXVwKRjiIhOnWttOskm5CtxMsjgE/MXAYRHWJqgXOpM8IkcPBoXnyTU5lFHcYa5ChG0LQ==",
+      "license": "ISC"
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",

--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -15,7 +15,9 @@
     "react-leaflet": "^5.0.0",
     "react-router-dom": "^6.30.3",
     "react-scripts": "5.0.1",
-    "web-vitals": "^2.1.4"
+    "react-simple-maps": "^3.0.0",
+    "web-vitals": "^2.1.4",
+    "world-atlas": "^2.0.2"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/app/frontend/src/__tests__/PassportMap.test.jsx
+++ b/app/frontend/src/__tests__/PassportMap.test.jsx
@@ -1,0 +1,34 @@
+import { render } from '@testing-library/react';
+import PassportMap from '../components/passport/PassportMap';
+
+describe('PassportMap', () => {
+  it('renders without crashing when cultures is null', () => {
+    expect(() => render(<PassportMap cultures={null} />)).not.toThrow();
+  });
+
+  it('renders without crashing when cultures is undefined', () => {
+    expect(() => render(<PassportMap cultures={undefined} />)).not.toThrow();
+  });
+
+  it('renders without crashing when cultures is empty', () => {
+    expect(() => render(<PassportMap cultures={[]} />)).not.toThrow();
+  });
+
+  it('renders without crashing on the canonical backend culture shape (no `name`)', () => {
+    // Regression: PassportMap used to read `c.name` directly and crashed when
+    // the backend shipped `culture_summaries[]` with `culture` instead.
+    const backendShape = [
+      { culture: 'Black Sea', recipes_tried: 1, stories_saved: 0, interactions: 1, rarity: 'bronze' },
+      { culture: 'Aegean',    recipes_tried: 0, stories_saved: 2, interactions: 2, rarity: 'silver' },
+    ];
+    expect(() => render(<PassportMap cultures={backendShape} />)).not.toThrow();
+  });
+
+  it('drops cultures with no usable name without throwing', () => {
+    const bad = [
+      { culture: null, recipes_tried: 1, stories_saved: 0, rarity: 'bronze' },
+      { recipes_tried: 1, stories_saved: 0, rarity: 'bronze' }, // no `culture` key at all
+    ];
+    expect(() => render(<PassportMap cultures={bad} />)).not.toThrow();
+  });
+});

--- a/app/frontend/src/__tests__/PassportTimeline.test.jsx
+++ b/app/frontend/src/__tests__/PassportTimeline.test.jsx
@@ -48,4 +48,27 @@ describe('PassportTimeline', () => {
     renderTimeline([events[2]]);
     expect(screen.queryByRole('link')).not.toBeInTheDocument();
   });
+
+  it('prefers the human-readable description when the backend provides one', () => {
+    renderTimeline([
+      {
+        id: 99,
+        event_type: 'stamp_earned',
+        description: 'Earned a bronze stamp for Black Sea',
+        timestamp: '2026-05-12T00:00:00Z',
+        related_recipe: null,
+        related_story: null,
+      },
+    ]);
+    expect(screen.getByText(/earned a bronze stamp for black sea/i)).toBeInTheDocument();
+    // The raw slug should not leak through when a description is present
+    expect(screen.queryByText(/^stamp earned$/i)).not.toBeInTheDocument();
+  });
+
+  it('falls back to the event_type slug when description is missing', () => {
+    renderTimeline([
+      { id: 100, event_type: 'recipe_tried', timestamp: '2026-05-12T00:00:00Z', related_recipe: null, related_story: null },
+    ]);
+    expect(screen.getByText(/recipe tried/i)).toBeInTheDocument();
+  });
 });

--- a/app/frontend/src/__tests__/QuestList.test.jsx
+++ b/app/frontend/src/__tests__/QuestList.test.jsx
@@ -44,4 +44,23 @@ describe('QuestList', () => {
     render(<QuestList quests={[quests[1]]} />);
     expect(screen.getByText(/✓ done/i)).toBeInTheDocument();
   });
+
+  it('accepts the backend event_end field for event quest deadlines', () => {
+    // Backend ships `event_end` for time-limited quests; older mock data
+    // used `deadline`. The component should accept either.
+    render(<QuestList quests={[
+      {
+        id: 99,
+        name: 'Event Quest',
+        description: 'Limited time',
+        progress: 0,
+        target_count: 1,
+        reward_type: 'badge',
+        reward_value: 'Event',
+        event_end: '2026-12-31T00:00:00Z',
+        completed_at: null,
+      },
+    ]} />);
+    expect(screen.getByText(/31 Dec 2026/i)).toBeInTheDocument();
+  });
 });

--- a/app/frontend/src/__tests__/StampGrid.test.jsx
+++ b/app/frontend/src/__tests__/StampGrid.test.jsx
@@ -53,4 +53,30 @@ describe('StampGrid', () => {
     render(<StampGrid stamps={[stamps[2]]} />);
     expect(screen.getByText('🔒')).toBeInTheDocument();
   });
+
+  it('groups stamps by the backend lowercase category value', () => {
+    // Backend ships `category` lowercase (e.g. 'recipe', 'story'); we still
+    // render the human-readable header. Earlier code did a strict PascalCase
+    // match and dumped everything into "Other".
+    const backendShape = [
+      { id: 10, culture: 'Black Sea',  category: 'recipe',    rarity: 'bronze',    earned_at: '2026-05-12T00:00:00Z' },
+      { id: 11, culture: 'Anatolian',  category: 'heritage',  rarity: 'gold',      earned_at: '2026-05-12T00:00:00Z' },
+      { id: 12, culture: 'World Tour', category: 'community', rarity: 'legendary', earned_at: null },
+    ];
+    render(<StampGrid stamps={backendShape} />);
+    // Headers render in their canonical capitalised form even though backend
+    // sent lowercase keys.
+    expect(screen.getByRole('heading', { name: 'Recipe' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Heritage' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Community' })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Other' })).not.toBeInTheDocument();
+  });
+
+  it('puts stamps with unknown categories under "Other"', () => {
+    render(<StampGrid stamps={[
+      { id: 20, culture: 'Mystery', category: 'mystery_category', rarity: 'bronze', earned_at: '2026-05-12T00:00:00Z' },
+    ]} />);
+    expect(screen.getByRole('heading', { name: 'Other' })).toBeInTheDocument();
+    expect(screen.getByText('Mystery')).toBeInTheDocument();
+  });
 });

--- a/app/frontend/src/__tests__/passportCultureRegions.test.js
+++ b/app/frontend/src/__tests__/passportCultureRegions.test.js
@@ -1,0 +1,73 @@
+import {
+  countriesForCulture,
+  buildCountryCultureIndex,
+} from '../utils/passportCultureRegions';
+
+describe('countriesForCulture', () => {
+  it('returns [] for unknown culture names', () => {
+    expect(countriesForCulture('Atlantis')).toEqual([]);
+  });
+
+  it('returns [] for non-string input', () => {
+    expect(countriesForCulture(null)).toEqual([]);
+    expect(countriesForCulture(undefined)).toEqual([]);
+    expect(countriesForCulture(42)).toEqual([]);
+  });
+
+  it('maps known sub-regions to their countries', () => {
+    expect(countriesForCulture('Black Sea')).toContain('Turkey');
+    expect(countriesForCulture('Black Sea')).toContain('Ukraine');
+    expect(countriesForCulture('Aegean')).toEqual(expect.arrayContaining(['Turkey', 'Greece']));
+    expect(countriesForCulture('Nordic')).toEqual(
+      expect.arrayContaining(['Sweden', 'Norway', 'Denmark', 'Finland', 'Iceland']),
+    );
+  });
+
+  it('is case-insensitive and trims whitespace', () => {
+    expect(countriesForCulture('  AEGEAN  ')).toEqual(expect.arrayContaining(['Turkey']));
+    expect(countriesForCulture('mediterranean')).toEqual(expect.arrayContaining(['Italy']));
+  });
+});
+
+describe('buildCountryCultureIndex', () => {
+  it('returns an empty object for null / undefined / empty input', () => {
+    expect(buildCountryCultureIndex(null)).toEqual({});
+    expect(buildCountryCultureIndex(undefined)).toEqual({});
+    expect(buildCountryCultureIndex([])).toEqual({});
+  });
+
+  it('indexes each mapped country to its source culture', () => {
+    const index = buildCountryCultureIndex([
+      { culture: 'Nordic', recipes_tried: 1, stories_saved: 0, rarity: 'bronze' },
+    ]);
+    expect(Object.keys(index)).toEqual(
+      expect.arrayContaining(['Sweden', 'Norway', 'Denmark', 'Finland', 'Iceland']),
+    );
+    expect(index.Sweden.culture.name).toBe('Nordic');
+  });
+
+  it('skips unmapped culture names without throwing', () => {
+    const index = buildCountryCultureIndex([
+      { culture: 'Unknown Region', recipes_tried: 5 },
+    ]);
+    expect(index).toEqual({});
+  });
+
+  it('resolves duplicate-claim conflicts by engagement (recipes_tried + stories_saved)', () => {
+    // Both "Aegean" and "Black Sea" claim Turkey. The one with higher
+    // engagement should win the cell.
+    const index = buildCountryCultureIndex([
+      { culture: 'Aegean',    recipes_tried: 1, stories_saved: 0, rarity: 'bronze' },
+      { culture: 'Black Sea', recipes_tried: 5, stories_saved: 2, rarity: 'gold' },
+    ]);
+    expect(index.Turkey.culture.name).toBe('Black Sea');
+  });
+
+  it('accepts the older mock `name` / `recipe_count` / `story_count` shape too', () => {
+    const index = buildCountryCultureIndex([
+      { name: 'Nordic', recipe_count: 2, story_count: 1, stamp_rarity: 'silver' },
+    ]);
+    expect(index.Sweden.culture.name).toBe('Nordic');
+    expect(index.Sweden.engagement).toBe(3);
+  });
+});

--- a/app/frontend/src/__tests__/passportMapColors.test.js
+++ b/app/frontend/src/__tests__/passportMapColors.test.js
@@ -34,4 +34,29 @@ describe('getRegionFill', () => {
     expect(getRegionFill({ recipe_count: 1, story_count: 0, heritage_count: 0, stamp_rarity: 'gold' }).star)
       .toBe(false);
   });
+
+  // Backend `culture_summaries[]` ships `recipes_tried` / `stories_saved` /
+  // `rarity` — these tests cover the canonical contract directly so the map
+  // tinting works against the real API (#583 fix).
+  describe('canonical backend shape', () => {
+    it('recipes_tried > 0 → medium fill', () => {
+      expect(getRegionFill({ recipes_tried: 3, stories_saved: 0, rarity: 'bronze' }))
+        .toEqual({ fill: MAP_FILLS.medium, star: false });
+    });
+
+    it('stories_saved > 0 (no recipes) → light fill', () => {
+      expect(getRegionFill({ recipes_tried: 0, stories_saved: 2, rarity: 'bronze' }))
+        .toEqual({ fill: MAP_FILLS.light, star: false });
+    });
+
+    it('legendary rarity → dark fill with star', () => {
+      expect(getRegionFill({ recipes_tried: 5, stories_saved: 2, rarity: 'legendary' }))
+        .toEqual({ fill: MAP_FILLS.dark, star: true });
+    });
+
+    it('gold rarity with recipes → medium fill, no star', () => {
+      expect(getRegionFill({ recipes_tried: 1, stories_saved: 0, rarity: 'gold' }))
+        .toEqual({ fill: MAP_FILLS.medium, star: false });
+    });
+  });
 });

--- a/app/frontend/src/components/passport/PassportMap.css
+++ b/app/frontend/src/components/passport/PassportMap.css
@@ -5,17 +5,20 @@
 .passport-map-svg {
   width: 100%;
   height: auto;
+  display: block;
   border-radius: var(--radius-md);
   border: 1.5px solid var(--color-border);
+  /* Ocean tint behind the country polygons. */
+  background:
+    radial-gradient(circle at 50% 45%, #E5F0FA 0%, #C7DEED 100%);
 }
 
-.passport-map-region {
-  cursor: pointer;
-  transition: opacity 0.15s ease;
+.passport-map-svg path {
+  transition: opacity 0.15s ease, filter 0.15s ease;
 }
 
-.passport-map-region:hover {
-  opacity: 0.8;
+.passport-map-svg path:hover {
+  filter: drop-shadow(0 1px 2px rgba(60, 30, 0, 0.35));
 }
 
 .passport-map-popover {
@@ -32,12 +35,21 @@
   gap: 0.2rem;
   font-size: 0.8125rem;
   pointer-events: none;
-  min-width: 140px;
+  min-width: 160px;
+  max-width: 240px;
 }
 
 .passport-map-popover strong {
   font-size: 0.9rem;
   color: var(--color-text);
+}
+
+.passport-map-popover-culture {
+  font-size: 0.75rem;
+  color: var(--color-primary-text);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
 }
 
 .passport-map-popover span {

--- a/app/frontend/src/components/passport/PassportMap.jsx
+++ b/app/frontend/src/components/passport/PassportMap.jsx
@@ -1,82 +1,86 @@
 import { useState } from 'react';
-import { getRegionFill } from '../../utils/passportMapColors';
+import { ComposableMap, Geographies, Geography } from 'react-simple-maps';
+import worldTopology from 'world-atlas/countries-110m.json';
+import { getRegionFill, MAP_FILLS } from '../../utils/passportMapColors';
+import { buildCountryCultureIndex } from '../../utils/passportCultureRegions';
 import './PassportMap.css';
 
-// Minimal SVG world map — simplified rectangles per macro-region for demo
-// Replace with a proper SVG asset once available
-const REGIONS = [
-  { id: 'europe',        label: 'Europe',          x: 440, y: 80,  w: 80, h: 60  },
-  { id: 'middle_east',   label: 'Middle East',      x: 530, y: 120, w: 60, h: 50  },
-  { id: 'central_asia',  label: 'Central Asia',     x: 590, y: 80,  w: 80, h: 60  },
-  { id: 'east_asia',     label: 'East Asia',        x: 670, y: 80,  w: 80, h: 70  },
-  { id: 'south_asia',    label: 'South Asia',       x: 610, y: 140, w: 60, h: 50  },
-  { id: 'southeast_asia',label: 'Southeast Asia',   x: 680, y: 150, w: 70, h: 50  },
-  { id: 'africa',        label: 'Africa',           x: 450, y: 150, w: 90, h: 100 },
-  { id: 'north_america', label: 'North America',    x: 100, y: 80,  w: 160, h: 100},
-  { id: 'latin_america', label: 'Latin America',    x: 150, y: 190, w: 100, h: 110},
-  { id: 'oceania',       label: 'Oceania',          x: 700, y: 220, w: 100, h: 70 },
-];
-
+/**
+ * Cultural-passport world map. Uses Natural-Earth-derived country polygons
+ * (via `world-atlas/countries-110m.json`) so the map reads as a real world
+ * map. Each country's fill comes from how engaged the current user is with
+ * the cultures that "claim" it: see `passportCultureRegions.js` for the
+ * culture → country mapping.
+ *
+ * Backend `culture_summaries[]` is shaped
+ *   { culture, recipes_tried, stories_saved, interactions, rarity }
+ *
+ * The component falls back gracefully to a clean unexplored map when
+ * `cultures` is null, empty, or contains entries the mapping doesn't know
+ * about — it never throws.
+ */
 export default function PassportMap({ cultures }) {
   const [hovered, setHovered] = useState(null);
 
-  const cultureMap = {};
-  if (cultures) {
-    cultures.forEach(c => {
-      const key = c.name.toLowerCase().replace(/\s+/g, '_');
-      cultureMap[key] = c;
-    });
-  }
+  const countryIndex = buildCountryCultureIndex(cultures);
 
   return (
     <div className="passport-map-wrapper">
-      <svg
-        viewBox="0 0 860 320"
+      <ComposableMap
+        projection="geoEqualEarth"
+        projectionConfig={{ scale: 150, center: [10, 15] }}
+        width={900}
+        height={420}
         className="passport-map-svg"
-        role="img"
-        aria-label="Cultural passport world map"
       >
-        <rect width="860" height="320" fill="#d4e9f7" rx="8" />
-        {REGIONS.map(region => {
-          const culture = cultureMap[region.id];
-          const { fill, star } = getRegionFill(culture);
-          return (
-            <g key={region.id}>
-              <rect
-                x={region.x} y={region.y} width={region.w} height={region.h}
-                fill={fill}
-                stroke="#fff"
-                strokeWidth="1.5"
-                rx="4"
-                className="passport-map-region"
-                onMouseEnter={() => setHovered({ region, culture })}
-                onMouseLeave={() => setHovered(null)}
-              />
-              {star && (
-                <text x={region.x + region.w / 2} y={region.y + region.h / 2 + 5} textAnchor="middle" fontSize="14">⭐</text>
-              )}
-              <text
-                x={region.x + region.w / 2}
-                y={region.y + region.h - 6}
-                textAnchor="middle"
-                fontSize="8"
-                fill="#3D1500"
-                opacity="0.7"
-              >
-                {region.label}
-              </text>
-            </g>
-          );
-        })}
-      </svg>
+        <Geographies geography={worldTopology}>
+          {({ geographies }) =>
+            geographies.map((geo) => {
+              const name = geo.properties?.name ?? '';
+              const entry = countryIndex[name];
+              const culture = entry?.culture;
+              const { fill, star } = culture
+                ? getRegionFill(culture)
+                : { fill: MAP_FILLS.default, star: false };
+              const isHovered = hovered?.country === name;
+              return (
+                <Geography
+                  key={geo.rsmKey}
+                  geography={geo}
+                  fill={fill}
+                  stroke="#FFFFFF"
+                  strokeWidth={0.4}
+                  style={{
+                    default:  { outline: 'none' },
+                    hover:    { outline: 'none', fill, opacity: 0.85, cursor: 'pointer' },
+                    pressed:  { outline: 'none' },
+                  }}
+                  onMouseEnter={() => setHovered({ country: name, culture, star })}
+                  onMouseLeave={() => setHovered(null)}
+                  data-hovered={isHovered ? 'true' : undefined}
+                />
+              );
+            })
+          }
+        </Geographies>
+      </ComposableMap>
 
       {hovered && (
         <div className="passport-map-popover">
-          <strong>{hovered.region.label}</strong>
+          <strong>{hovered.country || 'Unknown'}</strong>
           {hovered.culture ? (
             <>
-              <span>{hovered.culture.stamp_rarity} stamp</span>
-              <span>{hovered.culture.recipe_count} recipes · {hovered.culture.story_count} stories</span>
+              <span className="passport-map-popover-culture">
+                {hovered.culture.name ?? hovered.culture.culture}
+              </span>
+              <span>
+                {hovered.culture.rarity ?? hovered.culture.stamp_rarity} stamp
+                {hovered.star ? ' ⭐' : ''}
+              </span>
+              <span>
+                {hovered.culture.recipes_tried ?? hovered.culture.recipe_count ?? 0} recipes ·{' '}
+                {hovered.culture.stories_saved ?? hovered.culture.story_count ?? 0} stories
+              </span>
             </>
           ) : (
             <span>Not yet explored</span>

--- a/app/frontend/src/components/passport/PassportTimeline.jsx
+++ b/app/frontend/src/components/passport/PassportTimeline.jsx
@@ -20,23 +20,33 @@ export default function PassportTimeline({ events }) {
 
   return (
     <ol className="passport-timeline">
-      {events.map(event => (
-        <li key={event.id} className="timeline-event">
-          <span className="timeline-icon" aria-hidden="true">{EVENT_ICONS[event.event_type] ?? '📌'}</span>
-          <div className="timeline-body">
-            <p className="timeline-description">
-              {event.event_type?.replace('_', ' ')}
-              {event.related_recipe && (
-                <Link to={`/recipes/${event.related_recipe}`} className="timeline-link"> · Recipe #{event.related_recipe}</Link>
-              )}
-              {event.related_story && (
-                <Link to={`/stories/${event.related_story}`} className="timeline-link"> · Story #{event.related_story}</Link>
-              )}
-            </p>
-            <time className="timeline-date" dateTime={event.timestamp}>{formatDate(event.timestamp)}</time>
-          </div>
-        </li>
-      ))}
+      {events.map(event => {
+        // Backend ships a human-readable `description` like
+        // "Earned a bronze stamp for Black Sea" — prefer it over the raw
+        // event_type slug. Fall back to the slug (with underscores swapped
+        // for spaces) when the description is missing.
+        const label = event.description
+          || (typeof event.event_type === 'string'
+            ? event.event_type.replace(/_/g, ' ')
+            : 'event');
+        return (
+          <li key={event.id} className="timeline-event">
+            <span className="timeline-icon" aria-hidden="true">{EVENT_ICONS[event.event_type] ?? '📌'}</span>
+            <div className="timeline-body">
+              <p className="timeline-description">
+                {label}
+                {event.related_recipe && (
+                  <Link to={`/recipes/${event.related_recipe}`} className="timeline-link"> · Recipe #{event.related_recipe}</Link>
+                )}
+                {event.related_story && (
+                  <Link to={`/stories/${event.related_story}`} className="timeline-link"> · Story #{event.related_story}</Link>
+                )}
+              </p>
+              <time className="timeline-date" dateTime={event.timestamp}>{formatDate(event.timestamp)}</time>
+            </div>
+          </li>
+        );
+      })}
     </ol>
   );
 }

--- a/app/frontend/src/components/passport/QuestList.jsx
+++ b/app/frontend/src/components/passport/QuestList.jsx
@@ -8,6 +8,9 @@ function QuestItem({ quest }) {
   const completed = Boolean(quest.completed_at);
   const pct = quest.target_count > 0 ? Math.min(100, (quest.progress / quest.target_count) * 100) : 0;
   const rewardLabel = quest.reward_value ?? quest.reward_type ?? '';
+  // Backend ships `event_end` for time-limited event quests; older mocks used
+  // `deadline`. Accept either.
+  const deadline = quest.event_end ?? quest.deadline ?? null;
 
   return (
     <div className={`quest-item${completed ? ' quest-item--done' : ''}`}>
@@ -23,8 +26,8 @@ function QuestItem({ quest }) {
       )}
       <div className="quest-meta">
         {rewardLabel && <span className="quest-reward">🎁 {rewardLabel}</span>}
-        {quest.deadline && !completed && (
-          <span className="quest-deadline">⏰ {formatDeadline(quest.deadline)}</span>
+        {deadline && !completed && (
+          <span className="quest-deadline">⏰ {formatDeadline(deadline)}</span>
         )}
         {!completed && (
           <span className="quest-count">{quest.progress}/{quest.target_count}</span>

--- a/app/frontend/src/components/passport/StampGrid.jsx
+++ b/app/frontend/src/components/passport/StampGrid.jsx
@@ -1,20 +1,31 @@
 import StampCard from './StampCard';
 import './StampGrid.css';
 
-const CATEGORIES = ['Recipe', 'Story', 'Heritage', 'Exploration', 'Community'];
+// Backend ships `category` as lowercase ('recipe', 'story', …). Match
+// case-insensitively and render the human-friendly label here.
+const CATEGORIES = [
+  { key: 'recipe', label: 'Recipe' },
+  { key: 'story', label: 'Story' },
+  { key: 'heritage', label: 'Heritage' },
+  { key: 'exploration', label: 'Exploration' },
+  { key: 'community', label: 'Community' },
+];
 
 export default function StampGrid({ stamps }) {
   if (!stamps || stamps.length === 0) {
     return <p className="passport-empty">No stamps yet. Start exploring to earn your first stamp!</p>;
   }
 
-  const grouped = CATEGORIES.reduce((acc, cat) => {
-    const items = stamps.filter(s => s.category === cat);
-    if (items.length > 0) acc[cat] = items;
+  const knownKeys = new Set(CATEGORIES.map((c) => c.key));
+  const grouped = CATEGORIES.reduce((acc, { key, label }) => {
+    const items = stamps.filter((s) => typeof s.category === 'string' && s.category.toLowerCase() === key);
+    if (items.length > 0) acc[label] = items;
     return acc;
   }, {});
 
-  const ungrouped = stamps.filter(s => !CATEGORIES.includes(s.category));
+  const ungrouped = stamps.filter(
+    (s) => typeof s.category !== 'string' || !knownKeys.has(s.category.toLowerCase()),
+  );
   if (ungrouped.length > 0) grouped['Other'] = ungrouped;
 
   return (
@@ -23,7 +34,7 @@ export default function StampGrid({ stamps }) {
         <section key={category} className="stamp-category-section">
           <h3 className="stamp-category-title">{category}</h3>
           <div className="stamp-grid">
-            {items.map(stamp => <StampCard key={stamp.id} stamp={stamp} />)}
+            {items.map((stamp) => <StampCard key={stamp.id} stamp={stamp} />)}
           </div>
         </section>
       ))}

--- a/app/frontend/src/utils/passportCultureRegions.js
+++ b/app/frontend/src/utils/passportCultureRegions.js
@@ -1,0 +1,78 @@
+/**
+ * Map a backend `culture_summaries[].culture` value to the country names
+ * (as they appear in world-atlas' `countries-110m.json` `properties.name`)
+ * that should be tinted on the passport world map.
+ *
+ * Backend `Region.name` values are sub-region or geographic-region strings
+ * ("Black Sea", "Aegean", "Mediterranean", "Balkan", "Nordic", …) — not
+ * countries. We translate each one into the set of countries that culturally
+ * belongs to it so the world map can light up a meaningful area.
+ *
+ * Lookup is case-insensitive and ignores leading/trailing whitespace.
+ * Unknown culture names return `[]` so the map silently skips them rather
+ * than throwing.
+ *
+ * To extend: add a new lowercase key and the array of country names that
+ * match the strings in `countries-110m.json`. World-atlas uses Natural Earth
+ * naming, so "Bosnia and Herz." (with the dot) and "United States of America"
+ * are the canonical forms.
+ */
+const CULTURE_TO_COUNTRIES = {
+  // Turkish sub-regions all map to Türkiye.
+  aegean: ['Turkey', 'Greece'],
+  anatolian: ['Turkey'],
+  'central anatolia': ['Turkey'],
+  'east anatolia': ['Turkey'],
+  'eastern anatolia': ['Turkey'],
+  marmara: ['Turkey'],
+  'southeastern anatolia': ['Turkey', 'Iraq', 'Syria'],
+  // Geographic / multi-country regions.
+  'black sea': ['Turkey', 'Russia', 'Ukraine', 'Romania', 'Bulgaria', 'Georgia'],
+  mediterranean: [
+    'Turkey', 'Greece', 'Italy', 'Spain', 'France', 'Malta', 'Cyprus',
+    'Egypt', 'Libya', 'Tunisia', 'Algeria', 'Morocco', 'Lebanon', 'Israel',
+    'Syria', 'Croatia', 'Slovenia', 'Albania', 'Montenegro', 'Bosnia and Herz.',
+  ],
+  balkan: [
+    'Greece', 'Bulgaria', 'Romania', 'Serbia', 'Croatia', 'Bosnia and Herz.',
+    'Albania', 'Montenegro', 'Macedonia', 'Slovenia', 'Kosovo',
+  ],
+  balkans: [
+    'Greece', 'Bulgaria', 'Romania', 'Serbia', 'Croatia', 'Bosnia and Herz.',
+    'Albania', 'Montenegro', 'Macedonia', 'Slovenia', 'Kosovo',
+  ],
+  nordic: ['Sweden', 'Norway', 'Denmark', 'Finland', 'Iceland'],
+};
+
+export function countriesForCulture(cultureName) {
+  if (typeof cultureName !== 'string') return [];
+  const key = cultureName.trim().toLowerCase();
+  return CULTURE_TO_COUNTRIES[key] ?? [];
+}
+
+/**
+ * Build a `countryName → culture` lookup from a list of `culture_summaries`.
+ * The same country can be claimed by more than one culture (e.g. Turkey by
+ * both "Aegean" and "Black Sea"); in that case the culture with the highest
+ * engagement (`recipes_tried + stories_saved`) wins. Ties break by the order
+ * the backend sent them (cultures with higher arrays index lose).
+ */
+export function buildCountryCultureIndex(cultures) {
+  const index = {};
+  if (!Array.isArray(cultures)) return index;
+  cultures.forEach((culture) => {
+    const cultureName = culture?.culture ?? culture?.name;
+    if (typeof cultureName !== 'string' || !cultureName) return;
+    const countries = countriesForCulture(cultureName);
+    const engagement =
+      (culture.recipes_tried ?? culture.recipe_count ?? 0) +
+      (culture.stories_saved ?? culture.story_count ?? 0);
+    countries.forEach((country) => {
+      const existing = index[country];
+      if (!existing || engagement > existing.engagement) {
+        index[country] = { culture: { ...culture, name: cultureName }, engagement };
+      }
+    });
+  });
+  return index;
+}

--- a/app/frontend/src/utils/passportMapColors.js
+++ b/app/frontend/src/utils/passportMapColors.js
@@ -5,12 +5,32 @@ export const MAP_FILLS = {
   dark:      '#8B3A0F',
 };
 
+/**
+ * Decide a region fill + star marker based on the user's engagement with the
+ * culture mapped to that region.
+ *
+ * Backend `culture_summaries[]` ships
+ *   { culture, recipes_tried, stories_saved, interactions, rarity }
+ *
+ * Older mock payloads used `stamp_rarity` / `recipe_count` / `story_count`;
+ * we accept both shapes so the map keeps rendering through future contract
+ * tweaks. `heritage_count` is not exposed per-culture yet, so the
+ * "heritage contributed" tier collapses into the legendary-rarity branch
+ * (any culture deep enough to earn a legendary stamp gets the dark fill).
+ */
 export function getRegionFill(culture) {
   if (!culture) return { fill: MAP_FILLS.default, star: false };
 
-  const hasLegendary = culture.stamp_rarity === 'legendary';
-  if (culture.heritage_count > 0) return { fill: MAP_FILLS.dark,   star: hasLegendary };
-  if (culture.recipe_count   > 0) return { fill: MAP_FILLS.medium, star: hasLegendary };
-  if (culture.story_count    > 0) return { fill: MAP_FILLS.light,  star: hasLegendary };
+  const rarity = culture.rarity ?? culture.stamp_rarity ?? null;
+  const recipesTried = culture.recipes_tried ?? culture.recipe_count ?? 0;
+  const storiesSaved = culture.stories_saved ?? culture.story_count ?? 0;
+  const heritageCount = culture.heritage_count ?? 0;
+  const isLegendary = rarity === 'legendary';
+
+  if (heritageCount > 0 || isLegendary) {
+    return { fill: MAP_FILLS.dark, star: isLegendary };
+  }
+  if (recipesTried > 0) return { fill: MAP_FILLS.medium, star: false };
+  if (storiesSaved > 0) return { fill: MAP_FILLS.light, star: false };
   return { fill: MAP_FILLS.default, star: false };
 }


### PR DESCRIPTION
Passport detail UI shipped against a mock-data shape that diverged from the merged backend contract (`#583`). The Map tab crashed on the canonical payload, Stamps grouped everything under "Other", Timeline showed slug labels instead of the human-readable description the backend sends, and the world map itself was hand-drawn rectangles. This PR aligns every tab with the live API and replaces the hand-drawn map with a real one.

## Backend contract (already shipped, verified against `/api/users/<u>/passport/`)

```jsonc
{
  "stamps": [
    { "id", "culture", "category" /* lowercase: recipe|story|heritage|exploration|community */, "rarity", "earned_at", "source_recipe", "source_story" }
  ],
  "culture_summaries": [
    { "culture", "recipes_tried", "stories_saved", "interactions", "rarity" }
  ],
  "timeline": [
    { "id", "event_type", "description" /* human-readable */, "timestamp", "related_recipe", "related_story", "stamp_rarity" }
  ],
  "active_quests": [
    { "id", "name", "description", "category", "target_count", "reward_type", "reward_value",
      "is_event_quest", "event_start", "event_end", "progress", "completed_at", "reward_claimed" }
  ]
}
```

## Fixes

### Map tab — was crashing, now renders a real world map
- **Crash:** `PassportMap` read `c.name.toLowerCase()` but the backend ships `culture` (not `name`). Any non-empty `culture_summaries[]` payload threw `TypeError: Cannot read properties of undefined (reading 'toLowerCase')` and dropped the tab into a white screen.
- **Visual:** the previous "world map" was 10 hand-drawn `<rect>` blobs over a light-blue background — Daglar's own comment said "Replace with a proper SVG asset once available". This PR replaces them with `react-simple-maps` driven by `world-atlas/countries-110m.json` (Natural Earth derived, ~130 KB topology), rendered via `geoEqualEarth` projection. Every country is a real polygon; ocean tint, white country borders, hover drop-shadow, and a non-pointer popover are kept.
- **Culture → country mapping:** `utils/passportCultureRegions.js` translates backend sub-region names (`Aegean`, `Black Sea`, `Mediterranean`, `Balkan`, `Nordic`, etc.) into the country names that culturally belong to them. Lookup is case-insensitive, trims whitespace, returns `[]` for unknown values so the map silently skips them rather than throwing. Duplicate claims resolve by engagement (`recipes_tried + stories_saved`) — first-occurrence wins on ties.
- New deps: **`react-simple-maps@^3` + `world-atlas@^2`**. React 19 peer is flagged by the package as 16/17/18 only but the wrapper just uses refs + useState; runs fine with React 19 in practice. `Dockerfile` swapped to `npm ci --legacy-peer-deps` so production build matches local install behaviour.

### Stamps tab — wrong category grouping
- `CATEGORIES = ['Recipe', 'Story', …]` was PascalCase but backend ships `category: 'recipe'` (lowercase). Strict `s.category === cat` matched nothing, so every stamp landed under the "Other" bucket.
- Fix: store both `{ key: 'recipe', label: 'Recipe' }` pairs, compare via `s.category.toLowerCase() === key`, render the canonical label. Unknown categories still fall through to "Other" so the data isn't silently dropped.

### Timeline tab — slug labels instead of descriptions
- The component rendered `event.event_type?.replace('_', ' ')` ("stamp earned", "recipe tried"). Backend already ships a human-readable `description` field ("Earned a bronze stamp for Black Sea", "Tried recipe: Black Sea Collard Green Sarma"). Now prefers `description`, falls back to the slug only when `description` is missing.

### Quests tab — wrong deadline field
- Component read `quest.deadline`; backend ships `event_end` on event-quests. Accept either so the deadline pill renders for real event quests, and mock-shape callers keep working.

### `passportMapColors.getRegionFill` — wrong field set
- Was reading `culture.stamp_rarity` / `culture.recipe_count` / `culture.story_count` (mock shape). Now reads canonical `culture.rarity` / `culture.recipes_tried` / `culture.stories_saved`, with the old keys as fallbacks. `heritage_count` isn't exposed per-culture by the backend (yet), so the "heritage contributed" tier collapses into the legendary-rarity branch — any culture deep enough to earn a legendary stamp gets the dark fill.

## Tests

- **`PassportMap.test.jsx`** (new) — 5 cases: crash safety on `null`/`undefined`/empty cultures, canonical backend shape (no `name`), and bad entries (`culture: null`, no `culture` key at all).
- **`passportCultureRegions.test.js`** (new) — 9 cases covering the lookup table (case-insensitive, trimmed, unknown), the country index builder (empty input, mapped countries, unknown skip, engagement tie-break, legacy mock-shape).
- **`StampGrid.test.jsx`** (existing, +2) — grouping by lowercase backend category, unknown-category fallback.
- **`passportMapColors.test.js`** (existing, +4) — canonical backend shape under a `describe('canonical backend shape')` block.
- **`PassportTimeline.test.jsx`** (existing, +2) — prefer `description`, fall back to slug.
- **`QuestList.test.jsx`** (existing, +1) — `event_end` as deadline source.

Local `CI=true npm test` → **648 passed** (was 621 before this PR).
Local `npm run build` → clean.
Docker `compose up -d --build web` → clean.

## Manual smoke (against the dev stack)

- `/users/mehmet` → Map tab no longer crashes; Turkey + Black Sea coast countries are tinted amber for the "recipe tried" stamp on Black Sea; hover shows the country name + "Black Sea" culture + rarity + counts.
- Stamps tab shows the bronze stamp under "Recipe" (was "Other").
- Timeline shows "Earned a bronze stamp for Black Sea" / "Tried recipe: Black Sea Collard Green Sarma" instead of the bare slug.

## Out of scope

- A backend-level expansion of the culture → country mapping (the per-region rows currently only cover the seed regions we ship). New entries can be added incrementally as more `Region` records land.
- Per-stamp progress bar inside `StampGrid` (would need `compute_rarity` exposed on the API).