### PR TITLE
fix(devops): move DB seeding into a separate manual workflow (#845)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,11 +19,6 @@ POSTGRES_PASSWORD=change-me
 POSTGRES_HOST=db
 POSTGRES_PORT=5432
 
-# Run the idempotent seed_* management commands on backend container start.
-# Defaults to 1 for the compose stack (see docker-compose.yml); set to 0 to
-# bring the stack up against an empty DB.
-RUN_SEEDERS=1
-
 # Frontend build-time (baked into the web image). Set this before
 # `docker compose build` — runtime changes are ignored.
 REACT_APP_API_URL=http://localhost

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -73,10 +73,10 @@ jobs:
               docker stop genipe-db || true
             fi
 
-            # Bring up the compose stack. The backend entrypoint runs migrate,
-            # collectstatic, and the idempotent seed_* commands (RUN_SEEDERS,
-            # on by default) before gunicorn starts; that's covered by the
-            # backend healthcheck's 180s start_period.
+            # Bring up the compose stack. The backend entrypoint runs migrate
+            # and collectstatic automatically before gunicorn starts. Seeding
+            # is a separate manual step — see the "Seed database" workflow
+            # (.github/workflows/seed-db.yml) and ops/PROD.md.
             # --force-recreate guards against stale containers that survive a
             # config change (e.g. when the prod overlay adds ports or volumes
             # that compose's normal diff misses on already-running containers).

--- a/.github/workflows/seed-db.yml
+++ b/.github/workflows/seed-db.yml
@@ -1,0 +1,80 @@
+name: Seed database
+
+# Manually-triggered seeding of the production DB. Seeding is NOT part of the
+# deploy (deploy-web.yml) — it's a deliberate, occasional operation: run this
+# once after first bring-up, and again only when seed fixtures/commands change.
+# In that case deploy first (so the rebuilt backend image carries the new
+# fixtures), then run this workflow.
+#
+# mode=full  -> runs seed_canonical (which WIPES and rebuilds users / recipes /
+#               stories / heritage / cultural content) plus all the others.
+#               Destructive — requires confirm=yes.
+# mode=safe  -> runs everything EXCEPT seed_canonical. All of those are
+#               idempotent upserts; nothing is deleted.
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: 'full = include seed_canonical (DESTRUCTIVE wipe+rebuild); safe = everything else'
+        type: choice
+        options: [safe, full]
+        default: safe
+        required: true
+      confirm:
+        description: 'Type "yes" to confirm a destructive mode=full run (ignored for mode=safe)'
+        type: string
+        default: ''
+        required: false
+
+concurrency:
+  # Don't run seeding and a deploy at the same time — a deploy recreates the
+  # backend container mid-seed.
+  group: deploy-web-main
+  cancel-in-progress: false
+
+jobs:
+  seed:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Guard destructive runs
+        if: ${{ inputs.mode == 'full' && inputs.confirm != 'yes' }}
+        run: |
+          echo "::error::mode=full wipes and rebuilds users/recipes/stories — re-run with confirm=yes if you really mean it."
+          exit 1
+
+      - name: Seed via SSH (docker compose exec)
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          password: ${{ secrets.SERVER_PASSWORD }}
+          command_timeout: 30m
+          script: |
+            set -e
+            cd /root/bounswe2026group12
+            COMPOSE="docker compose -f docker-compose.yml -f docker-compose.prod.yml"
+
+            if [ "${{ inputs.mode }}" = "full" ]; then
+              SEEDERS="seed_canonical seed_region_geodata seed_region_geo seed_story_coordinates seed_cultural_facts seed_cultural_content seed_ingredient_densities seed_ingredient_routes"
+            else
+              SEEDERS="seed_region_geodata seed_region_geo seed_story_coordinates seed_cultural_facts seed_cultural_content seed_ingredient_densities seed_ingredient_routes"
+            fi
+
+            echo "Seeding (mode=${{ inputs.mode }}): $SEEDERS"
+            for cmd in $SEEDERS; do
+              echo "==> manage.py $cmd"
+              $COMPOSE exec -T backend python manage.py "$cmd"
+            done
+
+            echo "Done. Current counts:"
+            $COMPOSE exec -T backend python manage.py shell -c "
+            from django.contrib.auth import get_user_model
+            from apps.recipes.models import Region, Recipe
+            from apps.stories.models import Story
+            from apps.heritage.models import HeritageGroup, CulturalFact
+            from apps.cultural_content.models import CulturalContent, CulturalEvent
+            U = get_user_model()
+            for n, m in [('users', U), ('regions', Region), ('recipes', Recipe), ('stories', Story), ('heritage_groups', HeritageGroup), ('cultural_facts', CulturalFact), ('cultural_content', CulturalContent), ('cultural_events', CulturalEvent)]:
+                print(f'  {n}: {m.objects.count()}')
+            "

--- a/app/backend/docker-entrypoint.sh
+++ b/app/backend/docker-entrypoint.sh
@@ -7,31 +7,11 @@ python manage.py migrate --noinput
 echo "[entrypoint] running collectstatic..."
 python manage.py collectstatic --noinput
 
-# Seed reference + demo content. All seed_* commands are idempotent and
-# dependency-ordered (see each command's docstring), so this is safe to run on
-# every start. Gated by RUN_SEEDERS so the bare image stays generic — the
-# compose backend service sets RUN_SEEDERS=1 (override via .env). seed_test_db
-# is intentionally excluded: it's a mock-data seeder for throwaway test DBs.
-if [ "${RUN_SEEDERS:-0}" = "1" ] || [ "${RUN_SEEDERS:-0}" = "true" ]; then
-    echo "[entrypoint] running seeders (RUN_SEEDERS=${RUN_SEEDERS})..."
-    for cmd in \
-        seed_canonical \
-        seed_region_geodata \
-        seed_region_geo \
-        seed_story_coordinates \
-        seed_cultural_facts \
-        seed_cultural_content \
-        seed_ingredient_densities \
-        seed_ingredient_routes
-    do
-        echo "[entrypoint]   -> manage.py $cmd"
-        # Best-effort: a failing seeder logs a warning but must not block the
-        # API from coming up (unlike migrate, which is fatal by design).
-        python manage.py "$cmd" || echo "[entrypoint] WARN: $cmd failed — continuing"
-    done
-else
-    echo "[entrypoint] skipping seeders (RUN_SEEDERS unset)"
-fi
+# Seeding is NOT done here — it's a deliberate, occasional operation, not a
+# per-deploy one (seed_canonical wipes and rebuilds users/recipes/stories).
+# Run the "Seed database" GitHub Action (.github/workflows/seed-db.yml), or the
+# equivalent `docker compose exec backend …` from ops/PROD.md, once after first
+# bring-up and again only when seed fixtures/commands change.
 
 echo "[entrypoint] starting gunicorn..."
 exec gunicorn config.wsgi:application \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,11 +27,6 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-genipe_mvp_2026}
       POSTGRES_HOST: db
       POSTGRES_PORT: 5432
