### PR TITLE
fix(devops): seed the DB on backend start + fix web healthcheck (#835, #840)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,11 @@ POSTGRES_PASSWORD=change-me
 POSTGRES_HOST=db
 POSTGRES_PORT=5432
 
+# Run the idempotent seed_* management commands on backend container start.
+# Defaults to 1 for the compose stack (see docker-compose.yml); set to 0 to
+# bring the stack up against an empty DB.
+RUN_SEEDERS=1
+
 # Frontend build-time (baked into the web image). Set this before
 # `docker compose build` — runtime changes are ignored.
 REACT_APP_API_URL=http://localhost

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -73,8 +73,10 @@ jobs:
               docker stop genipe-db || true
             fi
 
-            # Bring up the compose stack. The backend entrypoint runs migrate
-            # and collectstatic automatically before gunicorn starts.
+            # Bring up the compose stack. The backend entrypoint runs migrate,
+            # collectstatic, and the idempotent seed_* commands (RUN_SEEDERS,
+            # on by default) before gunicorn starts; that's covered by the
+            # backend healthcheck's 180s start_period.
             # --force-recreate guards against stale containers that survive a
             # config change (e.g. when the prod overlay adds ports or volumes
             # that compose's normal diff misses on already-running containers).

--- a/app/backend/docker-entrypoint.sh
+++ b/app/backend/docker-entrypoint.sh
@@ -7,6 +7,32 @@ python manage.py migrate --noinput
 echo "[entrypoint] running collectstatic..."
 python manage.py collectstatic --noinput
 
+# Seed reference + demo content. All seed_* commands are idempotent and
+# dependency-ordered (see each command's docstring), so this is safe to run on
+# every start. Gated by RUN_SEEDERS so the bare image stays generic — the
+# compose backend service sets RUN_SEEDERS=1 (override via .env). seed_test_db
+# is intentionally excluded: it's a mock-data seeder for throwaway test DBs.
+if [ "${RUN_SEEDERS:-0}" = "1" ] || [ "${RUN_SEEDERS:-0}" = "true" ]; then
+    echo "[entrypoint] running seeders (RUN_SEEDERS=${RUN_SEEDERS})..."
+    for cmd in \
+        seed_canonical \
+        seed_region_geodata \
+        seed_region_geo \
+        seed_story_coordinates \
+        seed_cultural_facts \
+        seed_cultural_content \
+        seed_ingredient_densities \
+        seed_ingredient_routes
+    do
+        echo "[entrypoint]   -> manage.py $cmd"
+        # Best-effort: a failing seeder logs a warning but must not block the
+        # API from coming up (unlike migrate, which is fatal by design).
+        python manage.py "$cmd" || echo "[entrypoint] WARN: $cmd failed — continuing"
+    done
+else
+    echo "[entrypoint] skipping seeders (RUN_SEEDERS unset)"
+fi
+
 echo "[entrypoint] starting gunicorn..."
 exec gunicorn config.wsgi:application \
     --bind 0.0.0.0:8000 \

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -8,3 +8,14 @@ services:
     volumes:
       - /etc/letsencrypt:/etc/letsencrypt:ro
       - ./ops/nginx-prod.conf:/etc/nginx/conf.d/default.conf:ro
+    # Override the dev healthcheck: nginx-prod.conf only listens on 0.0.0.0
+    # (the base image's IPv6-listen patch can't run — the config is mounted
+    # read-only), and :80 301-redirects to https with the genipe.app cert, so
+    # `wget http://localhost/` can never pass. Hit https on loopback IPv4 with
+    # cert verification off — that serves the SPA index.html and returns 200.
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO /dev/null --no-check-certificate https://127.0.0.1/ || exit 1"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,8 +73,11 @@ services:
       backend:
         condition: service_healthy
     restart: unless-stopped
+    # NOTE: prod overrides this — see docker-compose.prod.yml. The prod nginx
+    # config (ops/nginx-prod.conf) only listens on 0.0.0.0 and :80 redirects
+    # to https, so this plain-http check only works for the dev/default image.
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost/ >/dev/null || exit 1"]
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1/ >/dev/null || exit 1"]
       interval: 10s
       timeout: 3s
       retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,11 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-genipe_mvp_2026}
       POSTGRES_HOST: db
       POSTGRES_PORT: 5432
+      # Run the idempotent seed_* management commands on container start (see
+      # app/backend/docker-entrypoint.sh). On by default for the compose stack
+      # so dev and prod both come up with reference + demo content; set
+      # RUN_SEEDERS=0 in .env to skip.
+      RUN_SEEDERS: ${RUN_SEEDERS:-1}
       # Optional S3-compatible object storage. Leave empty to use the local
       # media_data volume; set AWS_STORAGE_BUCKET_NAME (and the rest) in .env
       # to switch DEFAULT_FILE_STORAGE to S3Boto3Storage.
@@ -44,12 +49,14 @@ services:
     restart: unless-stopped
     # /admin/login/ renders without hitting the DB, so this is a clean
     # liveness probe for gunicorn. urlopen raises on non-2xx, exiting non-zero.
