### PR TITLE
feat(frontend): rating, bookmark, profile dashboard, rating notifications (#736 #707 #709 #739)

### DIFF
--- a/app/frontend/src/__tests__/NotificationTray.test.jsx
+++ b/app/frontend/src/__tests__/NotificationTray.test.jsx
@@ -1,4 +1,5 @@
 import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { NotificationContext } from '../context/NotificationContext';
 import NotificationTray from '../components/NotificationTray';
@@ -141,5 +142,59 @@ describe('NotificationTray', () => {
     fireEvent.click(screen.getByRole('link', { name: /click me/i }));
     expect(markRead).toHaveBeenCalledWith(99);
     expect(toggle).toHaveAttribute('aria-expanded', 'false');
+  });
+});
+
+describe('NotificationTray — rating notifications (#739)', () => {
+  it('renders a star icon for type === "rating"', async () => {
+    renderTray({
+      notifications: [
+        {
+          id: 99,
+          type: 'rating',
+          message: 'alice rated your recipe.',
+          recipeId: 5,
+          recipeTitle: 'Mercimek',
+          actorUsername: 'alice',
+          isRead: false,
+          createdAt: new Date().toISOString(),
+        },
+      ],
+    });
+    await userEvent.click(screen.getByRole('button', { name: /notifications/i }));
+    expect(screen.getByText('★')).toBeInTheDocument();
+  });
+
+  it('links a rating notification to /recipes/<recipeId>', async () => {
+    renderTray({
+      notifications: [
+        {
+          id: 100,
+          type: 'rating',
+          message: 'bob rated your recipe.',
+          recipeId: 12,
+          recipeTitle: 'Pilav',
+          isRead: false,
+          createdAt: new Date().toISOString(),
+        },
+      ],
+    });
+    await userEvent.click(screen.getByRole('button', { name: /notifications/i }));
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', '/recipes/12');
+  });
+
+  it('keeps question / reply icons unchanged', async () => {
+    renderTray({
+      notifications: [
+        { id: 1, type: 'question', message: 'q', recipeId: 1, isRead: false, createdAt: new Date().toISOString() },
+        { id: 2, type: 'reply',    message: 'r', recipeId: 1, isRead: false, createdAt: new Date().toISOString() },
+        { id: 3, type: 'rating',   message: 't', recipeId: 1, isRead: false, createdAt: new Date().toISOString() },
+      ],
+    });
+    await userEvent.click(screen.getByRole('button', { name: /notifications/i }));
+    expect(screen.getByText('💬')).toBeInTheDocument();
+    expect(screen.getByText('↪')).toBeInTheDocument();
+    expect(screen.getByText('★')).toBeInTheDocument();
   });
 });

--- a/app/frontend/src/__tests__/ProfilePage.test.jsx
+++ b/app/frontend/src/__tests__/ProfilePage.test.jsx
@@ -3,6 +3,11 @@ import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { AuthContext } from '../context/AuthContext';
 import ProfilePage from '../pages/ProfilePage';
