### PR TITLE
feat(mobile): refactor StampCollection into category sections with StampCard grid (closes #832)

### DIFF
--- a/app/mobile/__tests__/components/StampCard.test.tsx
+++ b/app/mobile/__tests__/components/StampCard.test.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import StampCard from '../../src/components/passport/StampCard';
+import type { Stamp } from '../../src/components/passport/StampCollection';
+
+const RARITY_COLOURS: Record<string, string> = {
+  bronze: '#CD7F32',
+  silver: '#C0C0C0',
+  gold: '#FFD700',
+  emerald: '#50C878',
+  legendary: '#9B59B6',
+};
+
+const make = (over: Partial<Stamp> = {}): Stamp => ({
+  id: 1,
+  name: 'Anatolian',
+  category: 'heritage',
+  rarity: 'gold',
+  earned_at: '2026-03-10T12:00:00Z',
+  ...over,
+});
+
+describe('StampCard', () => {
+  it('renders earned stamp with name, rarity label and MMM YYYY date', () => {
+    const { getByText, queryByText } = render(
+      <StampCard stamp={make({ rarity: 'gold' })} />,
+    );
+    expect(getByText('Anatolian')).toBeTruthy();
+    expect(getByText('Gold')).toBeTruthy();
+    expect(getByText('Mar 2026')).toBeTruthy();
+    expect(queryByText('🔒')).toBeNull();
+  });
+
+  it('renders locked stamp with 🔒 instead of date', () => {
+    const { getByText, queryByText } = render(
+      <StampCard
+        stamp={make({
+          id: 9,
+          name: 'Hidden',
+          rarity: 'legendary',
+          earned_at: null,
+          is_locked: true,
+        })}
+      />,
+    );
+    expect(getByText('🔒')).toBeTruthy();
+    expect(queryByText(/2026/)).toBeNull();
+  });
+
+  it('respects explicit locked prop over earned_at', () => {
+    const { getByText } = render(
+      <StampCard stamp={make()} locked />,
+    );
+    expect(getByText('🔒')).toBeTruthy();
+  });
+
+  it('exposes accessibilityLabel with name, rarity and earned status', () => {
+    const { getByLabelText } = render(
+      <StampCard
+        stamp={make({
+          name: 'Anatolian',
+          rarity: 'gold',
+          earned_at: '2026-01-05T00:00:00Z',
+        })}
+      />,
+    );
+    expect(getByLabelText('Anatolian, Gold, earned Jan 2026')).toBeTruthy();
+  });
+
+  it('exposes accessibilityLabel with locked status when locked', () => {
+    const { getByLabelText } = render(
+      <StampCard
+        stamp={make({
+          name: 'Hidden Heritage',
+          rarity: 'legendary',
+          earned_at: null,
+          is_locked: true,
+        })}
+      />,
+    );
+    expect(
+      getByLabelText('Hidden Heritage, Legendary, locked'),
+    ).toBeTruthy();
+  });
+
+  describe('rarity colours', () => {
+    (['bronze', 'silver', 'gold', 'emerald', 'legendary'] as const).forEach(
+      (rarity) => {
+        it(`applies the ${rarity} colour as the card border`, () => {
+          const { getByTestId } = render(
+            <StampCard stamp={make({ id: rarity, rarity })} />,
+          );
+          const card = getByTestId(`stamp-card-${rarity}`);
+          const style = Array.isArray(card.props.style)
+            ? Object.assign({}, ...card.props.style.filter(Boolean))
+            : card.props.style;
+          expect(style.borderColor).toBe(RARITY_COLOURS[rarity]);
+        });
+      },
+    );
+
+    it('falls back to a default border colour for unknown rarities', () => {
+      const { getByTestId } = render(
+        <StampCard stamp={make({ id: 'mystery', rarity: 'mythic' })} />,
+      );
+      const card = getByTestId('stamp-card-mystery');
+      const style = Array.isArray(card.props.style)
+        ? Object.assign({}, ...card.props.style.filter(Boolean))
+        : card.props.style;
+      expect(typeof style.borderColor).toBe('string');
+      expect(style.borderColor.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/app/mobile/__tests__/components/StampCollection.test.tsx
+++ b/app/mobile/__tests__/components/StampCollection.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render } from '@testing-library/react-native';
+import { render } from '@testing-library/react-native';
 import {
   StampCollection,
   normalizeStamp,
@@ -33,7 +33,7 @@ describe('StampCollection', () => {
     expect(getByLabelText('Stamp collection loading')).toBeTruthy();
   });
 
-  it('groups stamps by category and shows count badges', () => {
+  it('groups stamps by category and renders a section title per category', () => {
     const stamps: Stamp[] = [
       stamp({ id: 1, name: 'Anatolian', category: 'heritage' }),
       stamp({ id: 2, name: 'Black Sea', category: 'heritage' }),
@@ -47,10 +47,42 @@ describe('StampCollection', () => {
     const { getByText } = render(<StampCollection stamps={stamps} />);
     expect(getByText('Heritage')).toBeTruthy();
     expect(getByText('Story')).toBeTruthy();
-    expect(getByText('2')).toBeTruthy();
-    expect(getByText('1')).toBeTruthy();
     expect(getByText('Anatolian')).toBeTruthy();
+    expect(getByText('Black Sea')).toBeTruthy();
     expect(getByText('First Story')).toBeTruthy();
+  });
+
+  it('renders all category sections always open (no accordion)', () => {
+    const stamps: Stamp[] = [
+      stamp({ id: 1, name: 'Anatolian', category: 'heritage' }),
+      stamp({ id: 2, name: 'Tale One', category: 'story', rarity: 'silver' }),
+    ];
+    const { getByText, getByTestId } = render(
+      <StampCollection stamps={stamps} />,
+    );
+    // every group renders a grid container — items inside are visible without interaction
+    expect(getByTestId('stamp-grid-heritage')).toBeTruthy();
+    expect(getByTestId('stamp-grid-story')).toBeTruthy();
+    expect(getByText('Anatolian')).toBeTruthy();
+    expect(getByText('Tale One')).toBeTruthy();
+  });
+
+  it('puts each stamp inside its category grid as a StampCard', () => {
+    const stamps: Stamp[] = [
+      stamp({ id: 1, name: 'Anatolian', category: 'heritage' }),
+      stamp({ id: 2, name: 'Black Sea', category: 'heritage' }),
+    ];
+    const { getByTestId } = render(<StampCollection stamps={stamps} />);
+    const grid = getByTestId('stamp-grid-heritage');
+    // both cards should be descendants of the heritage grid
+    expect(getByTestId('stamp-card-1')).toBeTruthy();
+    expect(getByTestId('stamp-card-2')).toBeTruthy();
+    // grid uses row + wrap layout for the 2-column shape
+    const style = Array.isArray(grid.props.style)
+      ? Object.assign({}, ...grid.props.style.filter(Boolean))
+      : grid.props.style;
+    expect(style.flexDirection).toBe('row');
+    expect(style.flexWrap).toBe('wrap');
   });
 
   it('formats earned date as "MMM YYYY"', () => {
@@ -78,24 +110,9 @@ describe('StampCollection', () => {
     );
     expect(getByText('🔒')).toBeTruthy();
     expect(queryByText(/2026/)).toBeNull();
-    // a11y label includes "locked"
     expect(
       getByLabelText('Hidden Heritage, Legendary, locked'),
     ).toBeTruthy();
-  });
-
-  it('toggles a category open/closed when its header is pressed', () => {
-    const stamps: Stamp[] = [
-      stamp({ id: 1, name: 'Anatolian', category: 'heritage' }),
-    ];
-    const { getByLabelText, queryByText } = render(
-      <StampCollection stamps={stamps} />,
-    );
-    expect(queryByText('Anatolian')).toBeTruthy();
-    fireEvent.press(getByLabelText('Heritage stamps, 1 expanded'));
-    expect(queryByText('Anatolian')).toBeNull();
-    fireEvent.press(getByLabelText('Heritage stamps, 1 collapsed'));
-    expect(queryByText('Anatolian')).toBeTruthy();
   });
 
   it('exposes accessibility labels with name, rarity and status', () => {

--- a/app/mobile/src/components/passport/StampCard.tsx
+++ b/app/mobile/src/components/passport/StampCard.tsx
@@ -1,0 +1,151 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { tokens } from '../../theme';
+import type { Stamp } from './StampCollection';
+
+/**
+ * StampCard — square stamp tile used inside the category grid (#832).
+ *
+ * Pure presentational component. Mirrors the web `StampCard.jsx` shape so the
+ * mobile passport stamps tab has parity with the web layout: rarity colour
+ * stripe on top, display-font name (2 lines max), earned date as "MMM YYYY"
+ * or a lock glyph for locked stamps.
+ */
+
+export type StampCardProps = {
+  stamp: Stamp;
+  locked?: boolean;
+};
+
+const RARITY_COLOURS: Record<string, string> = {
+  bronze: '#CD7F32',
+  silver: '#C0C0C0',
+  gold: '#FFD700',
+  emerald: '#50C878',
+  legendary: '#9B59B6',
+};
+
+const titleCase = (s: string): string =>
+  s ? s.charAt(0).toUpperCase() + s.slice(1).toLowerCase() : s;
+
+const rarityLabel = (rarity: string): string => titleCase(rarity || 'Stamp');
+
+const rarityColour = (rarity: string): string =>
+  RARITY_COLOURS[(rarity || '').toLowerCase()] || tokens.colors.primary;
+
+const formatEarned = (iso: string | null | undefined): string => {
+  if (!iso) return '';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  const months = [
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec',
+  ];
+  return `${months[d.getMonth()]} ${d.getFullYear()}`;
+};
+
+export function StampCard({ stamp, locked }: StampCardProps) {
+  const isLocked =
+    typeof locked === 'boolean'
+      ? locked
+      : stamp.is_locked === true || stamp.earned_at == null;
+  const swatch = rarityColour(stamp.rarity);
+  const rLabel = rarityLabel(stamp.rarity);
+  const dateStr = formatEarned(stamp.earned_at);
+  const a11y = [
+    stamp.name,
+    rLabel,
+    isLocked ? 'locked' : dateStr ? `earned ${dateStr}` : 'earned',
+  ].join(', ');
+
+  return (
+    <View
+      accessibilityLabel={a11y}
+      style={[
+        styles.card,
+        { borderColor: swatch },
+        isLocked && styles.cardLocked,
+      ]}
+      testID={`stamp-card-${stamp.id}`}
+    >
+      <View style={[styles.stripe, { backgroundColor: swatch }]} />
+      <View style={styles.body}>
+        <Text
+          style={[styles.name, isLocked && styles.nameLocked]}
+          numberOfLines={2}
+        >
+          {stamp.name}
+        </Text>
+        <Text style={styles.rarity}>{rLabel}</Text>
+        {isLocked ? (
+          <Text style={styles.lockGlyph} accessibilityLabel="locked">
+            🔒
+          </Text>
+        ) : dateStr ? (
+          <Text style={styles.date}>{dateStr}</Text>
+        ) : null}
+      </View>
+    </View>
+  );
+}
+
+export default StampCard;
+
+const styles = StyleSheet.create({
+  card: {
+    width: 150,
+    height: 150,
+    borderRadius: tokens.radius.md,
+    borderWidth: 2,
+    backgroundColor: '#FFFFFF',
+    overflow: 'hidden',
+  },
+  cardLocked: {
+    backgroundColor: tokens.colors.surfaceDark,
+    opacity: 0.5,
+  },
+  stripe: {
+    height: 8,
+    width: '100%',
+  },
+  body: {
+    flex: 1,
+    paddingHorizontal: 10,
+    paddingVertical: 10,
+    gap: 4,
+    justifyContent: 'space-between',
+  },
+  name: {
+    ...tokens.typography.display,
+    fontSize: 14,
+    color: tokens.colors.text,
+  },
+  nameLocked: {
+    color: tokens.colors.bg,
+  },
+  rarity: {
+    ...tokens.typography.body,
+    fontSize: 11,
+    color: tokens.colors.textMuted,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  date: {
+    ...tokens.typography.body,
+    fontSize: 12,
+    color: tokens.colors.textMuted,
+  },
+  lockGlyph: {
+    fontSize: 18,
+  },
+});

--- a/app/mobile/src/components/passport/StampCollection.tsx
+++ b/app/mobile/src/components/passport/StampCollection.tsx
@@ -1,13 +1,13 @@
-import React, { useMemo, useState } from 'react';
-import { Pressable, StyleSheet, Text, View } from 'react-native';
+import React, { useMemo } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
 import { tokens } from '../../theme';
+import StampCard from './StampCard';
 
 /**
- * Stamp collection tab body for the user passport (#601).
+ * Stamp collection tab body for the user passport (#601, #832).
  *
- * Standalone, reusable component — does NOT touch PassportScreen. PR #781
- * scaffolds the passport tab bar and will import this component into the
- * Stamps tab body.
+ * Mirrors web `StampGrid`: per-category sections (always open, no accordion)
+ * with a 2-column grid of `StampCard`s inside.
  *
  * Backend probe of GET /api/users/<username>/passport/ returned items with
  * keys: { id, culture, category, rarity, earned_at, source_recipe,
@@ -47,14 +47,6 @@ type Props = {
   loading?: boolean;
 };
 
-const RARITY_COLOURS: Record<string, string> = {
-  bronze: '#CD7F32',
-  silver: '#C0C0C0',
-  gold: '#FFD700',
-  emerald: '#50C878',
-  legendary: '#9B59B6',
-};
-
 const CATEGORY_ORDER: StampCategory[] = [
   'recipe',
   'story',
@@ -69,6 +61,7 @@ const CATEGORY_LABELS: Record<string, string> = {
   heritage: 'Heritage',
   exploration: 'Exploration',
   community: 'Community',
+  other: 'Other',
 };
 
 const titleCase = (s: string): string =>
@@ -76,32 +69,6 @@ const titleCase = (s: string): string =>
 
 const categoryLabel = (cat: string): string =>
   CATEGORY_LABELS[cat] || titleCase(cat || 'Other');
-
-const rarityLabel = (rarity: string): string => titleCase(rarity || 'Stamp');
-
-const rarityColour = (rarity: string): string =>
-  RARITY_COLOURS[(rarity || '').toLowerCase()] || tokens.colors.primary;
-
-const formatEarned = (iso: string | null | undefined): string => {
-  if (!iso) return '';
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return '';
-  const months = [
-    'Jan',
-    'Feb',
-    'Mar',
-    'Apr',
-    'May',
-    'Jun',
-    'Jul',
-    'Aug',
-    'Sep',
-    'Oct',
-    'Nov',
-    'Dec',
-  ];
-  return `${months[d.getMonth()]} ${d.getFullYear()}`;
-};
 
 /**
  * Map a raw stamp object from the backend (or anywhere) onto the shape this
@@ -151,7 +118,6 @@ function groupByCategory(stamps: Stamp[]): Array<[string, Stamp[]]> {
     if (!map.has(key)) map.set(key, []);
     map.get(key)!.push(s);
   }
-  // Sort: known categories first in declared order, then alphabetical for the rest.
   const keys = Array.from(map.keys());
   keys.sort((a, b) => {
     const ai = CATEGORY_ORDER.indexOf(a as StampCategory);
@@ -166,10 +132,6 @@ function groupByCategory(stamps: Stamp[]): Array<[string, Stamp[]]> {
 
 export function StampCollection({ stamps, loading = false }: Props) {
   const groups = useMemo(() => groupByCategory(stamps || []), [stamps]);
-  const [collapsed, setCollapsed] = useState<Record<string, boolean>>({});
-
-  const toggle = (cat: string) =>
-    setCollapsed((c) => ({ ...c, [cat]: !c[cat] }));
 
   if (loading) {
     return (
@@ -195,109 +157,26 @@ export function StampCollection({ stamps, loading = false }: Props) {
 
   return (
     <View style={styles.container} accessibilityLabel="Stamp collection">
-      {groups.map(([category, items]) => {
-        const isOpen = !collapsed[category];
-        return (
-          <View key={category} style={styles.group}>
-            <Pressable
-              onPress={() => toggle(category)}
-              accessibilityRole="button"
-              accessibilityLabel={`${categoryLabel(category)} stamps, ${items.length} ${
-                isOpen ? 'expanded' : 'collapsed'
-              }`}
-              style={({ pressed }) => [
-                styles.groupHeader,
-                pressed && styles.pressed,
-              ]}
-            >
-              <Text style={styles.groupTitle}>{categoryLabel(category)}</Text>
-              <View style={styles.headerRight}>
-                <View style={styles.countBadge}>
-                  <Text style={styles.countBadgeText}>{items.length}</Text>
-                </View>
-                <Text style={styles.chevron}>{isOpen ? '▾' : '▸'}</Text>
-              </View>
-            </Pressable>
-
-            {isOpen ? (
-              <View style={styles.rows}>
-                {items.map((stamp) => {
-                  const locked = isLocked(stamp);
-                  const swatch = rarityColour(stamp.rarity);
-                  const dateStr = formatEarned(stamp.earned_at);
-                  const progress =
-                    typeof stamp.progress_percent === 'number'
-                      ? Math.max(0, Math.min(100, stamp.progress_percent))
-                      : null;
-                  const a11y = [
-                    stamp.name,
-                    rarityLabel(stamp.rarity),
-                    locked
-                      ? 'locked'
-                      : dateStr
-                        ? `earned ${dateStr}`
-                        : 'earned',
-                  ].join(', ');
-                  return (
-                    <View
-                      key={String(stamp.id)}
-                      accessibilityLabel={a11y}
-                      style={[styles.row, locked && styles.rowLocked]}
-                    >
-                      <View
-                        style={[
-                          styles.swatch,
-                          {
-                            backgroundColor: locked ? '#B8B8B8' : swatch,
-                            borderColor: locked ? '#8A8A8A' : '#1A1A1A',
-                          },
-                        ]}
-                      >
-                        {locked ? <Text style={styles.lockGlyph}>🔒</Text> : null}
-                      </View>
-                      <View style={styles.rowBody}>
-                        <Text
-                          style={[styles.rowName, locked && styles.rowNameLocked]}
-                          numberOfLines={1}
-                        >
-                          {stamp.name}
-                        </Text>
-                        <View style={styles.rowMetaRow}>
-                          <Text style={styles.rowMeta}>
-                            {rarityLabel(stamp.rarity)}
-                          </Text>
-                          {!locked && dateStr ? (
-                            <>
-                              <Text style={styles.dot}>·</Text>
-                              <Text style={styles.rowMeta}>{dateStr}</Text>
-                            </>
-                          ) : null}
-                        </View>
-                        {progress != null ? (
-                          <View
-                            style={styles.progressTrack}
-                            accessibilityLabel={`progress ${progress} percent`}
-                          >
-                            <View
-                              style={[
-                                styles.progressFill,
-                                {
-                                  width: `${progress}%`,
-                                  backgroundColor: locked ? '#8A8A8A' : swatch,
-                                },
-                              ]}
-                            />
-                          </View>
-                        ) : null}
-                      </View>
-                    </View>
-                  );
-                })}
-              </View>
-            ) : null}
+      {groups.map(([category, items]) => (
+        <View key={category} style={styles.group}>
+          <Text
+            style={styles.groupTitle}
+            accessibilityRole="header"
+            accessibilityLabel={`${categoryLabel(category)} stamps, ${items.length}`}
+          >
+            {categoryLabel(category)}
+          </Text>
+          <View style={styles.grid} testID={`stamp-grid-${category}`}>
+            {items.map((stamp) => (
+              <StampCard
+                key={String(stamp.id)}
+                stamp={stamp}
+                locked={isLocked(stamp)}
+              />
+            ))}
           </View>
-        );
-      })}
+        </View>
+      ))}
     </View>
   );
 }
@@ -309,7 +188,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingTop: 12,
     paddingBottom: 24,
-    gap: 12,
+    gap: 20,
   },
   loadingText: {
     ...tokens.typography.body,
@@ -337,119 +216,16 @@ const styles = StyleSheet.create({
     textAlign: 'center',
   },
   group: {
-    borderRadius: tokens.radius.md,
-    borderWidth: 1,
-    borderColor: tokens.colors.primaryBorder,
-    backgroundColor: tokens.colors.bg,
-    overflow: 'hidden',
-  },
-  groupHeader: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    paddingHorizontal: 14,
-    paddingVertical: 12,
-    backgroundColor: tokens.colors.primarySubtle,
-  },
-  pressed: {
-    opacity: 0.7,
+    gap: 12,
   },
   groupTitle: {
     ...tokens.typography.display,
-    fontSize: 16,
+    fontSize: 18,
     color: tokens.colors.text,
   },
-  headerRight: {
+  grid: {
     flexDirection: 'row',
-    alignItems: 'center',
-    gap: 8,
-  },
-  countBadge: {
-    minWidth: 24,
-    paddingHorizontal: 8,
-    paddingVertical: 2,
-    borderRadius: tokens.radius.pill,
-    backgroundColor: tokens.colors.primary,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  countBadgeText: {
-    ...tokens.typography.body,
-    color: tokens.colors.textOnDark,
-    fontSize: 12,
-    fontWeight: '700',
-  },
-  chevron: {
-    ...tokens.typography.body,
-    color: tokens.colors.text,
-    fontSize: 14,
-  },
-  rows: {
-    paddingHorizontal: 12,
-    paddingVertical: 8,
-    gap: 8,
-  },
-  row: {
-    flexDirection: 'row',
-    alignItems: 'center',
+    flexWrap: 'wrap',
     gap: 12,
-    padding: 10,
-    borderRadius: tokens.radius.sm,
-    backgroundColor: '#FFFFFF',
-    borderWidth: 1,
-    borderColor: tokens.colors.primaryBorder,
-  },
-  rowLocked: {
-    backgroundColor: '#ECECEC',
-    borderColor: '#CFCFCF',
-  },
-  swatch: {
-    width: 36,
-    height: 36,
-    borderRadius: tokens.radius.pill,
-    borderWidth: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  lockGlyph: {
-    fontSize: 16,
-  },
-  rowBody: {
-    flex: 1,
-    gap: 2,
-  },
-  rowName: {
-    ...tokens.typography.body,
-    fontSize: 15,
-    fontWeight: '600',
-    color: tokens.colors.text,
-  },
-  rowNameLocked: {
-    color: '#6B6B6B',
-  },
-  rowMetaRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 6,
-  },
-  rowMeta: {
-    ...tokens.typography.body,
-    fontSize: 12,
-    color: tokens.colors.textMuted,
-  },
-  dot: {
-    color: tokens.colors.textMuted,
-    fontSize: 12,
-  },
-  progressTrack: {
-    marginTop: 6,
-    height: 4,
-    borderRadius: 2,
-    backgroundColor: 'rgba(0,0,0,0.08)',
-    overflow: 'hidden',
-  },
-  progressFill: {
-    height: '100%',
-    borderRadius: 2,
   },
 });


### PR DESCRIPTION
## Summary
Drops the accordion/expand-collapse pattern. Each category section is always open and renders its stamps as a 2-column grid using `flexDirection: 'row' + flexWrap: 'wrap'` so it composes inside a parent ScrollView. Extracts a new `StampCard` component: 150×150 card, rarity-coloured border + top stripe, MMM YYYY date or 🔒 glyph for locked, full a11y label. Web parity — mirrors `StampGrid.jsx` + `StampCard.jsx`.

## Test plan
- [ ] Open a profile with stamps — each category section renders as a 2-col grid
- [ ] Locked stamps render greyed out with 🔒
- [ ] Earned stamps show rarity stripe + MMM YYYY date
- [ ] tsc clean, jest 183/183

Closes #832