-      # Run the idempotent seed_* management commands on container start (see
-      # app/backend/docker-entrypoint.sh). On by default for the compose stack
-      # so dev and prod both come up with reference + demo content; set
-      # RUN_SEEDERS=0 in .env to skip.
-      RUN_SEEDERS: ${RUN_SEEDERS:-1}
       # Optional S3-compatible object storage. Leave empty to use the local
       # media_data volume; set AWS_STORAGE_BUCKET_NAME (and the rest) in .env
       # to switch DEFAULT_FILE_STORAGE to S3Boto3Storage.
@@ -49,14 +44,13 @@ services:
     restart: unless-stopped
     # /admin/login/ renders without hitting the DB, so this is a clean
     # liveness probe for gunicorn. urlopen raises on non-2xx, exiting non-zero.
-    # start_period covers migrate + collectstatic + the seed_* commands
-    # (RUN_SEEDERS), which gunicorn only starts after.
+    # start_period covers migrate + collectstatic, which gunicorn starts after.
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/admin/login/')"]
       interval: 15s
       timeout: 5s
       retries: 3
-      start_period: 180s
+      start_period: 40s
 
   web:
     build:

--- a/ops/PROD.md
+++ b/ops/PROD.md
@@ -45,14 +45,19 @@ docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --force-re
 # 6. Wait for healthchecks (≤60s) and smoke
 docker compose -f docker-compose.yml -f docker-compose.prod.yml ps
 curl -fsS https://genipe.app/
