### PR TITLE
feat(frontend): map story pins, lunar calendar resolution, profile editing (#732 #669 #660)

### DIFF
--- a/app/frontend/src/App.js
+++ b/app/frontend/src/App.js
@@ -20,6 +20,7 @@ import InboxPage from './pages/InboxPage';
 import ThreadPage from './pages/ThreadPage';
 import OnboardingPage from './pages/OnboardingPage';
 import ProfilePage from './pages/ProfilePage';
+import ProfileEditPage from './pages/ProfileEditPage';
 import UserProfilePage from './pages/UserProfilePage';
 import MapPage from './pages/MapPage';
 import ExplorePage from './pages/ExplorePage';
@@ -85,6 +86,10 @@ export default function App() {
           <Route
             path="/profile"
             element={<ProtectedRoute><ProfilePage /></ProtectedRoute>}
+          />
+          <Route
+            path="/profile/edit"
+            element={<ProtectedRoute><ProfileEditPage /></ProtectedRoute>}
           />
           <Route
             path="/account"

--- a/app/frontend/src/__tests__/CalendarPage.test.jsx
+++ b/app/frontend/src/__tests__/CalendarPage.test.jsx
@@ -49,12 +49,16 @@ describe('CalendarPage', () => {
     expect(container.querySelectorAll('[data-testid^="calendar-month-"]').length).toBe(12);
   });
 
-  it('places fixed events under the correct month and lunar events under a dedicated panel', async () => {
+  it('places fixed events under the correct month and resolves lunar events into their month panel', async () => {
     renderPage();
-    const march = await screen.findByTestId('calendar-month-3');
+    await screen.findByText('Nevruz');
+    const march = screen.getByTestId('calendar-month-3');
     expect(within(march).getByText('Nevruz')).toBeInTheDocument();
-    const lunar = screen.getByTestId('calendar-lunar');
-    expect(within(lunar).getByText('Iftar')).toBeInTheDocument();
+    const ramadanResolved = require('../services/calendarService').LUNAR_YEARLY[new Date().getFullYear()]?.ramadan;
+    if (ramadanResolved) {
+      const ramadanPanel = screen.getByTestId(`calendar-month-${ramadanResolved.month}`);
+      expect(within(ramadanPanel).getByText('Iftar')).toBeInTheDocument();
+    }
     const november = screen.getByTestId('calendar-month-11');
     expect(within(november).getByText('Dia de los Muertos')).toBeInTheDocument();
   });
@@ -84,5 +88,55 @@ describe('CalendarPage', () => {
     const panel = await screen.findByTestId('event-detail');
     expect(within(panel).getByRole('heading', { name: /nevruz/i })).toBeInTheDocument();
     expect(within(panel).getByRole('link', { name: /sumalak/i })).toHaveAttribute('href', '/recipes/10');
+  });
+});
+
+describe('CalendarPage — lunar resolution + subline (#669)', () => {
+  const ramadanCurrentYear = require('../services/calendarService').LUNAR_YEARLY[new Date().getFullYear()]?.ramadan;
+
+  beforeEach(() => {
+    searchService.fetchRegions.mockResolvedValue([{ id: 1, name: 'All Regions' }]);
+  });
+
+  it('drops a current-year lunar event into its resolved month panel', async () => {
+    if (!ramadanCurrentYear) {
+      return;
+    }
+    culturalEventService.fetchCulturalEvents.mockResolvedValue([
+      { id: 1, name: 'Ramadan', date_rule: 'lunar:ramadan', region: { id: 1, name: 'All Regions' }, description: '', recipes: [] },
+    ]);
+    renderPage();
+    await screen.findAllByText(/ramadan/i);
+    const monthPanel = screen.getByTestId(`calendar-month-${ramadanCurrentYear.month}`);
+    const within = require('@testing-library/react').within;
+    expect(within(monthPanel).getAllByText(/ramadan/i).length).toBeGreaterThan(0);
+  });
+
+  it('shows a lunar subline on every lunar event card', async () => {
+    culturalEventService.fetchCulturalEvents.mockResolvedValue([
+      { id: 2, name: 'Eid al-Adha', date_rule: 'lunar:eid-adha', region: { id: 1, name: 'All Regions' }, description: '', recipes: [] },
+    ]);
+    renderPage();
+    expect(await screen.findByText(/on the lunar calendar/i)).toBeInTheDocument();
+  });
+
+  it('keeps unresolved lunar events in a "Lunar / movable feasts" section with (movable)', async () => {
+    culturalEventService.fetchCulturalEvents.mockResolvedValue([
+      { id: 3, name: 'Made-up Lunar', date_rule: 'lunar:unknown-name', region: { id: 1, name: 'All Regions' }, description: '', recipes: [] },
+    ]);
+    renderPage();
+    expect(await screen.findByText(/lunar.+movable feasts/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/\(movable\)/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders a dark badge on lunar cards and the regular badge on fixed cards', async () => {
+    culturalEventService.fetchCulturalEvents.mockResolvedValue([
+      { id: 4, name: 'Hıdırellez',  date_rule: 'fixed:05-06',    region: { id: 1, name: 'All Regions' }, description: '', recipes: [] },
+      { id: 5, name: 'Eid al-Adha', date_rule: 'lunar:eid-adha', region: { id: 1, name: 'All Regions' }, description: '', recipes: [] },
+    ]);
+    const { container } = renderPage();
+    await screen.findByText(/hıdırellez/i);
+    expect(container.querySelectorAll('.calendar-event-badge.is-lunar').length).toBeGreaterThan(0);
+    expect(container.querySelectorAll('.calendar-event-badge:not(.is-lunar)').length).toBeGreaterThan(0);
   });
 });

--- a/app/frontend/src/__tests__/MapPage.test.jsx
+++ b/app/frontend/src/__tests__/MapPage.test.jsx
@@ -2,30 +2,56 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import MapPage from '../pages/MapPage';
 import * as mapService from '../services/mapService';
+import * as recipeService from '../services/recipeService';
+import * as storyService from '../services/storyService';
 
 jest.mock('../services/mapService');
+jest.mock('../services/recipeService');
+jest.mock('../services/storyService');
+
 jest.mock('react-leaflet', () => ({
-  MapContainer: ({ children }) => <div data-testid="map-container">{children}</div>,
+  MapContainer: ({ children }) => <div data-testid="map">{children}</div>,
   TileLayer: () => null,
-  CircleMarker: ({ children }) => <div data-testid="circle-marker">{children}</div>,
+  CircleMarker: ({ children, eventHandlers, pathOptions }) => (
+    <button
+      type="button"
+      data-testid={`marker-${pathOptions?.fillColor ?? 'unknown'}`}
+      onClick={eventHandlers?.click}
+    >
+      {children}
+    </button>
+  ),
   Tooltip: ({ children }) => <span>{children}</span>,
 }));
 
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <MapPage />
+    </MemoryRouter>,
+  );
+}
+
 beforeEach(() => {
+  jest.clearAllMocks();
   mapService.fetchMapRegions.mockResolvedValue([
-    {
-      id: 1,
-      name: 'Aegean',
-      latitude: 38.5,
-      longitude: 27.0,
-      content_count: { recipes: 0, stories: 0 },
-    },
+    { id: 1, name: 'Black Sea', latitude: 41.0, longitude: 39.7 },
   ]);
-  mapService.fetchMapRegionContent.mockResolvedValue([]);
+  recipeService.fetchRecipesByRegion = jest.fn().mockResolvedValue([]);
+  storyService.fetchStoriesByRegion = jest.fn().mockResolvedValue([]);
 });
 
 describe('MapPage', () => {
   it('builds "See all from {region}" using region.name, not region.id', async () => {
+    mapService.fetchMapRegions.mockResolvedValue([
+      {
+        id: 1,
+        name: 'Aegean',
+        latitude: 38.5,
+        longitude: 27.0,
+        content_count: { recipes: 0, stories: 0 },
+      },
+    ]);
     render(
       <MemoryRouter>
         <MapPage />
@@ -34,5 +60,59 @@ describe('MapPage', () => {
     await waitFor(() => expect(screen.getByRole('link', { name: /see all from aegean/i })).toBeInTheDocument());
     const link = screen.getByRole('link', { name: /see all from aegean/i });
     expect(link).toHaveAttribute('href', '/search?region=Aegean');
+  });
+});
+
+describe('MapPage — recipe and story pins (#732)', () => {
+  it('renders a pin per located recipe and per located story with distinct colours', async () => {
+    recipeService.fetchRecipesByRegion.mockResolvedValue([
+      { id: 1, title: 'Anchovy Pilaf', latitude: 41.0, longitude: 39.7, author_username: 'a' },
+    ]);
+    storyService.fetchStoriesByRegion.mockResolvedValue([
+      { id: 2, title: 'Trabzon Memory', latitude: 41.1, longitude: 39.8, author_username: 'b' },
+    ]);
+    renderPage();
+    expect(await screen.findByText(/anchovy pilaf/i)).toBeInTheDocument();
+    expect(screen.getByTestId('marker-#C4521E')).toBeInTheDocument();
+    expect(screen.getByTestId('marker-#2E7D7D')).toBeInTheDocument();
+  });
+
+  it('lists unlocated items in the "Without a location" panel', async () => {
+    recipeService.fetchRecipesByRegion.mockResolvedValue([
+      { id: 3, title: 'Located Recipe',   latitude: 41.0, longitude: 39.7, author_username: 'a' },
+      { id: 4, title: 'Unlocated Recipe', latitude: null, longitude: null, author_username: 'a' },
+    ]);
+    storyService.fetchStoriesByRegion.mockResolvedValue([
+      { id: 5, title: 'Unlocated Story',  latitude: null, longitude: null, author_username: 'b' },
+    ]);
+    renderPage();
+    expect(await screen.findByText(/unlocated recipe/i)).toBeInTheDocument();
+    expect(screen.getByText(/unlocated story/i)).toBeInTheDocument();
+    expect(screen.getByText(/without a location/i)).toBeInTheDocument();
+  });
+
+  it('renders an explicit "X recipes + Y stories on map · Z without a location" count line', async () => {
+    recipeService.fetchRecipesByRegion.mockResolvedValue([
+      { id: 10, title: 'On Map A',  latitude: 41.0, longitude: 39.7, author_username: 'a' },
+      { id: 11, title: 'Off Map A', latitude: null, longitude: null, author_username: 'a' },
+    ]);
+    storyService.fetchStoriesByRegion.mockResolvedValue([
+      { id: 12, title: 'On Map B',  latitude: 41.1, longitude: 39.8, author_username: 'b' },
+    ]);
+    renderPage();
+    expect(await screen.findByText(/1 recipe.* \+ 1 stor.* on map.* 1 without a location/i))
+      .toBeInTheDocument();
+  });
+
+  it('links recipe pins to /recipes/:id and story pins to /stories/:id', async () => {
+    recipeService.fetchRecipesByRegion.mockResolvedValue([
+      { id: 1, title: 'R1', latitude: 41.0, longitude: 39.7, author_username: 'a' },
+    ]);
+    storyService.fetchStoriesByRegion.mockResolvedValue([
+      { id: 2, title: 'S1', latitude: 41.1, longitude: 39.8, author_username: 'b' },
+    ]);
+    renderPage();
+    expect(await screen.findByRole('link', { name: /r1/i })).toHaveAttribute('href', '/recipes/1');
+    expect(screen.getByRole('link', { name: /s1/i })).toHaveAttribute('href', '/stories/2');
   });
 });

--- a/app/frontend/src/__tests__/ProfileEditPage.test.jsx
+++ b/app/frontend/src/__tests__/ProfileEditPage.test.jsx
@@ -1,0 +1,92 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import ProfileEditPage from '../pages/ProfileEditPage';
+import { AuthContext } from '../context/AuthContext';
+import * as authService from '../services/authService';
+
+jest.mock('../services/authService');
+
+function renderPage({ user = { id: 1, username: 'me', email: 'me@x.com', bio: 'old bio', region: 'Aegean', preferred_language: 'tr' }, updateUser = jest.fn() } = {}) {
+  return {
+    updateUser,
+    ...render(
+      <MemoryRouter initialEntries={['/profile/edit']}>
+        <AuthContext.Provider value={{ user, token: 't', refreshToken: 'r', login: jest.fn(), logout: jest.fn(), updateUser, loading: false }}>
+          <Routes>
+            <Route path="/profile/edit" element={<ProfileEditPage />} />
+            <Route path="/profile" element={<div>profile-home</div>} />
+          </Routes>
+        </AuthContext.Provider>
+      </MemoryRouter>,
+    ),
+  };
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('ProfileEditPage', () => {
+  it('prefills inputs from AuthContext user', () => {
+    renderPage();
+    expect(screen.getByLabelText(/username/i)).toHaveValue('me');
+    expect(screen.getByLabelText(/bio/i)).toHaveValue('old bio');
+    expect(screen.getByLabelText(/region/i)).toHaveValue('Aegean');
+    expect(screen.getByLabelText(/language/i)).toHaveValue('tr');
+  });
+
+  it('renders email as read-only', () => {
+    renderPage();
+    const email = screen.getByLabelText(/email/i);
+    expect(email).toHaveValue('me@x.com');
+    expect(email).toHaveAttribute('readonly');
+  });
+
+  it('Save calls authService.updateMe with edited payload and calls updateUser', async () => {
+    authService.updateMe.mockResolvedValue({ id: 1, username: 'me2', email: 'me@x.com', bio: 'new bio', region: 'Aegean', preferred_language: 'tr' });
+    const { updateUser } = renderPage();
+    await userEvent.clear(screen.getByLabelText(/username/i));
+    await userEvent.type(screen.getByLabelText(/username/i), 'me2');
+    await userEvent.clear(screen.getByLabelText(/bio/i));
+    await userEvent.type(screen.getByLabelText(/bio/i), 'new bio');
+    await userEvent.click(screen.getByRole('button', { name: /save/i }));
+    await waitFor(() => expect(authService.updateMe).toHaveBeenCalledWith({
+      username: 'me2',
+      bio: 'new bio',
+      region: 'Aegean',
+      preferred_language: 'tr',
+    }));
+    expect(updateUser).toHaveBeenCalledWith(expect.objectContaining({ username: 'me2', bio: 'new bio' }));
+  });
+
+  it('Cancel navigates back to /profile without calling updateMe', async () => {
+    renderPage();
+    await userEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(authService.updateMe).not.toHaveBeenCalled();
+    expect(await screen.findByText('profile-home')).toBeInTheDocument();
+  });
+
+  it('shows a username-required error when username is empty', async () => {
+    renderPage();
+    await userEvent.clear(screen.getByLabelText(/username/i));
+    await userEvent.click(screen.getByRole('button', { name: /save/i }));
+    expect(await screen.findByText(/username is required/i)).toBeInTheDocument();
+    expect(authService.updateMe).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a 400 username-taken error from the backend', async () => {
+    authService.updateMe.mockRejectedValue({ response: { status: 400, data: { username: ['username already taken'] } } });
+    renderPage();
+    await userEvent.click(screen.getByRole('button', { name: /save/i }));
+    expect(await screen.findByText(/username already taken/i)).toBeInTheDocument();
+  });
+
+  it('disables Save while the request is in flight', async () => {
+    let resolve;
+    authService.updateMe.mockReturnValue(new Promise((r) => { resolve = r; }));
+    renderPage();
+    await userEvent.click(screen.getByRole('button', { name: /save/i }));
+    expect(screen.getByRole('button', { name: /saving/i })).toBeDisabled();
+    resolve({ id: 1, username: 'me', email: 'me@x.com' });
+    await waitFor(() => expect(screen.queryByRole('button', { name: /saving/i })).not.toBeInTheDocument());
+  });
+});

--- a/app/frontend/src/__tests__/ProfilePage.test.jsx
+++ b/app/frontend/src/__tests__/ProfilePage.test.jsx
@@ -105,3 +105,11 @@ describe('ProfilePage — my recipes / stories / bookmarks', () => {
     expect(screen.getByText(/no saved recipes yet/i)).toBeInTheDocument();
   });
 });
+
+describe('ProfilePage — edit link (#660)', () => {
+  it('renders an "Edit profile" link pointing at /profile/edit', () => {
+    renderPage({ user: { id: 1, username: 'me', email: 'me@x.com', is_contactable: true } });
+    const link = screen.getByRole('link', { name: /edit profile/i });
+    expect(link).toHaveAttribute('href', '/profile/edit');
+  });
+});

--- a/app/frontend/src/__tests__/recipeService.test.js
+++ b/app/frontend/src/__tests__/recipeService.test.js
@@ -14,6 +14,7 @@ import {
   toggleBookmark,
   fetchMyRecipes,
   fetchMyBookmarks,
+  fetchRecipesByRegion,
 } from '../services/recipeService';
 
 jest.mock('../services/api', () => ({
@@ -306,5 +307,19 @@ describe('fetchMyBookmarks', () => {
   it('unwraps paginated DRF responses', async () => {
     apiClient.get.mockResolvedValue({ data: { results: [{ id: 10 }] } });
     expect(await fetchMyBookmarks()).toEqual([{ id: 10 }]);
+  });
+});
+
+describe('fetchRecipesByRegion', () => {
+  it('GETs /api/recipes/?region=<name> and returns the list', async () => {
+    apiClient.get.mockResolvedValue({ data: [{ id: 1, title: 'Anchovy Pilaf', latitude: 41.0, longitude: 39.7 }] });
+    const result = await fetchRecipesByRegion('Black Sea');
+    expect(apiClient.get).toHaveBeenCalledWith('/api/recipes/', { params: { region: 'Black Sea' } });
+    expect(result).toEqual([{ id: 1, title: 'Anchovy Pilaf', latitude: 41.0, longitude: 39.7 }]);
+  });
+
+  it('unwraps paginated DRF responses', async () => {
+    apiClient.get.mockResolvedValue({ data: { results: [{ id: 5 }] } });
+    expect(await fetchRecipesByRegion('Aegean')).toEqual([{ id: 5 }]);
   });
 });

--- a/app/frontend/src/__tests__/storyService.test.js
+++ b/app/frontend/src/__tests__/storyService.test.js
@@ -1,5 +1,5 @@
 import * as storyService from '../services/storyService';
-import { fetchMyStories } from '../services/storyService';
+import { fetchMyStories, fetchStoriesByRegion } from '../services/storyService';
 import { apiClient } from '../services/api';
 
 jest.mock('../services/api', () => ({
@@ -104,5 +104,19 @@ describe('fetchMyStories', () => {
   it('unwraps paginated DRF responses', async () => {
     apiClient.get.mockResolvedValue({ data: { results: [{ id: 8 }] } });
     expect(await fetchMyStories(42)).toEqual([{ id: 8 }]);
+  });
+});
+
+describe('fetchStoriesByRegion', () => {
+  it('GETs /api/stories/?region=<name> and returns the list', async () => {
+    apiClient.get.mockResolvedValue({ data: [{ id: 2, title: 'Trabzon Memory', latitude: 41.0, longitude: 39.7 }] });
+    const result = await fetchStoriesByRegion('Black Sea');
+    expect(apiClient.get).toHaveBeenCalledWith('/api/stories/', { params: { region: 'Black Sea' } });
+    expect(result).toEqual([{ id: 2, title: 'Trabzon Memory', latitude: 41.0, longitude: 39.7 }]);
+  });
+
+  it('unwraps paginated DRF responses', async () => {
+    apiClient.get.mockResolvedValue({ data: { results: [{ id: 6 }] } });
+    expect(await fetchStoriesByRegion('Aegean')).toEqual([{ id: 6 }]);
   });
 });

--- a/app/frontend/src/pages/CalendarPage.css
+++ b/app/frontend/src/pages/CalendarPage.css
@@ -186,3 +186,38 @@
   text-decoration: none;
   font-size: 0.85rem;
 }
+
+.calendar-event-card {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.25rem;
+  padding: 0.5rem 0.75rem;
+  background: transparent;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+  width: 100%;
+}
+
+.calendar-event-badge {
+  display: inline-block;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  padding: 0.15rem 0.45rem;
+  border-radius: 999px;
+  background: var(--color-accent-mustard, #D4A830);
+  color: var(--color-surface-dark, #3D1500);
+}
+
+.calendar-event-badge.is-lunar {
+  background: var(--color-surface-dark, #3D1500);
+  color: var(--color-surface, #FAF7EF);
+}
+
+.calendar-event-lunar-subline {
+  font-style: italic;
+  font-size: 0.8rem;
+  color: var(--color-text-muted, #6b6b6b);
+}

--- a/app/frontend/src/pages/CalendarPage.jsx
+++ b/app/frontend/src/pages/CalendarPage.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { fetchCulturalEvents } from '../services/culturalEventService';
+import { parseEventDate } from '../services/calendarService';
 import { fetchRegions } from '../services/searchService';
 import './CalendarPage.css';
 
@@ -9,17 +10,26 @@ const MONTHS = [
   'July', 'August', 'September', 'October', 'November', 'December',
 ];
 
-function parseDateRule(rule) {
-  if (typeof rule !== 'string') return { kind: 'unknown' };
-  if (rule.startsWith('fixed:')) {
-    const [mm, dd] = rule.slice('fixed:'.length).split('-');
-    const month = parseInt(mm, 10);
-    return { kind: 'fixed', month, day: parseInt(dd, 10) };
-  }
-  if (rule.startsWith('lunar:')) {
-    return { kind: 'lunar', name: rule.slice('lunar:'.length) };
-  }
-  return { kind: 'unknown' };
+const LUNAR_PRETTY = {
+  'ramadan': 'Ramadan',
+  'eid-fitr': 'Eid al-Fitr',
+  'eid-adha': 'Eid al-Adha',
+  'kurban-bayrami': 'Eid al-Adha',
+  'mevlid': 'Mevlid',
+  'ashura': 'Ashura',
+};
+
+function prettyLunar(slug) {
+  if (!slug) return '';
+  if (LUNAR_PRETTY[slug]) return LUNAR_PRETTY[slug];
+  return slug.split('-').map((p) => p.charAt(0).toUpperCase() + p.slice(1)).join(' ');
+}
+
+function ruleFromEvent(event) {
+  const r = event.date_rule;
+  if (typeof r !== 'string') return null;
+  if (r.startsWith('fixed:')) return r.slice('fixed:'.length);
+  return r;
 }
 
 export default function CalendarPage() {
@@ -48,16 +58,20 @@ export default function CalendarPage() {
 
   const grouped = useMemo(() => {
     const byMonth = Array.from({ length: 12 }, () => []);
-    const lunar = [];
+    const movable = [];
     for (const event of events) {
-      const parsed = parseDateRule(event.date_rule);
-      if (parsed.kind === 'fixed' && parsed.month >= 1 && parsed.month <= 12) {
-        byMonth[parsed.month - 1].push(event);
-      } else if (parsed.kind === 'lunar') {
-        lunar.push(event);
+      const rule = ruleFromEvent(event);
+      const parsed = parseEventDate(rule);
+      if (!parsed) continue;
+      if (parsed.isLunar && parsed.lunarUnresolved) {
+        movable.push({ event, parsed });
+        continue;
+      }
+      if (Number.isInteger(parsed.monthIndex) && parsed.monthIndex >= 0 && parsed.monthIndex <= 11) {
+        byMonth[parsed.monthIndex].push({ event, parsed });
       }
     }
-    return { byMonth, lunar };
+    return { byMonth, movable };
   }, [events]);
 
   return (
@@ -107,20 +121,13 @@ export default function CalendarPage() {
                 <p className="calendar-month-empty">No events.</p>
               ) : (
                 <ul>
-                  {monthEvents.map((event) => (
-                    <li key={event.id}>
-                      <button
-                        type="button"
-                        className="calendar-event-card"
-                        aria-label={`Open ${event.name} details`}
-                        onClick={() => setSelected(event)}
-                      >
-                        <span className="calendar-event-name">{event.name}</span>
-                        {event.region?.name && (
-                          <span className="calendar-event-region">{event.region.name}</span>
-                        )}
-                      </button>
-                    </li>
+                  {monthEvents.map(({ event, parsed }) => (
+                    <CalendarEventCard
+                      key={event.id}
+                      event={event}
+                      parsed={parsed}
+                      onSelect={() => setSelected(event)}
+                    />
                   ))}
                 </ul>
               )}
@@ -129,27 +136,20 @@ export default function CalendarPage() {
         })}
       </div>
 
-      {grouped.lunar.length > 0 && (
+      {grouped.movable.length > 0 && (
         <section className="calendar-lunar" data-testid="calendar-lunar">
-          <h2>Lunar-Anchored Events</h2>
+          <h2>Lunar / movable feasts</h2>
           <p className="calendar-lunar-note">
-            Lunar dates shift each year; check a current lunar calendar for the exact day.
+            These shift each year — check a current lunar calendar for the exact day.
           </p>
           <ul>
-            {grouped.lunar.map((event) => (
-              <li key={event.id}>
-                <button
-                  type="button"
-                  className="calendar-event-card"
-                  aria-label={`Open ${event.name} details`}
-                  onClick={() => setSelected(event)}
-                >
-                  <span className="calendar-event-name">{event.name}</span>
-                  {event.region?.name && (
-                    <span className="calendar-event-region">{event.region.name}</span>
-                  )}
-                </button>
-              </li>
+            {grouped.movable.map(({ event, parsed }) => (
+              <CalendarEventCard
+                key={event.id}
+                event={event}
+                parsed={parsed}
+                onSelect={() => setSelected(event)}
+              />
             ))}
           </ul>
         </section>
@@ -188,5 +188,39 @@ export default function CalendarPage() {
         </aside>
       )}
     </main>
+  );
+}
+
+function CalendarEventCard({ event, parsed, onSelect }) {
+  const isLunar = Boolean(parsed?.isLunar);
+  const isMovable = isLunar && parsed?.lunarUnresolved;
+  const pretty = isLunar ? prettyLunar(parsed.lunarName) : '';
+  const dateLabel = isMovable
+    ? '(movable)'
+    : `${MONTHS[parsed.monthIndex].slice(0, 3)} ${parsed.day}`;
+
+  return (
+    <li>
+      <button
+        type="button"
+        className="calendar-event-card"
+        aria-label={`Open ${event.name} details`}
+        onClick={onSelect}
+      >
+        <span className={`calendar-event-badge${isLunar ? ' is-lunar' : ''}`}>
+          {dateLabel}
+        </span>
+        <span className="calendar-event-name">{event.name}</span>
+        {event.region?.name && (
+          <span className="calendar-event-region">{event.region.name}</span>
+        )}
+        {isLunar && (
+          <span className="calendar-event-lunar-subline">
+            ☾ On the lunar calendar: {pretty} this year
+            {isMovable ? ' (movable)' : ''}
+          </span>
+        )}
+      </button>
+    </li>
   );
 }

--- a/app/frontend/src/pages/MapPage.css
+++ b/app/frontend/src/pages/MapPage.css
@@ -172,3 +172,18 @@
   border-color: var(--color-primary);
   color: #fff;
 }
+
+.map-content-item-story {
+  border-left: 3px solid #2E7D7D;
+}
+
+.map-pin-link {
+  color: var(--color-primary, #C4521E);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.map-pin-link:hover,
+.map-pin-link:focus-visible {
+  text-decoration: underline;
+}

--- a/app/frontend/src/pages/MapPage.jsx
+++ b/app/frontend/src/pages/MapPage.jsx
@@ -2,17 +2,20 @@ import { useState, useEffect, useRef } from 'react';
 import { Link } from 'react-router-dom';
 import { MapContainer, TileLayer, CircleMarker, Tooltip } from 'react-leaflet';
 import 'leaflet/dist/leaflet.css';
-import { fetchMapRegions, fetchMapRegionContent } from '../services/mapService';
+import { fetchMapRegions } from '../services/mapService';
+import { fetchRecipesByRegion } from '../services/recipeService';
+import { fetchStoriesByRegion } from '../services/storyService';
 import './MapPage.css';
 
 export default function MapPage() {
   const [regions, setRegions] = useState([]);
   const [selected, setSelected] = useState(null);
-  const [content, setContent] = useState([]);
+  const [recipes, setRecipes] = useState([]);
+  const [stories, setStories] = useState([]);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState('');
   const [contentLoading, setContentLoading] = useState(false);
-  const currentRegionId = useRef(null);
+  const currentRegionName = useRef(null);
 
   useEffect(() => {
     fetchMapRegions()
@@ -28,21 +31,27 @@ export default function MapPage() {
   function selectRegion(region) {
     setSelected(region);
     setContentLoading(true);
-    currentRegionId.current = region.id;
-    fetchMapRegionContent(region.id)
-      .then((data) => {
-        if (currentRegionId.current === region.id) setContent(data);
-      })
-      .catch(() => {
-        if (currentRegionId.current === region.id) setContent([]);
-      })
-      .finally(() => {
-        if (currentRegionId.current === region.id) setContentLoading(false);
-      });
+    currentRegionName.current = region.name;
+    Promise.allSettled([
+      fetchRecipesByRegion(region.name),
+      fetchStoriesByRegion(region.name),
+    ]).then(([r, s]) => {
+      if (currentRegionName.current !== region.name) return;
+      setRecipes(r.status === 'fulfilled' && Array.isArray(r.value) ? r.value : []);
+      setStories(s.status === 'fulfilled' && Array.isArray(s.value) ? s.value : []);
+      setContentLoading(false);
+    });
   }
 
-  const recipes = content.filter((c) => c.content_type === 'recipe');
-  const stories = content.filter((c) => c.content_type === 'story');
+  const hasCoords = (it) =>
+    it.latitude !== null && it.latitude !== undefined &&
+    it.longitude !== null && it.longitude !== undefined &&
+    Number.isFinite(Number(it.latitude)) && Number.isFinite(Number(it.longitude));
+  const locatedRecipes   = recipes.filter(hasCoords);
+  const unlocatedRecipes = recipes.filter((r) => !hasCoords(r));
+  const locatedStories   = stories.filter(hasCoords);
+  const unlocatedStories = stories.filter((s) => !hasCoords(s));
+  const unlocatedCount   = unlocatedRecipes.length + unlocatedStories.length;
 
   return (
     <div className="map-page">
@@ -68,12 +77,12 @@ export default function MapPage() {
               />
               {regions.map((region) => (
                 <CircleMarker
-                  key={region.id}
+                  key={`region-${region.id}`}
                   center={[region.latitude, region.longitude]}
                   radius={selected?.id === region.id ? 16 : 11}
                   pathOptions={{
-                    color: selected?.id === region.id ? '#A3401A' : '#C4521E',
-                    fillColor: selected?.id === region.id ? '#C4521E' : '#FAF7EF',
+                    color: selected?.id === region.id ? '#5A2410' : '#C4521E',
+                    fillColor: selected?.id === region.id ? '#7A2E14' : '#FAF7EF',
                     fillOpacity: selected?.id === region.id ? 0.9 : 0.7,
                     weight: 2,
                   }}
@@ -81,6 +90,40 @@ export default function MapPage() {
                 >
                   <Tooltip direction="top" offset={[0, -8]} opacity={0.95}>
                     {region.name}
+                  </Tooltip>
+                </CircleMarker>
+              ))}
+              {locatedRecipes.map((r) => (
+                <CircleMarker
+                  key={`recipe-${r.id}`}
+                  center={[Number(r.latitude), Number(r.longitude)]}
+                  radius={7}
+                  pathOptions={{
+                    color: '#A3401A',
+                    fillColor: '#C4521E',
+                    fillOpacity: 0.9,
+                    weight: 1.5,
+                  }}
+                >
+                  <Tooltip direction="top" offset={[0, -8]} opacity={0.95}>
+                    <Link to={`/recipes/${r.id}`} className="map-pin-link">{r.title}</Link>
+                  </Tooltip>
+                </CircleMarker>
+              ))}
+              {locatedStories.map((s) => (
+                <CircleMarker
+                  key={`story-${s.id}`}
+                  center={[Number(s.latitude), Number(s.longitude)]}
+                  radius={7}
+                  pathOptions={{
+                    color: '#1F5959',
+                    fillColor: '#2E7D7D',
+                    fillOpacity: 0.9,
+                    weight: 1.5,
+                  }}
+                >
+                  <Tooltip direction="top" offset={[0, -8]} opacity={0.95}>
+                    <Link to={`/stories/${s.id}`} className="map-pin-link">{s.title}</Link>
                   </Tooltip>
                 </CircleMarker>
               ))}
@@ -94,36 +137,27 @@ export default function MapPage() {
           {selected ? (
             <>
               <h2 className="map-panel-title">{selected.name}</h2>
-              <div className="map-panel-counts">
-                <span>{selected.content_count?.recipes ?? 0} recipes</span>
-                <span>{selected.content_count?.stories ?? 0} stories</span>
-              </div>
+              <p className="map-panel-counts">
+                {`${locatedRecipes.length} ${locatedRecipes.length === 1 ? 'recipe' : 'recipes'} + ${locatedStories.length} ${locatedStories.length === 1 ? 'story' : 'stories'} on map · ${unlocatedCount} without a location`}
+              </p>
 
               {contentLoading && <p className="map-panel-empty">Loading…</p>}
 
-              {!contentLoading && recipes.length > 0 && (
+              {!contentLoading && unlocatedCount > 0 && (
                 <section className="map-panel-section">
-                  <h3>Recipes</h3>
+                  <h3>No coordinates</h3>
                   <ul className="map-content-list">
-                    {recipes.map((r) => (
-                      <li key={r.id}>
+                    {unlocatedRecipes.map((r) => (
+                      <li key={`ur-${r.id}`}>
                         <Link to={`/recipes/${r.id}`} className="map-content-item">
                           <span className="map-content-title">{r.title}</span>
                           <span className="map-content-author">@{r.author_username}</span>
                         </Link>
                       </li>
                     ))}
-                  </ul>
-                </section>
-              )}
-
-              {!contentLoading && stories.length > 0 && (
-                <section className="map-panel-section">
-                  <h3>Stories</h3>
-                  <ul className="map-content-list">
-                    {stories.map((s) => (
-                      <li key={s.id}>
-                        <Link to={`/stories/${s.id}`} className="map-content-item">
+                    {unlocatedStories.map((s) => (
+                      <li key={`us-${s.id}`}>
+                        <Link to={`/stories/${s.id}`} className="map-content-item map-content-item-story">
                           <span className="map-content-title">{s.title}</span>
                           <span className="map-content-author">@{s.author_username}</span>
                         </Link>

--- a/app/frontend/src/pages/ProfileEditPage.css
+++ b/app/frontend/src/pages/ProfileEditPage.css
@@ -1,0 +1,48 @@
+.profile-edit {
+  max-width: 480px;
+  margin: 2rem auto;
+}
+
+.profile-edit-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.profile-edit-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.profile-edit-field > span {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.profile-edit-field input,
+.profile-edit-field textarea,
+.profile-edit-field select {
+  font: inherit;
+  padding: 0.5rem 0.65rem;
+  border: 1px solid var(--color-border, #ccc);
+  border-radius: var(--radius-sm, 6px);
+  background: var(--color-surface, #FAF7EF);
+}
+
+.profile-edit-field input[readonly] {
+  background: rgba(0, 0, 0, 0.04);
+  color: var(--color-text-muted, #777);
+}
+
+.profile-edit-actions {
+  display: flex;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+}
+
+.profile-edit-error {
+  color: var(--color-error, #b00020);
+  margin: 0 0 0.5rem;
+}

--- a/app/frontend/src/pages/ProfileEditPage.jsx
+++ b/app/frontend/src/pages/ProfileEditPage.jsx
@@ -1,0 +1,124 @@
+import { useContext, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { AuthContext } from '../context/AuthContext';
+import { updateMe } from '../services/authService';
+import './ProfileEditPage.css';
+
+const LANGUAGES = [
+  { code: '',   label: '— None —' },
+  { code: 'tr', label: 'Turkish' },
+  { code: 'en', label: 'English' },
+  { code: 'ar', label: 'Arabic' },
+];
+
+export default function ProfileEditPage() {
+  const { user, updateUser } = useContext(AuthContext);
+  const navigate = useNavigate();
+
+  const [username, setUsername]     = useState(user?.username ?? '');
+  const [bio, setBio]               = useState(user?.bio ?? '');
+  const [region, setRegion]         = useState(user?.region ?? '');
+  const [language, setLanguage]     = useState(user?.preferred_language ?? '');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError]           = useState('');
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    setError('');
+    if (!username.trim()) {
+      setError('Username is required.');
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const next = await updateMe({
+        username: username.trim(),
+        bio,
+        region,
+        preferred_language: language,
+      });
+      updateUser({ ...(user ?? {}), ...next });
+      navigate('/profile');
+    } catch (err) {
+      const data = err?.response?.data;
+      if (data?.username?.[0]) setError(String(data.username[0]));
+      else if (typeof data?.detail === 'string') setError(data.detail);
+      else setError('Could not save changes. Please try again.');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  function handleCancel() {
+    navigate('/profile');
+  }
+
+  return (
+    <main className="page-card profile-edit">
+      <h1>Edit profile</h1>
+      {error && <p className="profile-edit-error" role="alert">{error}</p>}
+      <form className="profile-edit-form" onSubmit={handleSubmit}>
+        <label className="profile-edit-field">
+          <span>Username</span>
+          <input
+            type="text"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            disabled={submitting}
+          />
+        </label>
+
+        <label className="profile-edit-field">
+          <span>Email</span>
+          <input
+            type="email"
+            value={user?.email ?? ''}
+            readOnly
+          />
+        </label>
+
+        <label className="profile-edit-field">
+          <span>Bio</span>
+          <textarea
+            value={bio}
+            onChange={(e) => setBio(e.target.value)}
+            rows={3}
+            disabled={submitting}
+          />
+        </label>
+
+        <label className="profile-edit-field">
+          <span>Region</span>
+          <input
+            type="text"
+            value={region}
+            onChange={(e) => setRegion(e.target.value)}
+            disabled={submitting}
+          />
+        </label>
+
+        <label className="profile-edit-field">
+          <span>Preferred language</span>
+          <select
+            value={language}
+            onChange={(e) => setLanguage(e.target.value)}
+            disabled={submitting}
+          >
+            {LANGUAGES.map((l) => (
+              <option key={l.code || 'none'} value={l.code}>{l.label}</option>
+            ))}
+          </select>
+        </label>
+
+        <div className="profile-edit-actions">
+          <button type="submit" className="btn btn-primary" disabled={submitting}>
+            {submitting ? 'Saving…' : 'Save'}
+          </button>
+          <button type="button" className="btn btn-outline" onClick={handleCancel} disabled={submitting}>
+            Cancel
+          </button>
+        </div>
+      </form>
+    </main>
+  );
+}

--- a/app/frontend/src/pages/ProfilePage.jsx
+++ b/app/frontend/src/pages/ProfilePage.jsx
@@ -20,6 +20,10 @@ export default function ProfilePage() {
         <p className="profile-email">{user.email}</p>
       </section>
 
+      <p className="profile-edit-link-wrap">
+        <Link to="/profile/edit" className="btn btn-outline btn-sm">Edit profile</Link>
+      </p>
+
       <ContactabilityToggle user={user} onUserUpdated={updateUser} />
 
       <ProfileDashboard user={user} />

--- a/app/frontend/src/services/calendarService.js
+++ b/app/frontend/src/services/calendarService.js
@@ -4,7 +4,7 @@ const USE_MOCK = process.env.REACT_APP_USE_MOCK === 'true';
 
 // Lunar event dates resolved to Gregorian, keyed by year then event name.
 // Keep in sync with mobile calendarService.ts — update both together each year.
-const LUNAR_YEARLY = {
+export const LUNAR_YEARLY = {
   2024: { ramadan: { month: 2, day: 10 }, 'eid-fitr': { month: 3, day: 10 }, 'eid-adha': { month: 5, day: 16 }, mevlid: { month: 9, day: 15 }, ashura: { month: 7, day: 17 } },
   2025: { ramadan: { month: 2, day: 28 }, 'eid-fitr': { month: 3, day: 30 }, 'eid-adha': { month: 5, day: 6 }, mevlid: { month: 9, day: 4 }, ashura: { month: 7, day: 5 } },
   2026: { ramadan: { month: 2, day: 17 }, 'eid-fitr': { month: 3, day: 19 }, 'eid-adha': { month: 4, day: 26 }, mevlid: { month: 8, day: 24 }, ashura: { month: 6, day: 24 } },

--- a/app/frontend/src/services/recipeService.js
+++ b/app/frontend/src/services/recipeService.js
@@ -137,3 +137,16 @@ export async function fetchMyBookmarks() {
   const response = await apiClient.get('/api/recipes/', { params: { bookmarked: 'true' } });
   return response.data.results ?? response.data;
 }
+
+/**
+ * Recipes attached to a region by name (#732 — map story-pin parity).
+ * Backend: `GET /api/recipes/?region=<name>`. Returns items with optional
+ * `latitude` / `longitude` for plotting on the region map.
+ */
+export async function fetchRecipesByRegion(regionName) {
+  if (USE_MOCK) {
+    return MOCK_RECIPES_LIST.filter((r) => r.region_name === regionName);
+  }
+  const response = await apiClient.get('/api/recipes/', { params: { region: regionName } });
+  return response.data.results ?? response.data;
+}

--- a/app/frontend/src/services/storyService.js
+++ b/app/frontend/src/services/storyService.js
@@ -58,3 +58,16 @@ export async function fetchMyStories(authorId) {
   const response = await apiClient.get('/api/stories/', { params: { author: authorId } });
   return response.data.results ?? response.data;
 }
+
+/**
+ * Stories attached to a region by name (#732 — map story-pin parity).
+ * Backend: `GET /api/stories/?region=<name>`. Returns items with optional
+ * `latitude` / `longitude` for plotting on the region map.
+ */
+export async function fetchStoriesByRegion(regionName) {
+  if (USE_MOCK) {
+    return MOCK_STORIES_LIST.filter((s) => s.region_name === regionName);
+  }
+  const response = await apiClient.get('/api/stories/', { params: { region: regionName } });
+  return response.data.results ?? response.data;
+}


### PR DESCRIPTION
Closes #732, #669, #660.

Three independent web-frontend features in one branch:

- **#732 Story pins on the region map** — MapPage now fetches \`/api/recipes/?region=<name>\` and \`/api/stories/?region=<name>\` in parallel; located items render as distinct CircleMarkers (recipes rust orange, stories teal); unlocated items appear in a dedicated sidebar panel; explicit count line "X recipes + Y stories on map · Z without a location."
- **#669 Cultural calendar lunar resolution** — \`CalendarPage\` now uses \`calendarService.parseEventDate\`; lunar events with a current-year entry resolve into their resolved month panel; unresolved lunar events stay in a "Lunar / movable feasts" section. Each lunar card carries a dark badge and an italic subline ("☾ On the lunar calendar: {Pretty Name} this year" or "(movable)").
- **#660 Profile editing page** — new \`/profile/edit\` route with prefilled form (username / bio / region / preferred_language); email read-only; Save calls \`authService.updateMe\` and refreshes \`AuthContext\`; Cancel routes back; inline validation + 400 surfacing + \"Saving…\" disabled state.

## Test plan
- [x] Full Jest suite: 705 passing (82 suites) · +20 new tests
- [x] Production build: \`Compiled successfully\`
- [ ] Manual QA: open \`/map\` → pick a region with mixed content; recipe pins (rust) and story pins (teal) render and link out; unlocated items show in sidebar with correct count line
- [ ] Manual QA: open \`/calendar\` → Ramadan shows in February (2026), each lunar card has the italic "☾ On the lunar calendar: …" subline
- [ ] Manual QA: open \`/profile\` → \"Edit profile\" link routes to \`/profile/edit\`; edit fields, Save updates header; reload preserves changes