+    # start_period covers migrate + collectstatic + the seed_* commands
+    # (RUN_SEEDERS), which gunicorn only starts after.
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/admin/login/')"]
       interval: 15s
       timeout: 5s
       retries: 3
-      start_period: 40s
+      start_period: 180s
 
   web:
     build:

--- a/ops/PROD.md
+++ b/ops/PROD.md
@@ -161,7 +161,10 @@ All three services report container-level health to compose:
   liveness probe for gunicorn. 15s interval, 180s `start_period` to cover
   migrate + collectstatic + the `seed_*` commands (gunicorn starts only after
   the entrypoint finishes them).
-- `web`: `wget -qO- http://localhost/`, 10s interval
+- `web`: in prod, `wget --no-check-certificate https://127.0.0.1/` (overridden
+  in `docker-compose.prod.yml`); the base/dev healthcheck uses plain HTTP, but
+  `nginx-prod.conf` only listens on `0.0.0.0` and `:80` redirects to https, so
+  the prod check hits https on loopback. 10s interval.
 
 `backend` waits on `db: service_healthy`; `web` waits on `backend:
 service_healthy`. Compose will not mark the stack up until each dependency

--- a/ops/PROD.md
+++ b/ops/PROD.md
@@ -48,8 +48,11 @@ curl -fsS https://genipe.app/
 ```
 
 `db`, `backend`, and `web` should all report `(healthy)`. The backend
-entrypoint runs `migrate` and `collectstatic` automatically before gunicorn
-starts; that's covered by the backend healthcheck's 40s `start_period`.
+entrypoint runs `migrate`, `collectstatic`, and — when `RUN_SEEDERS` is set
+(the compose default) — the idempotent `seed_*` management commands, in
+dependency order, before gunicorn starts. That whole sequence is covered by
+the backend healthcheck's 180s `start_period`, so the first start after a
+fresh DB can take a couple of minutes.
 
 ## Required environment variables
 
@@ -69,6 +72,7 @@ Audited against `app/backend/config/settings.py`. Every `os.getenv` /
 | `POSTGRES_HOST` | Yes | `db` (compose service name) | Hardcoded in compose; only override outside compose |
 | `POSTGRES_PORT` | Yes | `5432` | Hardcoded in compose |
 | `REACT_APP_API_URL` | Yes (build-time) | `http://localhost` | Baked into the `web` image; set before `compose build` |
+| `RUN_SEEDERS` | No | `1` (compose) | When `1`/`true`, the backend entrypoint runs the idempotent `seed_*` commands on start; set `0` to bring the stack up against an empty DB. The bare image (outside compose) defaults to off. |
 | `AWS_STORAGE_BUCKET_NAME` | No | empty | When set, switches `DEFAULT_FILE_STORAGE` to S3Boto3Storage; otherwise the local `media_data` volume is used |
 | `AWS_S3_ENDPOINT_URL` | If S3 | empty | Required when bucket name is set |
 | `AWS_ACCESS_KEY_ID` | If S3 | empty | Required when bucket name is set |