+
+# 7. Seed the DB (one-time — see "Seeding" below). On a brand-new box:
+docker compose -f docker-compose.yml -f docker-compose.prod.yml \
+  exec backend sh -c 'for c in seed_canonical seed_region_geodata seed_region_geo \
+    seed_story_coordinates seed_cultural_facts seed_cultural_content \
+    seed_ingredient_densities seed_ingredient_routes; do python manage.py "$c"; done'
 ```
 
 `db`, `backend`, and `web` should all report `(healthy)`. The backend
-entrypoint runs `migrate`, `collectstatic`, and — when `RUN_SEEDERS` is set
-(the compose default) — the idempotent `seed_*` management commands, in
-dependency order, before gunicorn starts. That whole sequence is covered by
-the backend healthcheck's 180s `start_period`, so the first start after a
-fresh DB can take a couple of minutes.
+entrypoint runs `migrate` and `collectstatic` before gunicorn starts; that's
+covered by the backend healthcheck's 40s `start_period`. Seeding is **not**
+done by the entrypoint or the deploy — it's the separate step above (and the
+"Seed database" workflow), run once after first bring-up.
 
 ## Required environment variables
 
@@ -72,7 +77,6 @@ Audited against `app/backend/config/settings.py`. Every `os.getenv` /
 | `POSTGRES_HOST` | Yes | `db` (compose service name) | Hardcoded in compose; only override outside compose |
 | `POSTGRES_PORT` | Yes | `5432` | Hardcoded in compose |
 | `REACT_APP_API_URL` | Yes (build-time) | `http://localhost` | Baked into the `web` image; set before `compose build` |
-| `RUN_SEEDERS` | No | `1` (compose) | When `1`/`true`, the backend entrypoint runs the idempotent `seed_*` commands on start; set `0` to bring the stack up against an empty DB. The bare image (outside compose) defaults to off. |
 | `AWS_STORAGE_BUCKET_NAME` | No | empty | When set, switches `DEFAULT_FILE_STORAGE` to S3Boto3Storage; otherwise the local `media_data` volume is used |
 | `AWS_S3_ENDPOINT_URL` | If S3 | empty | Required when bucket name is set |
 | `AWS_ACCESS_KEY_ID` | If S3 | empty | Required when bucket name is set |
@@ -110,13 +114,21 @@ docker compose -f docker-compose.yml -f docker-compose.prod.yml logs --tail=100 
 
 ## Seeding
 
-The backend entrypoint (`app/backend/docker-entrypoint.sh`) runs these
-management commands, in this order, on every start when `RUN_SEEDERS` is
-truthy (the compose default):
+Seeding is a deliberate, occasional operation — **not** part of the deploy.
+`seed_canonical` *wipes and rebuilds* users / recipes / stories / heritage /
+cultural content, so running it on every deploy would destroy anything created
+on prod since the last deploy and (because `web` waits on `backend` being
+healthy) take the site down for the duration. Run seeding once after first
+bring-up, and again only when seed fixtures or commands change — in that case
+deploy first (so the rebuilt backend image carries the new fixtures), then
+seed.
+
+The commands, in dependency order:
 
 ```
 seed_canonical            # base data: regions, ingredients, recipes, stories,
                           #   heritage groups, cultural content/events, …
+                          #   (DESTRUCTIVE — wipes & rebuilds the above)
 seed_region_geodata       # built-in geo coords for known regions
 seed_region_geo           # region bbox + per-recipe map coords (fixture)
 seed_story_coordinates    # per-story map pins (needs region bbox)
@@ -126,22 +138,24 @@ seed_ingredient_densities # g/ml for unit conversions
 seed_ingredient_routes    # ingredient migration map overlays
 ```
 
-All of them are idempotent (keyed on natural keys), so rerunning on every
-container restart does not duplicate rows. A failing seeder logs a warning
-and the entrypoint continues — only `migrate` is fatal. `seed_test_db` is
-**not** in this list: it's a mock-data seeder for throwaway test DBs, not for
-prod.
+Everything except `seed_canonical` is an idempotent upsert (keyed on natural
+keys) — safe to rerun. `seed_test_db` is **not** in this list: it's a
+mock-data seeder for throwaway test DBs, not for prod.
 
-To seed a running stack manually (or to re-run after changing a fixture):
+Two ways to run it:
 
-```bash
-docker compose -f docker-compose.yml -f docker-compose.prod.yml \
-  exec backend sh -c 'for c in seed_canonical seed_region_geodata seed_region_geo \
-    seed_story_coordinates seed_cultural_facts seed_cultural_content \
-    seed_ingredient_densities seed_ingredient_routes; do python manage.py "$c"; done'
-```
+1. **"Seed database" GitHub Action** (`.github/workflows/seed-db.yml`) —
+   `workflow_dispatch`. Pick `mode=safe` (everything except `seed_canonical`)
+   or `mode=full` (includes the destructive `seed_canonical`; requires
+   `confirm=yes`).
+2. **Directly on the box** (take a DB dump first — see `ops/ROLLBACK.md`):
 
