### PR TITLE
feat(mobile): tappable Recipe/Story links on timeline events (closes #833)

### DIFF
--- a/app/mobile/__tests__/components/JourneyTimeline.test.tsx
+++ b/app/mobile/__tests__/components/JourneyTimeline.test.tsx
@@ -6,11 +6,17 @@ jest.mock('../../src/services/passportTimelineService', () => ({
   normalizeEvent: jest.fn(),
 }));
 
+const mockNavigate = jest.fn();
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
+
 import React from 'react';
-import { render, waitFor } from '@testing-library/react-native';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
 import {
   JourneyTimeline,
   composeTitle,
+  extractRelatedIds,
   formatTimeAgo,
 } from '../../src/components/passport/JourneyTimeline';
 import {
@@ -81,9 +87,39 @@ describe('composeTitle', () => {
   });
 });
 
+describe('extractRelatedIds', () => {
+  it('finds related_recipe id', () => {
+    expect(
+      extractRelatedIds(makeEvent({ payload: { related_recipe: 42 } })),
+    ).toEqual({ recipeId: 42, storyId: null });
+  });
+
+  it('finds story id under linked_story', () => {
+    expect(
+      extractRelatedIds(makeEvent({ payload: { linked_story: '7' } })),
+    ).toEqual({ recipeId: null, storyId: 7 });
+  });
+
+  it('returns nulls when payload is empty', () => {
+    expect(extractRelatedIds(makeEvent({ payload: {} }))).toEqual({
+      recipeId: null,
+      storyId: null,
+    });
+  });
+
+  it('ignores non-positive or non-numeric values', () => {
+    expect(
+      extractRelatedIds(
+        makeEvent({ payload: { related_recipe: 0, related_story: 'abc' } }),
+      ),
+    ).toEqual({ recipeId: null, storyId: null });
+  });
+});
+
 describe('JourneyTimeline', () => {
   beforeEach(() => {
     mockedFetch.mockReset();
+    mockNavigate.mockReset();
   });
 
   it('renders the empty state when there are no events', async () => {
@@ -130,6 +166,58 @@ describe('JourneyTimeline', () => {
     const { findByText } = render(<JourneyTimeline username="ayse" />);
     expect(await findByText('fresh')).toBeTruthy();
     expect(mockedFetch).toHaveBeenCalledWith('ayse');
+  });
+
+  it('renders a Recipe pill when payload has related_recipe and tapping navigates', async () => {
+    const ev = makeEvent({
+      id: 21,
+      message: 'Tried Sarma',
+      payload: { related_recipe: 99 },
+    });
+    const { getByText } = render(
+      <JourneyTimeline username="ayse" initialEvents={[ev]} />,
+    );
+    const pill = getByText('Recipe #99 →');
+    expect(pill).toBeTruthy();
+    fireEvent.press(pill);
+    expect(mockNavigate).toHaveBeenCalledWith('RecipeDetail', { id: '99' });
+  });
+
+  it('renders both Recipe and Story pills when both ids are present', async () => {
+    const ev = makeEvent({
+      id: 22,
+      message: 'Linked event',
+      payload: { related_recipe: 5, related_story: 8 },
+    });
+    const { getByText } = render(
+      <JourneyTimeline username="ayse" initialEvents={[ev]} />,
+    );
+    expect(getByText('Recipe #5 →')).toBeTruthy();
+    const storyPill = getByText('Story #8 →');
+    expect(storyPill).toBeTruthy();
+    fireEvent.press(storyPill);
+    expect(mockNavigate).toHaveBeenCalledWith('StoryDetail', { id: '8' });
+  });
+
+  it('renders no pill when payload has no related ids', async () => {
+    const ev = makeEvent({ id: 23, message: 'Plain event', payload: {} });
+    const { queryByText } = render(
+      <JourneyTimeline username="ayse" initialEvents={[ev]} />,
+    );
+    expect(queryByText(/Recipe #/)).toBeNull();
+    expect(queryByText(/Story #/)).toBeNull();
+  });
+
+  it('skips the Recipe pill when the message already mentions Recipe #', async () => {
+    const ev = makeEvent({
+      id: 24,
+      message: 'Linked to Recipe #99 yesterday',
+      payload: { related_recipe: 99 },
+    });
+    const { queryByText } = render(
+      <JourneyTimeline username="ayse" initialEvents={[ev]} />,
+    );
+    expect(queryByText('Recipe #99 →')).toBeNull();
   });
 
   it('renders a time-ago label for recent events', async () => {

--- a/app/mobile/src/components/passport/JourneyTimeline.tsx
+++ b/app/mobile/src/components/passport/JourneyTimeline.tsx
@@ -1,5 +1,8 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { FlatList, Pressable, RefreshControl, StyleSheet, Text, View } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import type { RootStackParamList } from '../../navigation/types';
 import { tokens } from '../../theme';
 import { ErrorView } from '../ui/ErrorView';
 import { LoadingView } from '../ui/LoadingView';
@@ -7,6 +10,62 @@ import {
   fetchTimeline,
   type TimelineEvent,
 } from '../../services/passportTimelineService';
+
+type Nav = NativeStackNavigationProp<RootStackParamList>;
+
+const RECIPE_ID_KEYS = ['related_recipe', 'recipe_id', 'linked_recipe'] as const;
+const STORY_ID_KEYS = ['related_story', 'story_id', 'linked_story'] as const;
+
+/**
+ * Coerce an arbitrary payload value into a positive integer id. Accepts
+ * either a number or a numeric string — backends have been known to send
+ * ids as strings via DRF serializers. Returns `null` for anything we can't
+ * confidently turn into a positive int.
+ */
+function coerceId(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+    return Math.floor(value);
+  }
+  if (typeof value === 'string' && value.trim() !== '') {
+    const n = Number(value);
+    if (Number.isFinite(n) && n > 0) return Math.floor(n);
+  }
+  return null;
+}
+
+/**
+ * Pull recipe + story ids out of an event's payload. Defensive against
+ * backend key drift — the wire format has shipped under at least three
+ * different names for the same field. Returns the first positive id we
+ * find per slot, `null` otherwise.
+ */
+export function extractRelatedIds(event: TimelineEvent): {
+  recipeId: number | null;
+  storyId: number | null;
+} {
+  const payload = (event.payload ?? {}) as Record<string, unknown>;
+  let recipeId: number | null = null;
+  for (const key of RECIPE_ID_KEYS) {
+    recipeId = coerceId(payload[key]);
+    if (recipeId !== null) break;
+  }
+  let storyId: number | null = null;
+  for (const key of STORY_ID_KEYS) {
+    storyId = coerceId(payload[key]);
+    if (storyId !== null) break;
+  }
+  return { recipeId, storyId };
+}
+
+/**
+ * Server-formatted messages sometimes already embed the link text (e.g.
+ * "Tried Recipe #42"). When that's the case we skip rendering our own pill
+ * to avoid duplicating the affordance on screen.
+ */
+function messageMentions(message: string | undefined, kind: 'Recipe' | 'Story'): boolean {
+  if (!message) return false;
+  return message.includes(`${kind} #`);
+}
 
 type Props = {
   username: string;
@@ -102,10 +161,14 @@ type RowProps = {
 };
 
 function TimelineRow({ event, isFirst, isLast }: RowProps) {
+  const navigation = useNavigation<Nav>();
   const title = composeTitle(event);
   const time = formatTimeAgo(event.created_at);
   const icon = iconFor(event.event_type);
   const a11y = `${event.event_type.replace(/_/g, ' ')}: ${title}${time ? `, ${time}` : ''}`;
+  const { recipeId, storyId } = extractRelatedIds(event);
+  const showRecipePill = recipeId !== null && !messageMentions(event.message, 'Recipe');
+  const showStoryPill = storyId !== null && !messageMentions(event.message, 'Story');
   return (
     <View style={styles.row} accessible accessibilityLabel={a11y}>
       <View style={styles.rail}>
@@ -119,6 +182,42 @@ function TimelineRow({ event, isFirst, isLast }: RowProps) {
         <Text style={styles.title} numberOfLines={2}>
           {title}
         </Text>
+        {(showRecipePill || showStoryPill) ? (
+          <View style={styles.pillRow}>
+            {showRecipePill && recipeId !== null ? (
+              <Pressable
+                onPress={() =>
+                  navigation.navigate('RecipeDetail', { id: String(recipeId) })
+                }
+                style={({ pressed }) => [
+                  styles.pill,
+                  styles.recipePill,
+                  pressed && styles.pillPressed,
+                ]}
+                accessibilityRole="link"
+                accessibilityLabel={`Open Recipe ${recipeId}`}
+              >
+                <Text style={styles.pillText}>{`Recipe #${recipeId} →`}</Text>
+              </Pressable>
+            ) : null}
+            {showStoryPill && storyId !== null ? (
+              <Pressable
+                onPress={() =>
+                  navigation.navigate('StoryDetail', { id: String(storyId) })
+                }
+                style={({ pressed }) => [
+                  styles.pill,
+                  styles.storyPill,
+                  pressed && styles.pillPressed,
+                ]}
+                accessibilityRole="link"
+                accessibilityLabel={`Open Story ${storyId}`}
+              >
+                <Text style={styles.pillText}>{`Story #${storyId} →`}</Text>
+              </Pressable>
+            ) : null}
+          </View>
+        ) : null}
         {time ? <Text style={styles.time}>{time}</Text> : null}
       </View>
     </View>
@@ -324,6 +423,33 @@ const styles = StyleSheet.create({
     marginTop: 2,
     fontSize: 12,
     color: tokens.colors.textMuted,
+  },
+  pillRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 6,
+    marginTop: 6,
+  },
+  pill: {
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderRadius: tokens.radius.pill,
+    borderWidth: 1,
+    borderColor: tokens.colors.surfaceDark,
+  },
+  recipePill: {
+    backgroundColor: tokens.colors.accentMustard,
+  },
+  storyPill: {
+    backgroundColor: tokens.colors.accentGreen,
+  },
+  pillPressed: {
+    opacity: 0.75,
+  },
+  pillText: {
+    fontSize: 12,
+    fontWeight: '700',
+    color: tokens.colors.text,
   },
   empty: {
     paddingVertical: 24,


### PR DESCRIPTION
## Summary
Each timeline event with a related recipe / story id now renders a small tappable pill that opens the matching detail screen. Defensive id extraction (`related_recipe` / `recipe_id` / `linked_recipe` and the story equivalents; accepts numeric strings). Double-link guard: if the server-formatted `message` already mentions 'Recipe #' or 'Story #', the pill is skipped to avoid duplication. Web parity — mirrors `PassportTimeline.jsx` link rendering.

## Test plan
- [ ] Open a passport with timeline events — events linked to a recipe show a mustard 'Recipe #N →' pill; tap opens that recipe
- [ ] Events linked to a story show a green 'Story #N →' pill; tap opens that story
- [ ] Events with neither id render as before (just icon + text)
- [ ] tsc clean, jest 179/179

Closes #833