+import * as recipeService from '../services/recipeService';
+import * as storyService from '../services/storyService';
+
+jest.mock('../services/recipeService');
+jest.mock('../services/storyService');
 
 function renderPage({ user = { id: 1, username: 'eren', email: 'e@x.com', is_contactable: true }, logout = jest.fn(), updateUser = jest.fn() } = {}) {
   return render(
@@ -16,6 +21,12 @@ function renderPage({ user = { id: 1, username: 'eren', email: 'e@x.com', is_con
     </AuthContext.Provider>,
   );
 }
+
+beforeEach(() => {
+  recipeService.fetchMyRecipes = jest.fn().mockResolvedValue([]);
+  recipeService.fetchMyBookmarks = jest.fn().mockResolvedValue([]);
+  storyService.fetchMyStories = jest.fn().mockResolvedValue([]);
+});
 
 describe('ProfilePage', () => {
   it('displays the current user info', () => {
@@ -40,5 +51,57 @@ describe('ProfilePage', () => {
     renderPage();
     const link = screen.getByRole('link', { name: /edit cultural preferences/i });
     expect(link).toHaveAttribute('href', '/onboarding');
+  });
+});
+
+describe('ProfilePage — my recipes / stories / bookmarks', () => {
+  it('renders three section headings (My recipes, My stories, Saved recipes)', async () => {
+    recipeService.fetchMyRecipes.mockResolvedValue([]);
+    storyService.fetchMyStories.mockResolvedValue([]);
+    recipeService.fetchMyBookmarks.mockResolvedValue([]);
+    renderPage({ user: { id: 7, username: 'me', email: 'me@x.com', is_contactable: true } });
+    expect(await screen.findByRole('heading', { name: /my recipes/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /my stories/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /saved recipes/i })).toBeInTheDocument();
+  });
+
+  it('renders one card per recipe / story / bookmark with a link to detail', async () => {
+    recipeService.fetchMyRecipes.mockResolvedValue([
+      { id: 1, title: 'My Sarma', region_name: 'Black Sea' },
+    ]);
+    storyService.fetchMyStories.mockResolvedValue([
+      { id: 2, title: 'My Memory' },
+    ]);
+    recipeService.fetchMyBookmarks.mockResolvedValue([
+      { id: 3, title: 'Saved Pasta' },
+    ]);
+    renderPage({ user: { id: 7, username: 'me', email: 'me@x.com', is_contactable: true } });
+    expect(await screen.findByRole('link', { name: /my sarma/i }))
+      .toHaveAttribute('href', '/recipes/1');
+    expect(screen.getByRole('link', { name: /my memory/i }))
+      .toHaveAttribute('href', '/stories/2');
+    expect(screen.getByRole('link', { name: /saved pasta/i }))
+      .toHaveAttribute('href', '/recipes/3');
+  });
+
+  it('shows an empty-state hint when a section has no items', async () => {
+    recipeService.fetchMyRecipes.mockResolvedValue([]);
+    storyService.fetchMyStories.mockResolvedValue([]);
+    recipeService.fetchMyBookmarks.mockResolvedValue([]);
+    renderPage({ user: { id: 7, username: 'me', email: 'me@x.com', is_contactable: true } });
+    await screen.findByRole('heading', { name: /my recipes/i });
+    expect(screen.getByText(/no recipes yet/i)).toBeInTheDocument();
+    expect(screen.getByText(/no stories yet/i)).toBeInTheDocument();
+    expect(screen.getByText(/no saved recipes yet/i)).toBeInTheDocument();
+  });
+
+  it('handles per-section fetch failures gracefully (other sections still render)', async () => {
+    recipeService.fetchMyRecipes.mockResolvedValue([{ id: 1, title: 'Mine' }]);
+    storyService.fetchMyStories.mockRejectedValue(new Error('boom'));
+    recipeService.fetchMyBookmarks.mockResolvedValue([]);
+    renderPage({ user: { id: 7, username: 'me', email: 'me@x.com', is_contactable: true } });
+    expect(await screen.findByRole('link', { name: /mine/i })).toBeInTheDocument();
+    expect(screen.getByText(/could not load stories/i)).toBeInTheDocument();
+    expect(screen.getByText(/no saved recipes yet/i)).toBeInTheDocument();
   });
 });

--- a/app/frontend/src/__tests__/RecipeDetailPage.test.jsx
+++ b/app/frontend/src/__tests__/RecipeDetailPage.test.jsx
@@ -378,3 +378,47 @@ describe('RecipeDetailPage steps section', () => {
     expect(screen.queryByRole('heading', { name: /^steps$/i })).not.toBeInTheDocument();
   });
 });
+
+describe('RecipeDetailPage star rating', () => {
+  it('renders read-only stars with the average + count when present', async () => {
+    recipeService.fetchRecipe.mockResolvedValueOnce({
+      ...mockRecipe,
+      average_rating: 4.5,
+      rating_count: 6,
+      user_rating: null,
+    });
+    renderPage('1', null);
+    expect(await screen.findByText('Baklava')).toBeInTheDocument();
+    expect(screen.getByText('4.5 (6)')).toBeInTheDocument();
+    // Anonymous: no interactive radios
+    expect(screen.queryByRole('radio')).not.toBeInTheDocument();
+  });
+
+  it('disables interactivity for the recipe author with a tooltip', async () => {
+    recipeService.fetchRecipe.mockResolvedValueOnce({
+      ...mockRecipe,
+      author: 3,
+      average_rating: 4,
+      rating_count: 2,
+    });
+    renderPage('1', { id: 3, username: 'eren' });
+    await screen.findByText('Baklava');
+    expect(screen.queryByRole('radio')).not.toBeInTheDocument();
+    expect(screen.getByRole('img', { name: /can't rate your own recipe/i })).toBeInTheDocument();
+  });
+
+  it('lets a non-author authenticated user submit a rating via POST', async () => {
+    recipeService.fetchRecipe.mockResolvedValueOnce({
+      ...mockRecipe,
+      author: 99,
+      average_rating: null,
+      rating_count: 0,
+      user_rating: null,
+    });
+    recipeService.rateRecipe.mockResolvedValue({ average_rating: 5, rating_count: 1, user_rating: 5 });
+    renderPage('1', { id: 3, username: 'eren' });
+    await screen.findByText('Baklava');
+    await userEvent.click(screen.getByRole('radio', { name: /5 stars/i }));
+    await waitFor(() => expect(recipeService.rateRecipe).toHaveBeenCalledWith('1', 5));
+  });
+});

--- a/app/frontend/src/__tests__/RecipeDetailPage.test.jsx
+++ b/app/frontend/src/__tests__/RecipeDetailPage.test.jsx
@@ -422,3 +422,56 @@ describe('RecipeDetailPage star rating', () => {
     await waitFor(() => expect(recipeService.rateRecipe).toHaveBeenCalledWith('1', 5));
   });
 });
+
+describe('RecipeDetailPage bookmark button', () => {
+  it('hides the bookmark button for anonymous viewers', async () => {
+    recipeService.fetchRecipe.mockResolvedValueOnce({
+      ...mockRecipe,
+      is_bookmarked: false,
+      bookmark_count: 4,
+    });
+    renderPage('1', null);
+    await screen.findByText('Baklava');
+    expect(screen.queryByRole('button', { name: /bookmark|save/i })).not.toBeInTheDocument();
+  });
+
+  it('hides the bookmark button for the recipe author', async () => {
+    recipeService.fetchRecipe.mockResolvedValueOnce({
+      ...mockRecipe,
+      author: 3,
+      is_bookmarked: false,
+      bookmark_count: 1,
+    });
+    renderPage('1', { id: 3, username: 'eren' });
+    await screen.findByText('Baklava');
+    expect(screen.queryByRole('button', { name: /bookmark|save/i })).not.toBeInTheDocument();
+  });
+
+  it('renders an unsaved bookmark button for a non-author authenticated viewer', async () => {
+    recipeService.fetchRecipe.mockResolvedValueOnce({
+      ...mockRecipe,
+      author: 99,
+      is_bookmarked: false,
+      bookmark_count: 2,
+    });
+    renderPage('1', { id: 3, username: 'eren' });
+    await screen.findByText('Baklava');
+    const btn = screen.getByRole('button', { name: /bookmark this recipe/i });
+    expect(btn).toHaveTextContent(/save/i);
+  });
+
+  it('calls toggleBookmark and flips state on click', async () => {
+    recipeService.fetchRecipe.mockResolvedValueOnce({
+      ...mockRecipe,
+      author: 99,
+      is_bookmarked: false,
+      bookmark_count: 2,
+    });
+    recipeService.toggleBookmark.mockResolvedValue({ is_bookmarked: true, bookmark_count: 3 });
+    renderPage('1', { id: 3, username: 'eren' });
+    await screen.findByText('Baklava');
+    await userEvent.click(screen.getByRole('button', { name: /bookmark this recipe/i }));
+    await waitFor(() => expect(recipeService.toggleBookmark).toHaveBeenCalledWith('1'));
+    expect(await screen.findByRole('button', { name: /remove bookmark/i })).toBeInTheDocument();
+  });
+});

--- a/app/frontend/src/__tests__/RecipeListPage.test.jsx
+++ b/app/frontend/src/__tests__/RecipeListPage.test.jsx
@@ -99,3 +99,25 @@ describe('RecipeListPage', () => {
     );
   });
 });
+
+describe('RecipeListPage star rating', () => {
+  it('shows read-only stars with the average and count next to each card', async () => {
+    recipeService.fetchRecipes.mockResolvedValueOnce([
+      {
+        id: 1, title: 'Baklava', region_name: 'Aegean', image: null, author_username: 'eren',
+        average_rating: 4.3, rating_count: 12, user_rating: null,
+      },
+      {
+        id: 2, title: 'Manti', region_name: 'Anatolian', image: null, author_username: 'eren',
+        average_rating: null, rating_count: 0,
+      },
+    ]);
+    renderPage();
+    expect(await screen.findByText('Baklava')).toBeInTheDocument();
+    expect(screen.getByText('4.3 (12)')).toBeInTheDocument();
+    // The unrated card shows the "Not rated" label.
+    expect(screen.getByText(/not rated/i)).toBeInTheDocument();
+    // Cards never expose interactive radios.
+    expect(screen.queryByRole('radio')).not.toBeInTheDocument();
+  });
+});

--- a/app/frontend/src/__tests__/RecipeListPage.test.jsx
+++ b/app/frontend/src/__tests__/RecipeListPage.test.jsx
@@ -121,3 +121,25 @@ describe('RecipeListPage star rating', () => {
     expect(screen.queryByRole('radio')).not.toBeInTheDocument();
   });
 });