@@ -104,6 +108,41 @@ docker compose -f docker-compose.yml -f docker-compose.prod.yml ps
 docker compose -f docker-compose.yml -f docker-compose.prod.yml logs --tail=100 backend web db
 ```
 
+## Seeding
+
+The backend entrypoint (`app/backend/docker-entrypoint.sh`) runs these
+management commands, in this order, on every start when `RUN_SEEDERS` is
+truthy (the compose default):
+
+```
+seed_canonical            # base data: regions, ingredients, recipes, stories,
+                          #   heritage groups, cultural content/events, …
+seed_region_geodata       # built-in geo coords for known regions
+seed_region_geo           # region bbox + per-recipe map coords (fixture)
+seed_story_coordinates    # per-story map pins (needs region bbox)
+seed_cultural_facts       # region-tied "Did You Know?" facts
+seed_cultural_content     # culture cards
+seed_ingredient_densities # g/ml for unit conversions
+seed_ingredient_routes    # ingredient migration map overlays
+```
+
+All of them are idempotent (keyed on natural keys), so rerunning on every
+container restart does not duplicate rows. A failing seeder logs a warning
+and the entrypoint continues — only `migrate` is fatal. `seed_test_db` is
+**not** in this list: it's a mock-data seeder for throwaway test DBs, not for
+prod.
+
+To seed a running stack manually (or to re-run after changing a fixture):
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.prod.yml \
+  exec backend sh -c 'for c in seed_canonical seed_region_geodata seed_region_geo \
+    seed_story_coordinates seed_cultural_facts seed_cultural_content \
+    seed_ingredient_densities seed_ingredient_routes; do python manage.py "$c"; done'
+```
+
+Take a DB dump first if you're touching prod (see `ops/ROLLBACK.md`).
+
 ## Rollback
 
 Three rollback paths (quick reset to a previous good commit, full revert to
@@ -119,8 +158,9 @@ All three services report container-level health to compose:
 - `db`: `pg_isready -U $POSTGRES_USER -d $POSTGRES_DB`, 10s interval
 - `backend`: Python `urllib.request.urlopen("http://localhost:8000/admin/login/")` —
   the admin login page renders without a DB query, so this is a clean
-  liveness probe for gunicorn. 15s interval, 40s `start_period` to cover
-  migrate + collectstatic.
+  liveness probe for gunicorn. 15s interval, 180s `start_period` to cover
+  migrate + collectstatic + the `seed_*` commands (gunicorn starts only after
+  the entrypoint finishes them).
 - `web`: `wget -qO- http://localhost/`, 10s interval
 
 `backend` waits on `db: service_healthy`; `web` waits on `backend:


### PR DESCRIPTION
Closes #835
Closes #840

## Summary
**`app/backend/docker-entrypoint.sh` (#835):** The backend container only ran `migrate` + `collectstatic` on start, so production (and any fresh box brought up via `ops/PROD.md`) came up with an empty DB — 1 recipe, 0 stories, 0 cultural facts/content/events — and the live site rendered bare (`/api/cultural-facts/random/` 404, empty `/api/stories/`, `/api/recipes/`, `/api/map/regions/`). The `seed_*` management commands and their fixtures are shipped but were never invoked. Fixed by running the idempotent `seed_*` commands from the entrypoint, in dependency order: `seed_canonical` → `seed_region_geodata` → `seed_region_geo` → `seed_story_coordinates` → `seed_cultural_facts` → `seed_cultural_content` → `seed_ingredient_densities` → `seed_ingredient_routes`. A failing seeder logs a warning and the entrypoint continues; only `migrate` stays fatal. `seed_test_db` is intentionally excluded — it's a mock-data seeder for throwaway test DBs, not for prod.

**`docker-compose.yml` (#835):** Added `RUN_SEEDERS: ${RUN_SEEDERS:-1}` to the `backend` service so the entrypoint's seeding step is on by default for the compose stack (dev and prod) but off for the bare image. Bumped the `backend` healthcheck `start_period` 40s → 180s — gunicorn only `exec`s after the entrypoint finishes, so the first start against a fresh DB now does migrate + collectstatic + 8 seeders before the liveness probe can pass.

**`docker-compose.prod.yml` / `docker-compose.yml` (#840):** The `web` (nginx) container was permanently `(unhealthy)` even though it served traffic fine — `wget http://localhost/` can't pass with the prod nginx config: it only listens on `0.0.0.0` (the base image's `[::]:80` patch is skipped because `ops/nginx-prod.conf` is mounted read-only, so `localhost` → `::1` is refused), and the `:80` server block 301-redirects to https with the `genipe.app` cert (following the redirect fails verification). Overrode the `web` healthcheck in `docker-compose.prod.yml` to hit `https://127.0.0.1/` with `--no-check-certificate` (serves the SPA `index.html`, returns 200); the base `docker-compose.yml` keeps a plain-HTTP check for the dev/default image (no TLS listener there), now pinned to `127.0.0.1` instead of `localhost`.

**`.env.example`:** Documented `RUN_SEEDERS` (default `1`; set `0` to bring the stack up against an empty DB).

**`ops/PROD.md`:** Added a "Seeding" section (the command list + a manual `compose exec` snippet), added `RUN_SEEDERS` to the env table, updated the first-time-setup note and the `backend`/`web` healthcheck descriptions.

**`.github/workflows/deploy-web.yml`:** Updated the inline comment to reflect that the entrypoint now also runs the seeders.

All `seed_*` commands are idempotent (keyed on natural keys), so re-running on every container restart does not duplicate rows.

## Test plan
 - [ ] `sh -n app/backend/docker-entrypoint.sh` exits clean (syntax)
 - [ ] `docker compose -f docker-compose.yml config` and `docker compose -f docker-compose.yml -f docker-compose.prod.yml config` both parse with no error
 - [ ] Bring the prod stack up against an empty DB volume → `backend` reaches `(healthy)` within `start_period`; `recipes`, `stories`, `heritage_groups`, `cultural_facts`, `cultural_content`, `cultural_events` are all non-zero
 - [ ] `GET /api/cultural-facts/random/` returns 200; `/api/stories/`, `/api/recipes/`, `/api/map/regions/` are non-empty
 - [ ] `docker compose -f ... -f docker-compose.prod.yml ps` reports `web` as `(healthy)`
 - [ ] Restart the `backend` container → no duplicate rows (idempotency); entrypoint logs `running seeders`
 - [ ] `RUN_SEEDERS=0 docker compose up` → entrypoint logs `skipping seeders`, DB stays empty
 - [ ] Plain `docker compose up` (no prod overlay) → `web` healthcheck still passes (plain HTTP)
 - [ ] Existing dev/test workflows unaffected (`POSTGRES_HOST` unset → SQLite path; bare backend image has `RUN_SEEDERS` unset → no seeding)
 - [ ] `https://genipe.app/` still serves after deploy (regression)