-Take a DB dump first if you're touching prod (see `ops/ROLLBACK.md`).
+   ```bash
+   docker compose -f docker-compose.yml -f docker-compose.prod.yml \
+     exec backend sh -c 'for c in seed_canonical seed_region_geodata seed_region_geo \
+       seed_story_coordinates seed_cultural_facts seed_cultural_content \
+       seed_ingredient_densities seed_ingredient_routes; do python manage.py "$c"; done'
+   ```
 
 ## Rollback
 
@@ -158,9 +172,8 @@ All three services report container-level health to compose:
 - `db`: `pg_isready -U $POSTGRES_USER -d $POSTGRES_DB`, 10s interval
 - `backend`: Python `urllib.request.urlopen("http://localhost:8000/admin/login/")` —
   the admin login page renders without a DB query, so this is a clean
-  liveness probe for gunicorn. 15s interval, 180s `start_period` to cover
-  migrate + collectstatic + the `seed_*` commands (gunicorn starts only after
-  the entrypoint finishes them).
+  liveness probe for gunicorn. 15s interval, 40s `start_period` to cover
+  migrate + collectstatic (gunicorn starts after the entrypoint finishes them).
 - `web`: in prod, `wget --no-check-certificate https://127.0.0.1/` (overridden
   in `docker-compose.prod.yml`); the base/dev healthcheck uses plain HTTP, but
   `nginx-prod.conf` only listens on `0.0.0.0` and `:80` redirects to https, so


### PR DESCRIPTION
Closes #845

## Summary
`app/backend/docker-entrypoint.sh`: #836 made the entrypoint run the `seed_*` commands on every container start (gated by `RUN_SEEDERS`, on by default for the compose stack). In practice that took `genipe.app` fully down for ~1–3 min on **every merge to `main`** — `deploy-web.yml` does `docker compose up -d --force-recreate`, the entrypoint runs `migrate` + `collectstatic` + 8 seeders (including `seed_canonical`, which *wipes and rebuilds* ~84 recipes / 51 stories / users / media) before it `exec`s gunicorn, and `web` `depends_on: backend: service_healthy`, so nothing serves until seeding finishes. Re-seeding on every deploy is also wrong on its own: `seed_canonical._wipe()` destroys any account/recipe created on prod since the last deploy. Reverted the entrypoint to `migrate` + `collectstatic` only.

`docker-compose.yml` / `.env.example`: Removed the `RUN_SEEDERS` env plumbing; put the `backend` healthcheck `start_period` back to `40s` (no seed step to cover anymore).

`.github/workflows/seed-db.yml` (new): A `workflow_dispatch` action that runs the seeders against the running stack via `docker compose exec backend python manage.py …`. Inputs: `mode` = `safe` (everything except `seed_canonical` — all idempotent upserts) or `full` (includes the destructive `seed_canonical`; refuses to run unless `confirm=yes`). Shares `deploy-web.yml`'s `concurrency` group (`deploy-web-main`) so a seed run and a deploy can't overlap (a deploy recreates the backend container mid-seed). Prints DB counts at the end.

`.github/workflows/deploy-web.yml`: Updated the inline comment — the entrypoint no longer seeds; seeding is the separate workflow.

`ops/PROD.md`: Rewrote the "Seeding" section — seeding is a deliberate one-time / on-fixture-change operation, run via the new workflow (`mode=safe`/`full`) or `docker compose exec`; deploy first when fixtures change so the rebuilt image carries them. Added a `# 7. Seed the DB` step to first-time setup, removed the `RUN_SEEDERS` env-table row, and put the `backend` healthcheck description back to `40s`.

Note: prod is already seeded; the operator set `RUN_SEEDERS=0` in the server `.env` as an interim mitigation — once this merges, that var is unused and harmless. The `web` healthcheck fix from #840 is unrelated and untouched.

## Test plan
 - [ ] `sh -n app/backend/docker-entrypoint.sh` exits clean
 - [ ] `docker compose -f docker-compose.yml config` and `… -f docker-compose.prod.yml config` both parse
 - [ ] `.github/workflows/seed-db.yml` and `deploy-web.yml` parse as YAML
 - [ ] Merge to `main` → deploy recreates the backend container; `genipe.app` stays up (only the normal few-second nginx/gunicorn blip), no minutes-long outage; backend reaches `(healthy)` within `start_period`
 - [ ] Run the "Seed database" workflow with `mode=safe` → seeders run, DB counts printed, no data wiped
 - [ ] Run with `mode=full` and no `confirm` → workflow fails at the guard step
 - [ ] Run with `mode=full` + `confirm=yes` → `seed_canonical` + the rest run; counts non-zero
 - [ ] `grep RUN_SEEDERS docker-compose.yml .env.example` → nothing
 - [ ] `ops/PROD.md` Seeding section reads correctly
