### PR TITLE
fix(backend): re-seed country-level Regions missing from old DBs (#841)

### DIFF
--- a/app/backend/apps/recipes/migrations/0030_reseed_regions.py
+++ b/app/backend/apps/recipes/migrations/0030_reseed_regions.py
@@ -1,0 +1,47 @@
+"""Re-seed the Region table from the current 0004_seed_regions list (#841).
+
+0004_seed_regions was edited in place after it had already been applied: its
+REGIONS list started as ~31 macro-regions and later grew to include
+country-level regions (France, Germany, Saudi Arabia, China, ...). Long-lived
+DBs that applied 0004 against the original list never got the added names, so
+`seed_canonical` — which resolves regions with a strict get() — fails there
+("Region 'Saudi Arabia' not found").
+
+This migration get_or_creates every name in 0004's *current* REGIONS list, so
+it back-fills the missing rows on old DBs and is a no-op on fresh ones. New
+rows are is_approved=True (the model default is False; 0004's originals were
+backfilled by 0015_backfill_region_is_approved).
+
+We import REGIONS from 0004 rather than copying it so the two stay in sync if
+the list grows again. Reverse is a no-op: 0004's own reverse already deletes
+everything in REGIONS, so there is nothing extra to undo here.
+
+Follow-up (#841): move REGIONS into a non-migration module so it has a single
+source of truth and stops silently drifting.
+"""
+import importlib
+
+from django.db import migrations
+
+_seed_regions = importlib.import_module("apps.recipes.migrations.0004_seed_regions")
+
+
+def reseed_regions(apps, schema_editor):
+    Region = apps.get_model("recipes", "Region")
+    for name in _seed_regions.REGIONS:
+        Region.objects.get_or_create(name=name, defaults={"is_approved": True})
+
+
+def reverse_noop(apps, schema_editor):
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("recipes", "0029_list_ordering_pk_tiebreaker_770"),
+    ]
+
+    operations = [
+        migrations.RunPython(reseed_regions, reverse_noop),
+    ]


### PR DESCRIPTION
Closes #841

## Summary
`apps/recipes/migrations/0004_seed_regions.py` was edited in place after it had already been applied: its `REGIONS` list started as ~31 macro-regions (Aegean, Anatolian, Arabian, Balkan, …) and was later expanded to 58 entries by adding country-level regions (France, Germany, Saudi Arabia, China, …). Long-lived DBs that applied `0004` against the original list never got the 27 added names; fresh DBs (which run `0004` against the current list) get all 58.

`apps/recipes/management/commands/seed_canonical.py` resolves regions with a strict `Region.objects.get(name=…)`, and the current `seed_canonical.json` fixture references the country-level regions — so on prod it dies on the first missing one (`CommandError: Region 'Saudi Arabia' not found`). Since #836 the deploy entrypoint logs `WARN: seed_canonical failed — continuing`, and prod has no recipes / stories / heritage groups / cultural events (the independent seeders — `seed_cultural_facts`, `seed_cultural_content`, … — did run). The failed `seed_canonical` runs inside `transaction.atomic()`, so they roll back cleanly — no partial data.

Added `apps/recipes/migrations/0030_reseed_regions.py`: a `RunPython` data migration that `get_or_create`s every name in `0004`'s **current** `REGIONS` list, with `is_approved=True` for new rows (the model default is `False`; `0004`'s originals were backfilled by `0015_backfill_region_is_approved`). The list is **imported** from the `0004` module rather than copied, so the two can't drift apart again. It back-fills the 27 missing regions on old DBs and is a no-op on fresh ones. Reverse is a no-op — `0004`'s own reverse already deletes everything in `REGIONS`.

Follow-up noted in #841: move `REGIONS` into a non-migration module so it has a single source of truth, and consider making `seed_canonical._resolve(Region, …)` `get_or_create` instead of hard-failing.

## Test plan
 - [ ] `manage.py makemigrations --check` reports no changes
 - [ ] `manage.py migrate` applies `0030_reseed_regions` cleanly; `Region.objects.count()` is 58, `Region.objects.filter(is_approved=False)` is empty
 - [ ] Re-running (`migrate recipes 0029` then `migrate recipes 0030`) is idempotent
 - [ ] `manage.py seed_canonical` runs without `CommandError` (locally: 84 recipes / 51 stories / 4 heritage groups / 27 cultural events)
 - [ ] After deploy to prod: backend entrypoint log no longer shows `WARN: seed_canonical failed`; `Recipe` / `Story` / `HeritageGroup` / `CulturalEvent` counts are non-zero; `/api/recipes/`, `/api/stories/`, `/api/heritage/...` return content