+
+describe('RecipeListPage bookmark icon', () => {
+  it('renders a filled bookmark icon when recipe.is_bookmarked is true', async () => {
+    recipeService.fetchRecipes.mockResolvedValueOnce([
+      { id: 1, title: 'Baklava', region_name: 'Aegean', image: null, author_username: 'eren',
+        is_bookmarked: true, bookmark_count: 4, rating_count: 0, average_rating: null },
+    ]);
+    renderPage();
+    expect(await screen.findByText('Baklava')).toBeInTheDocument();
+    expect(screen.getByLabelText(/bookmarked, 4 saves/i)).toBeInTheDocument();
+  });
+
+  it('renders an empty bookmark icon when recipe.is_bookmarked is false / missing', async () => {
+    recipeService.fetchRecipes.mockResolvedValueOnce([
+      { id: 2, title: 'Manti', region_name: 'Anatolian', image: null, author_username: 'eren',
+        is_bookmarked: false, bookmark_count: 0, rating_count: 0, average_rating: null },
+    ]);
+    renderPage();
+    expect(await screen.findByText('Manti')).toBeInTheDocument();
+    expect(screen.getByLabelText(/not bookmarked/i)).toBeInTheDocument();
+  });
+});

--- a/app/frontend/src/__tests__/StarRating.test.jsx
+++ b/app/frontend/src/__tests__/StarRating.test.jsx
@@ -1,0 +1,58 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import StarRating from '../components/StarRating';
+
+describe('StarRating — read-only mode (no onChange)', () => {
+  it('shows the average + count summary when given a numeric average', () => {
+    render(<StarRating average={4.2} count={17} />);
+    expect(screen.getByText('4.2 (17)')).toBeInTheDocument();
+  });
+
+  it('renders a "Not rated" hint when no average and no count', () => {
+    render(<StarRating average={null} count={0} />);
+    expect(screen.getByText(/not rated/i)).toBeInTheDocument();
+  });
+
+  it('accepts a string average (DRF DecimalField shape) and renders it as a number', () => {
+    render(<StarRating average={'3.7'} count={3} />);
+    expect(screen.getByText('3.7 (3)')).toBeInTheDocument();
+  });
+
+  it('does NOT render interactive star buttons when onChange is missing', () => {
+    render(<StarRating average={3} count={2} />);
+    expect(screen.queryByRole('radio')).not.toBeInTheDocument();
+  });
+});
+
+describe('StarRating — interactive mode (onChange provided)', () => {
+  it('renders five radio buttons for stars', () => {
+    render(<StarRating average={null} count={0} onChange={() => {}} />);
+    expect(screen.getAllByRole('radio')).toHaveLength(5);
+  });
+
+  it('calls onChange(score) when a star is clicked', async () => {
+    const onChange = jest.fn();
+    render(<StarRating userScore={null} average={null} count={0} onChange={onChange} />);
+    await userEvent.click(screen.getByRole('radio', { name: /4 stars/i }));
+    expect(onChange).toHaveBeenCalledWith(4);
+  });
+
+  it('calls onChange(null) when the user re-clicks their current score (unrate)', async () => {
+    const onChange = jest.fn();
+    render(<StarRating userScore={3} average={3} count={1} onChange={onChange} />);
+    await userEvent.click(screen.getByRole('radio', { name: /3 stars/i }));
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+
+  it('still renders interactive when disabledReason is empty', () => {
+    render(<StarRating average={null} count={0} onChange={() => {}} disabledReason="" />);
+    expect(screen.getAllByRole('radio')).toHaveLength(5);
+  });
+
+  it('falls back to read-only when disabledReason is non-empty', async () => {
+    const onChange = jest.fn();
+    render(<StarRating average={null} count={0} onChange={onChange} disabledReason="Log in to rate." />);
+    expect(screen.queryByRole('radio')).not.toBeInTheDocument();
+    expect(screen.getByRole('img', { name: /log in to rate/i })).toBeInTheDocument();
+  });
+});

--- a/app/frontend/src/__tests__/recipeService.test.js
+++ b/app/frontend/src/__tests__/recipeService.test.js
@@ -9,6 +9,9 @@ import {
   submitIngredient,
   submitUnit,
   fetchRecipes,
+  rateRecipe,
+  unrateRecipe,
+  toggleBookmark,
 } from '../services/recipeService';
 
 jest.mock('../services/api', () => ({
@@ -236,5 +239,42 @@ describe('fetchUnits — promise cache', () => {
     const result = await fetchUnits();
     expect(result[0].name).toBe('g');
     expect(calls).toBe(2);
+  });
+});
+
+describe('rateRecipe', () => {
+  it('POSTs /api/recipes/:id/rate/ with { score } and returns the summary', async () => {
+    apiClient.post.mockResolvedValue({ data: { average_rating: 4.5, rating_count: 2, user_rating: 5 } });
+    const result = await rateRecipe(42, 5);
+    expect(apiClient.post).toHaveBeenCalledWith('/api/recipes/42/rate/', { score: 5 });
+    expect(result).toEqual({ average_rating: 4.5, rating_count: 2, user_rating: 5 });
+  });
+
+  it('propagates API errors', async () => {
+    apiClient.post.mockRejectedValue(new Error('forbidden'));
+    await expect(rateRecipe(1, 3)).rejects.toThrow('forbidden');
+  });
+});
+
+describe('unrateRecipe', () => {
+  it('DELETEs /api/recipes/:id/rate/ and returns the summary', async () => {
+    apiClient.delete.mockResolvedValue({ data: { average_rating: null, rating_count: 0, user_rating: null } });
+    const result = await unrateRecipe(42);
+    expect(apiClient.delete).toHaveBeenCalledWith('/api/recipes/42/rate/');
+    expect(result).toEqual({ average_rating: null, rating_count: 0, user_rating: null });
+  });
+});
+
+describe('toggleBookmark', () => {
+  it('POSTs /api/recipes/:id/bookmark/ and returns the toggle result', async () => {
+    apiClient.post.mockResolvedValue({ data: { is_bookmarked: true, bookmark_count: 7 } });
+    const result = await toggleBookmark(42);
+    expect(apiClient.post).toHaveBeenCalledWith('/api/recipes/42/bookmark/');
+    expect(result).toEqual({ is_bookmarked: true, bookmark_count: 7 });
+  });
+
+  it('propagates API errors', async () => {
+    apiClient.post.mockRejectedValue(new Error('Server error'));
+    await expect(toggleBookmark(1)).rejects.toThrow('Server error');
   });
 });

--- a/app/frontend/src/__tests__/recipeService.test.js
+++ b/app/frontend/src/__tests__/recipeService.test.js
@@ -12,6 +12,8 @@ import {
   rateRecipe,
   unrateRecipe,
   toggleBookmark,
+  fetchMyRecipes,
+  fetchMyBookmarks,
 } from '../services/recipeService';
 
 jest.mock('../services/api', () => ({
@@ -276,5 +278,33 @@ describe('toggleBookmark', () => {
   it('propagates API errors', async () => {
     apiClient.post.mockRejectedValue(new Error('Server error'));
     await expect(toggleBookmark(1)).rejects.toThrow('Server error');
+  });
+});
+
+describe('fetchMyRecipes', () => {
+  it('GETs /api/recipes/?author=<id> and returns the list', async () => {
+    apiClient.get.mockResolvedValue({ data: [{ id: 1, title: 'Mine' }] });
+    const result = await fetchMyRecipes(42);
+    expect(apiClient.get).toHaveBeenCalledWith('/api/recipes/', { params: { author: 42 } });
+    expect(result).toEqual([{ id: 1, title: 'Mine' }]);
+  });
+
+  it('unwraps paginated DRF responses', async () => {
+    apiClient.get.mockResolvedValue({ data: { results: [{ id: 7 }] } });
+    expect(await fetchMyRecipes(42)).toEqual([{ id: 7 }]);
+  });
+});
+
+describe('fetchMyBookmarks', () => {
+  it('GETs /api/recipes/?bookmarked=true and returns the list', async () => {
+    apiClient.get.mockResolvedValue({ data: [{ id: 9, title: 'Saved' }] });
+    const result = await fetchMyBookmarks();
+    expect(apiClient.get).toHaveBeenCalledWith('/api/recipes/', { params: { bookmarked: 'true' } });
+    expect(result).toEqual([{ id: 9, title: 'Saved' }]);
+  });
+
+  it('unwraps paginated DRF responses', async () => {
+    apiClient.get.mockResolvedValue({ data: { results: [{ id: 10 }] } });
+    expect(await fetchMyBookmarks()).toEqual([{ id: 10 }]);
   });
 });

--- a/app/frontend/src/__tests__/storyService.test.js
+++ b/app/frontend/src/__tests__/storyService.test.js
@@ -1,4 +1,5 @@
 import * as storyService from '../services/storyService';
+import { fetchMyStories } from '../services/storyService';
 import { apiClient } from '../services/api';
 
 jest.mock('../services/api', () => ({
@@ -89,5 +90,19 @@ describe('publishStory / unpublishStory', () => {
   it('unpublishStory propagates API errors', async () => {
     apiClient.post.mockRejectedValue(new Error('boom'));
     await expect(storyService.unpublishStory(5)).rejects.toThrow('boom');
+  });
+});
+
+describe('fetchMyStories', () => {
+  it('GETs /api/stories/?author=<id> and returns the list', async () => {
+    apiClient.get.mockResolvedValue({ data: [{ id: 3, title: 'Mine' }] });
+    const result = await fetchMyStories(42);
+    expect(apiClient.get).toHaveBeenCalledWith('/api/stories/', { params: { author: 42 } });
+    expect(result).toEqual([{ id: 3, title: 'Mine' }]);
+  });
+
+  it('unwraps paginated DRF responses', async () => {
+    apiClient.get.mockResolvedValue({ data: { results: [{ id: 8 }] } });
+    expect(await fetchMyStories(42)).toEqual([{ id: 8 }]);
   });
 });

--- a/app/frontend/src/components/NotificationTray.css
+++ b/app/frontend/src/components/NotificationTray.css
@@ -106,3 +106,10 @@
   color: #9f2930;
 }
 
+.notification-icon {
+  margin-right: 0.5rem;
+  font-size: 1rem;
+  line-height: 1;
+  display: inline-block;
+}
+

--- a/app/frontend/src/components/NotificationTray.jsx
+++ b/app/frontend/src/components/NotificationTray.jsx
@@ -3,6 +3,16 @@ import { Link } from 'react-router-dom';
 import { NotificationContext } from '../context/NotificationContext';
 import './NotificationTray.css';
 
+const ICONS = {
+  question: '💬',
+  reply: '↪',
+  rating: '★',
+};
+
+function iconFor(type) {
+  return ICONS[type] ?? '🔔';
+}
+
 function formatRelativeDate(isoDate) {
   const date = new Date(isoDate);
   const now = new Date();
@@ -89,6 +99,7 @@ export default function NotificationTray() {
                       setOpen(false);
                     }}
                   >
+                    <span className="notification-icon" aria-hidden="true">{iconFor(item.type)}</span>
                     <p className="notification-message">{getNotificationText(item)}</p>
                     <span className="notification-time">{formatRelativeDate(item.createdAt)}</span>
                   </Link>

--- a/app/frontend/src/components/StarRating.css
+++ b/app/frontend/src/components/StarRating.css
@@ -1,0 +1,47 @@
+.star-rating {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.15rem;
+  line-height: 1;
+}
+
+.star-rating-star {
+  background: transparent;
+  border: none;
+  padding: 0;
+  margin: 0;
+  color: #D6CBB6;
+  cursor: default;
+  font-size: 1.1rem;
+  line-height: 1;
+  transition: color 0.12s ease, transform 0.12s ease;
+}
+
+.star-rating.interactive .star-rating-star {
+  cursor: pointer;
+}
+
+.star-rating-star.filled {
+  color: #D4A830;
+}
+
+.star-rating.interactive .star-rating-star:hover,
+.star-rating.interactive .star-rating-star:focus-visible {
+  transform: scale(1.12);
+  outline: none;
+}
+
+.star-rating-summary {
+  margin-left: 0.4rem;
+  font-size: 0.85em;
+  color: var(--color-text-muted);
+  font-weight: 600;
+}
+
+.star-rating-summary-empty {
+  font-weight: 500;
+  font-style: italic;
+}
+
+.star-rating-sm .star-rating-star { font-size: 0.9rem; }
+.star-rating-lg .star-rating-star { font-size: 1.4rem; }

--- a/app/frontend/src/components/StarRating.jsx
+++ b/app/frontend/src/components/StarRating.jsx
@@ -1,0 +1,107 @@
+import { useState } from 'react';
+import './StarRating.css';
+
+/**
+ * Five-star rating widget (#736). Two modes:
+ *
+ *   - **Interactive**: `onChange(score)` provided and `disabledReason` is empty.
+ *     Click a star to set; click the currently-set star again to unrate
+ *     (`onChange(null)`). Hover preview tints stars up to the hover index.
+ *
+ *   - **Read-only**: no `onChange`, or `disabledReason` is non-empty. The
+ *     `disabledReason` becomes the tooltip + accessible label.
+ *
+ * `userScore` (1-5 or null) is the current user's submitted rating; rendered
+ * as filled stars. `average` (number, numeric string, or null) is the
+ * aggregate; when `userScore` is missing, stars paint at the rounded average.
+ * `count` shows in the trailing summary.
+ */
+export default function StarRating({
+  userScore = null,
+  average = null,
+  count = 0,
+  onChange,
+  disabledReason = '',
+  size = 'md',
+}) {
+  const [hover, setHover] = useState(null);
+  const interactive = typeof onChange === 'function' && !disabledReason;
+
+  const numericAverage = (() => {
+    const value = typeof average === 'string' ? parseFloat(average) : average;
+    return Number.isFinite(value) ? value : null;
+  })();
+
+  const displayScore =
+    hover != null
+      ? hover
+      : typeof userScore === 'number' && userScore > 0
+      ? userScore
+      : numericAverage != null
+      ? Math.round(numericAverage)
+      : 0;
+
+  function handleClick(value) {
+    if (!interactive) return;
+    onChange(userScore === value ? null : value);
+  }
+
+  const tooltip = disabledReason
+    ? disabledReason
+    : interactive
+    ? userScore
+      ? `Your rating: ${userScore} of 5`
+      : 'Click a star to rate'
+    : numericAverage != null
+    ? `${numericAverage.toFixed(1)} of 5 from ${count} rating${count === 1 ? '' : 's'}`
+    : 'Not rated yet';
+
+  return (
+    <span
+      className={`star-rating star-rating-${size}${interactive ? ' interactive' : ''}`}
+      title={tooltip}
+      role={interactive ? 'radiogroup' : 'img'}
+      aria-label={tooltip}
+    >
+      {[1, 2, 3, 4, 5].map((value) => {
+        const filled = displayScore >= value;
+        if (interactive) {
+          return (
+            <button
+              key={value}
+              type="button"
+              className={`star-rating-star${filled ? ' filled' : ''}`}
+              onClick={() => handleClick(value)}
+              onMouseEnter={() => setHover(value)}
+              onMouseLeave={() => setHover(null)}
+              onFocus={() => setHover(value)}
+              onBlur={() => setHover(null)}
+              role="radio"
+              aria-checked={userScore === value}
+              aria-label={`${value} star${value === 1 ? '' : 's'}`}
+            >
+              ★
+            </button>
+          );
+        }
+        return (
+          <span
+            key={value}
+            className={`star-rating-star${filled ? ' filled' : ''}`}
+            aria-hidden="true"
+          >
+            ★
+          </span>
+        );
+      })}
+      {numericAverage != null && count > 0 && (
+        <span className="star-rating-summary">
+          {numericAverage.toFixed(1)} ({count})
+        </span>
+      )}
+      {numericAverage == null && count === 0 && !interactive && (
+        <span className="star-rating-summary star-rating-summary-empty">Not rated</span>
+      )}
+    </span>
+  );
+}

--- a/app/frontend/src/pages/ProfilePage.css
+++ b/app/frontend/src/pages/ProfilePage.css
@@ -43,3 +43,54 @@
   border-top: 1px solid var(--border, #e5e5e5);
   padding-top: 1rem;
 }
+
+.profile-dashboard {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  margin-top: 2rem;
+}
+
+.profile-section {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border, #e5e5e5);
+  border-radius: var(--radius-md, 8px);
+  padding: 1rem 1.25rem;
+}
+
+.profile-section-title {
+  margin: 0 0 0.75rem;
+  font-size: 1.05rem;
+  color: var(--color-text, #1a1a1a);
+}
+
+.profile-section-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.profile-section-link {
+  color: var(--color-primary-text, var(--color-primary, #C4521E));
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.profile-section-link:hover,
+.profile-section-link:focus-visible {
+  text-decoration: underline;
+}
+
+.profile-section-empty {
+  color: var(--color-text-muted, var(--text-muted, #666));
+  font-style: italic;
+  margin: 0;
+}
+
+.profile-section-error {
+  color: var(--color-error, #b00020);
+  margin: 0;
+}

--- a/app/frontend/src/pages/ProfilePage.jsx
+++ b/app/frontend/src/pages/ProfilePage.jsx
@@ -1,7 +1,9 @@
-import { useContext } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { AuthContext } from '../context/AuthContext';
 import ContactabilityToggle from '../components/ContactabilityToggle';
+import { fetchMyRecipes, fetchMyBookmarks } from '../services/recipeService';
+import { fetchMyStories } from '../services/storyService';
 import './ProfilePage.css';
 
 export default function ProfilePage() {
@@ -19,6 +21,8 @@ export default function ProfilePage() {
       </section>
 
       <ContactabilityToggle user={user} onUserUpdated={updateUser} />
+
+      <ProfileDashboard user={user} />
 
       <section className="profile-preferences">
         <h2>Cultural Preferences</h2>
@@ -40,5 +44,82 @@ export default function ProfilePage() {
         </button>
       </section>
     </main>
+  );
+}
+
+function ProfileDashboard({ user }) {
+  const [recipes, setRecipes] = useState([]);
+  const [stories, setStories] = useState([]);
+  const [bookmarks, setBookmarks] = useState([]);
+  const [recipesError, setRecipesError] = useState('');
+  const [storiesError, setStoriesError] = useState('');
+  const [bookmarksError, setBookmarksError] = useState('');
+
+  useEffect(() => {
+    if (!user?.id) return undefined;
+    let cancelled = false;
+    Promise.allSettled([
+      fetchMyRecipes(user.id),
+      fetchMyStories(user.id),
+      fetchMyBookmarks(),
+    ]).then(([r, s, b]) => {
+      if (cancelled) return;
+      if (r.status === 'fulfilled') setRecipes(Array.isArray(r.value) ? r.value : []);
+      else setRecipesError('Could not load recipes.');
+      if (s.status === 'fulfilled') setStories(Array.isArray(s.value) ? s.value : []);
+      else setStoriesError('Could not load stories.');
+      if (b.status === 'fulfilled') setBookmarks(Array.isArray(b.value) ? b.value : []);
+      else setBookmarksError('Could not load bookmarks.');
+    });
+    return () => { cancelled = true; };
+  }, [user?.id]);
+
+  return (
+    <section className="profile-dashboard">
+      <ProfileSection
+        title="My recipes"
+        items={recipes}
+        error={recipesError}
+        emptyHint="No recipes yet."
+        href={(r) => `/recipes/${r.id}`}
+      />
+      <ProfileSection
+        title="My stories"
+        items={stories}
+        error={storiesError}
+        emptyHint="No stories yet."
+        href={(s) => `/stories/${s.id}`}
+      />
+      <ProfileSection
+        title="Saved recipes"
+        items={bookmarks}
+        error={bookmarksError}
+        emptyHint="No saved recipes yet."
+        href={(r) => `/recipes/${r.id}`}
+      />
+    </section>
+  );
+}
+
+function ProfileSection({ title, items, error, emptyHint, href }) {
+  return (
+    <div className="profile-section">
+      <h2 className="profile-section-title">{title}</h2>
+      {error && <p className="profile-section-error">{error}</p>}
+      {!error && items.length === 0 && (
+        <p className="profile-section-empty">{emptyHint}</p>
+      )}
+      {!error && items.length > 0 && (
+        <ul className="profile-section-list">
+          {items.map((item) => (
+            <li key={item.id}>
+              <Link to={href(item)} className="profile-section-link">
+                {item.title}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
   );
 }

--- a/app/frontend/src/pages/RecipeDetailPage.css
+++ b/app/frontend/src/pages/RecipeDetailPage.css
@@ -464,3 +464,16 @@
   display: flex;
   align-items: center;
 }
+
+/* ── Bookmark (#707) ── */
+.recipe-bookmark-btn {
+  background: var(--color-surface);
+  border: 1.5px solid var(--color-border);
+  color: var(--color-text);
+}
+
+.recipe-bookmark-btn.active {
+  background: var(--color-accent-mustard);
+  border-color: var(--color-accent-mustard);
+  color: var(--color-text);
+}

--- a/app/frontend/src/pages/RecipeDetailPage.css
+++ b/app/frontend/src/pages/RecipeDetailPage.css
@@ -457,3 +457,10 @@
   white-space: pre-wrap;
   flex: 1;
 }
+
+/* ── Rating (#736) ── */
+.recipe-rating-row {
+  margin-top: 0.6rem;
+  display: flex;
+  align-items: center;
+}

--- a/app/frontend/src/pages/RecipeDetailPage.jsx
+++ b/app/frontend/src/pages/RecipeDetailPage.jsx
@@ -1,13 +1,14 @@
 import { useState, useEffect, useContext, useCallback } from 'react';
 import { useParams, Link, useNavigate } from 'react-router-dom';
 import { AuthContext } from '../context/AuthContext';
-import { fetchRecipe, deleteRecipe } from '../services/recipeService';
+import { fetchRecipe, deleteRecipe, rateRecipe, unrateRecipe } from '../services/recipeService';
 import { fetchRegions } from '../services/searchService';
 import { fetchSubstitutes } from '../services/ingredientService';
 import { fetchCheckedIngredients, toggleCheckedIngredient } from '../services/checkOffService';
 import RecipeCommentsSection from '../components/RecipeCommentsSection';
 import HeritageBadge from '../components/HeritageBadge';
 import CulturalFactCard from '../components/CulturalFactCard';
+import StarRating from '../components/StarRating';
 import { fetchCulturalFacts } from '../services/culturalFactService';
 import { tryRecipe } from '../services/passportService';
 import './RecipeDetailPage.css';
@@ -54,6 +55,31 @@ export default function RecipeDetailPage() {
   const [tried, setTried] = useState(false);
   const [tryingRecipe, setTryingRecipe] = useState(false);
   const [tryError, setTryError] = useState('');
+
+  // #736 — rating
+  const [ratingBusy, setRatingBusy] = useState(false);
+
+  const handleRate = useCallback(async (nextScore) => {
+    if (ratingBusy || !recipe) return;
+    setRatingBusy(true);
+    const prev = {
+      user_rating: recipe.user_rating,
+      average_rating: recipe.average_rating,
+      rating_count: recipe.rating_count,
+    };
+    // Optimistic flip on the user's score; reconcile from the backend reply.
+    setRecipe((r) => (r ? { ...r, user_rating: nextScore } : r));
+    try {
+      const summary = nextScore == null
+        ? await unrateRecipe(id)
+        : await rateRecipe(id, nextScore);
+      setRecipe((r) => (r ? { ...r, ...summary } : r));
+    } catch {
+      setRecipe((r) => (r ? { ...r, ...prev } : r));
+    } finally {
+      setRatingBusy(false);
+    }
+  }, [ratingBusy, recipe, id]);
 
   const handleTryRecipe = useCallback(async () => {
     if (tryingRecipe || tried) return;
@@ -200,6 +226,20 @@ export default function RecipeDetailPage() {
           {recipe.author_username && (
             <p className="recipe-author"><Link to={`/users/${recipe.author_username}`} className="recipe-author-link">By {recipe.author_username}</Link></p>
           )}
+          <div className="recipe-rating-row">
+            <StarRating
+              userScore={recipe.user_rating ?? null}
+              average={recipe.average_rating ?? null}
+              count={recipe.rating_count ?? 0}
+              size="lg"
+              onChange={user && !isAuthor ? handleRate : undefined}
+              disabledReason={
+                !user ? 'Log in to rate.'
+                  : isAuthor ? "You can't rate your own recipe."
+                  : ''
+              }
+            />
+          </div>
         </div>
         <div className="recipe-detail-actions">
           {isAuthor && (

--- a/app/frontend/src/pages/RecipeDetailPage.jsx
+++ b/app/frontend/src/pages/RecipeDetailPage.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useContext, useCallback } from 'react';
 import { useParams, Link, useNavigate } from 'react-router-dom';
 import { AuthContext } from '../context/AuthContext';
-import { fetchRecipe, deleteRecipe, rateRecipe, unrateRecipe } from '../services/recipeService';
+import { fetchRecipe, deleteRecipe, rateRecipe, unrateRecipe, toggleBookmark } from '../services/recipeService';
 import { fetchRegions } from '../services/searchService';
 import { fetchSubstitutes } from '../services/ingredientService';
 import { fetchCheckedIngredients, toggleCheckedIngredient } from '../services/checkOffService';
@@ -80,6 +80,35 @@ export default function RecipeDetailPage() {
       setRatingBusy(false);
     }
   }, [ratingBusy, recipe, id]);
+
+  // #707 — bookmark
+  const [bookmarkBusy, setBookmarkBusy] = useState(false);
+
+  const handleBookmark = useCallback(async () => {
+    if (bookmarkBusy || !recipe) return;
+    setBookmarkBusy(true);
+    const prev = {
+      is_bookmarked: recipe.is_bookmarked,
+      bookmark_count: recipe.bookmark_count,
+    };
+    setRecipe((r) =>
+      r
+        ? {
+            ...r,
+            is_bookmarked: !r.is_bookmarked,
+            bookmark_count: (r.bookmark_count ?? 0) + (r.is_bookmarked ? -1 : 1),
+          }
+        : r,
+    );
+    try {
+      const summary = await toggleBookmark(id);
+      setRecipe((r) => (r ? { ...r, ...summary } : r));
+    } catch {
+      setRecipe((r) => (r ? { ...r, ...prev } : r));
+    } finally {
+      setBookmarkBusy(false);
+    }
+  }, [bookmarkBusy, recipe, id]);
 
   const handleTryRecipe = useCallback(async () => {
     if (tryingRecipe || tried) return;
@@ -242,6 +271,19 @@ export default function RecipeDetailPage() {
           </div>
         </div>
         <div className="recipe-detail-actions">
+          {user && !isAuthor && (
+            <button
+              type="button"
+              className={`btn btn-sm recipe-bookmark-btn${recipe.is_bookmarked ? ' active' : ''}`}
+              onClick={handleBookmark}
+              disabled={bookmarkBusy}
+              aria-pressed={Boolean(recipe.is_bookmarked)}
+              aria-label={recipe.is_bookmarked ? 'Remove bookmark' : 'Bookmark this recipe'}
+            >
+              {recipe.is_bookmarked ? '🔖 Saved' : '🏷 Save'}
+              {typeof recipe.bookmark_count === 'number' && ` · ${recipe.bookmark_count}`}
+            </button>
+          )}
           {isAuthor && (
             <Link to={`/recipes/${recipe.id}/edit`} className="btn btn-outline btn-sm">
               Edit

--- a/app/frontend/src/pages/RecipeListPage.css
+++ b/app/frontend/src/pages/RecipeListPage.css
@@ -96,3 +96,15 @@
 .recipe-browse-rating {
   margin-top: 0.35rem;
 }
+
+.recipe-browse-bookmark {
+  font-size: 1rem;
+  line-height: 1;
+  color: var(--color-text-muted);
+  margin-bottom: 0.25rem;
+  display: inline-block;
+}
+
+.recipe-browse-bookmark.active {
+  color: var(--color-accent-mustard);
+}

--- a/app/frontend/src/pages/RecipeListPage.css
+++ b/app/frontend/src/pages/RecipeListPage.css
@@ -92,3 +92,7 @@
     grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
   }
 }
+
+.recipe-browse-rating {
+  margin-top: 0.35rem;
+}

--- a/app/frontend/src/pages/RecipeListPage.jsx
+++ b/app/frontend/src/pages/RecipeListPage.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { fetchRecipes } from '../services/recipeService';
+import StarRating from '../components/StarRating';
 import './RecipeListPage.css';
 
 export default function RecipeListPage() {
@@ -45,6 +46,13 @@ export default function RecipeListPage() {
               {recipe.author_username && (
                 <p className="recipe-browse-author">By {recipe.author_username}</p>
               )}
+              <div className="recipe-browse-rating">
+                <StarRating
+                  average={recipe.average_rating ?? null}
+                  count={recipe.rating_count ?? 0}
+                  size="sm"
+                />
+              </div>
             </div>
           </article>
         ))}

--- a/app/frontend/src/pages/RecipeListPage.jsx
+++ b/app/frontend/src/pages/RecipeListPage.jsx
@@ -40,6 +40,16 @@ export default function RecipeListPage() {
               {recipe.region_name && (
                 <span className="recipe-browse-region">{recipe.region_name}</span>
               )}
+              <span
+                className={`recipe-browse-bookmark${recipe.is_bookmarked ? ' active' : ''}`}
+                aria-label={
+                  recipe.is_bookmarked
+                    ? `Bookmarked, ${recipe.bookmark_count ?? 0} saves`
+                    : 'Not bookmarked'
+                }
+              >
+                {recipe.is_bookmarked ? '🔖' : '🏷'}
+              </span>
               <h2 className="recipe-browse-title">
                 <Link to={`/recipes/${recipe.id}`} className="recipe-browse-link">{recipe.title}</Link>
               </h2>

--- a/app/frontend/src/services/recipeService.js
+++ b/app/frontend/src/services/recipeService.js
@@ -117,3 +117,23 @@ export async function toggleBookmark(id) {
   const response = await apiClient.post(`/api/recipes/${id}/bookmark/`);
   return response.data;
 }
+
+/**
+ * Recipes authored by a specific user (#709 — "My recipes" section).
+ * Backend: `GET /api/recipes/?author=<userId>`.
+ */
+export async function fetchMyRecipes(authorId) {
+  if (USE_MOCK) return MOCK_RECIPES_LIST.filter((r) => r.author === authorId);
+  const response = await apiClient.get('/api/recipes/', { params: { author: authorId } });
+  return response.data.results ?? response.data;
+}
+
+/**
+ * Recipes the current user has bookmarked (#709 — "Saved recipes").
+ * Backend: `GET /api/recipes/?bookmarked=true` (requires authentication).
+ */
+export async function fetchMyBookmarks() {
+  if (USE_MOCK) return [];
+  const response = await apiClient.get('/api/recipes/', { params: { bookmarked: 'true' } });
+  return response.data.results ?? response.data;
+}

--- a/app/frontend/src/services/recipeService.js
+++ b/app/frontend/src/services/recipeService.js
@@ -84,3 +84,36 @@ export async function fetchEventTags() {
   const response = await apiClient.get('/api/event-tags/');
   return response.data;
 }
+
+/**
+ * Submit or update the current user's rating for a recipe (#736).
+ * Backend: `POST /api/recipes/<id>/rate/` body `{ score: 1-5 }`.
+ * Returns `{ average_rating, rating_count, user_rating }`. 403 if the
+ * authenticated user is the recipe author.
+ */
+export async function rateRecipe(id, score) {
+  if (USE_MOCK) return { average_rating: score, rating_count: 1, user_rating: score };
+  const response = await apiClient.post(`/api/recipes/${id}/rate/`, { score });
+  return response.data;
+}
+
+/**
+ * Clear the current user's rating for a recipe (#736).
+ * Backend: `DELETE /api/recipes/<id>/rate/`. Returns the updated summary.
+ */
+export async function unrateRecipe(id) {
+  if (USE_MOCK) return { average_rating: null, rating_count: 0, user_rating: null };
+  const response = await apiClient.delete(`/api/recipes/${id}/rate/`);
+  return response.data;
+}
+
+/**
+ * Toggle the current user's bookmark on a recipe (#707).
+ * Backend: `POST /api/recipes/<id>/bookmark/` — idempotent toggle, no body.
+ * Returns `{ is_bookmarked, bookmark_count }`.
+ */
+export async function toggleBookmark(id) {
+  if (USE_MOCK) return { is_bookmarked: true, bookmark_count: 1 };
+  const response = await apiClient.post(`/api/recipes/${id}/bookmark/`);
+  return response.data;
+}

--- a/app/frontend/src/services/storyService.js
+++ b/app/frontend/src/services/storyService.js
@@ -48,3 +48,13 @@ export async function unpublishStory(id) {
   const response = await apiClient.post(`/api/stories/${id}/unpublish/`);
   return response.data;
 }
+
+/**
+ * Stories authored by a specific user (#709 — "My stories" section).
+ * Backend: `GET /api/stories/?author=<userId>`.
+ */
+export async function fetchMyStories(authorId) {
+  if (USE_MOCK) return MOCK_STORIES_LIST.filter((s) => s.author === authorId);
+  const response = await apiClient.get('/api/stories/', { params: { author: authorId } });
+  return response.data.results ?? response.data;
+}


### PR DESCRIPTION
Closes #736
Closes #707
Closes #709 
Closes #739

Four backend-already-shipped features wired up on web in one branch:

- **#736 Star rating** — reusable `StarRating` component; interactive on `RecipeDetailPage` (anonymous = read-only, author can't rate, non-author clicks to rate / re-clicks to unrate); read-only on `RecipeListPage` cards.
- **#707 Bookmark** — toggle button on `RecipeDetailPage` (non-author authenticated only, with optimistic update + rollback); informational icon on list cards.
- **#709 ProfilePage dashboard** — three sections (My recipes / My stories / Saved recipes) backed by new `fetchMyRecipes` / `fetchMyStories` / `fetchMyBookmarks` services; parallel `Promise.allSettled` fetches with per-section empty + error states.
- **#739 Rating notification UI** — ★ icon for `type === 'rating'`; click routes to `/recipes/<recipeId>`; existing question/reply icons unchanged.

## Test plan
- [x] Full Jest suite: **662 passed / 79 suites** (+28 new tests across the four features)
- [x] Production build: clean
- [ ] Manual QA in browser: rate as non-author, unrate, bookmark toggle, list-page cards, `/profile` dashboard, rating notification → recipe link

All commits are TDD-driven (failing test → impl → passing test) and scoped to one concern per commit.