### PR TITLE
fix(frontend): paginated list endpoints fetch the full data set (#851)

### DIFF
--- a/app/frontend/src/__tests__/mapService.test.js
+++ b/app/frontend/src/__tests__/mapService.test.js
@@ -29,7 +29,7 @@ describe('fetchMapRegionContent', () => {
       data: { results: [{ id: 1, title: 'Item' }], next: null },
     });
     const result = await fetchMapRegionContent('tr');
-    expect(apiClient.get).toHaveBeenCalledWith('/api/map/regions/tr/content/');
+    expect(apiClient.get).toHaveBeenCalledWith('/api/map/regions/tr/content/', { params: { page_size: 100 } });
     expect(result).toEqual([{ id: 1, title: 'Item' }]);
   });
 
@@ -37,5 +37,18 @@ describe('fetchMapRegionContent', () => {
     apiClient.get.mockResolvedValue({ data: [{ id: 2 }] });
     const result = await fetchMapRegionContent('jp');
     expect(result).toEqual([{ id: 2 }]);
+  });
+});
+
+describe('fetchMapRegionContent — pagination cap (#851)', () => {
+  it('passes page_size=100', async () => {
+    apiClient.get.mockResolvedValue({ data: [{ id: 1 }] });
+    await fetchMapRegionContent(3);
+    expect(apiClient.get).toHaveBeenCalledWith('/api/map/regions/3/content/', { params: { page_size: 100 } });
+  });
+
+  it('unwraps DRF results', async () => {
+    apiClient.get.mockResolvedValue({ data: { count: 1, next: null, results: [{ id: 2 }] } });
+    expect(await fetchMapRegionContent(3)).toEqual([{ id: 2 }]);
   });
 });

--- a/app/frontend/src/__tests__/messageService.test.js
+++ b/app/frontend/src/__tests__/messageService.test.js
@@ -154,3 +154,34 @@ describe('markThreadRead', () => {
     expect(apiClient.post).toHaveBeenCalledWith('/api/threads/42/read/');
   });
 });
+
+describe('fetchMessages — cursor pagination (#851)', () => {
+  it('follows the cursor `next` link and concatenates all pages', async () => {
+    apiClient.get
+      .mockResolvedValueOnce({
+        data: {
+          results: [{ id: 1, body: 'hi',    created_at: '2026-05-01T00:00:00Z', sender: 1, sender_username: 'a' }],
+          next: 'https://api.example.com/api/threads/9/messages/?cursor=abc',
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          results: [{ id: 2, body: 'there', created_at: '2026-05-01T00:00:01Z', sender: 2, sender_username: 'b' }],
+          next: null,
+        },
+      });
+
+    const result = await fetchMessages(9);
+    expect(apiClient.get).toHaveBeenNthCalledWith(1, '/api/threads/9/messages/');
+    expect(apiClient.get).toHaveBeenNthCalledWith(2, '/api/threads/9/messages/?cursor=abc');
+    expect(result).toHaveLength(2);
+    expect(result.map((m) => m.id)).toEqual([1, 2]);
+  });
+
+  it('falls back to a single-page array response', async () => {
+    apiClient.get.mockResolvedValue({ data: [{ id: 5, body: 'hello', created_at: '2026-05-01T00:00:00Z', sender: 1, sender_username: 'a' }] });
+    const result = await fetchMessages(9);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe(5);
+  });
+});

--- a/app/frontend/src/__tests__/recipeService.test.js
+++ b/app/frontend/src/__tests__/recipeService.test.js
@@ -125,7 +125,7 @@ describe('fetchRecipes', () => {
   it('calls GET /api/recipes/ and returns data', async () => {
     apiClient.get.mockResolvedValue({ data: [{ id: 1, title: 'Baklava' }] });
     const result = await fetchRecipes();
-    expect(apiClient.get).toHaveBeenCalledWith('/api/recipes/');
+    expect(apiClient.get).toHaveBeenCalledWith('/api/recipes/', { params: { page_size: 100 } });
     expect(result).toEqual([{ id: 1, title: 'Baklava' }]);
   });
 });
@@ -285,7 +285,7 @@ describe('fetchMyRecipes', () => {
   it('GETs /api/recipes/?author=<id> and returns the list', async () => {
     apiClient.get.mockResolvedValue({ data: [{ id: 1, title: 'Mine' }] });
     const result = await fetchMyRecipes(42);
-    expect(apiClient.get).toHaveBeenCalledWith('/api/recipes/', { params: { author: 42 } });
+    expect(apiClient.get).toHaveBeenCalledWith('/api/recipes/', { params: { author: 42, page_size: 100 } });
     expect(result).toEqual([{ id: 1, title: 'Mine' }]);
   });
 
@@ -299,12 +299,36 @@ describe('fetchMyBookmarks', () => {
   it('GETs /api/recipes/?bookmarked=true and returns the list', async () => {
     apiClient.get.mockResolvedValue({ data: [{ id: 9, title: 'Saved' }] });
     const result = await fetchMyBookmarks();
-    expect(apiClient.get).toHaveBeenCalledWith('/api/recipes/', { params: { bookmarked: 'true' } });
+    expect(apiClient.get).toHaveBeenCalledWith('/api/recipes/', { params: { bookmarked: 'true', page_size: 100 } });
     expect(result).toEqual([{ id: 9, title: 'Saved' }]);
   });
 
   it('unwraps paginated DRF responses', async () => {
     apiClient.get.mockResolvedValue({ data: { results: [{ id: 10 }] } });
     expect(await fetchMyBookmarks()).toEqual([{ id: 10 }]);
+  });
+});
+
+describe('fetchRecipes — pagination cap (#851)', () => {
+  it('passes page_size=100 so the list endpoint returns a full page', async () => {
+    apiClient.get.mockResolvedValue({ data: { count: 1, next: null, results: [{ id: 1 }] } });
+    await fetchRecipes();
+    expect(apiClient.get).toHaveBeenCalledWith('/api/recipes/', { params: { page_size: 100 } });
+  });
+});
+
+describe('fetchMyRecipes — pagination cap (#851)', () => {
+  it('keeps author param and adds page_size=100', async () => {
+    apiClient.get.mockResolvedValue({ data: [{ id: 7 }] });
+    await fetchMyRecipes(42);
+    expect(apiClient.get).toHaveBeenCalledWith('/api/recipes/', { params: { author: 42, page_size: 100 } });
+  });
+});
+
+describe('fetchMyBookmarks — pagination cap (#851)', () => {
+  it('keeps bookmarked=true and adds page_size=100', async () => {
+    apiClient.get.mockResolvedValue({ data: [{ id: 9 }] });
+    await fetchMyBookmarks();
+    expect(apiClient.get).toHaveBeenCalledWith('/api/recipes/', { params: { bookmarked: 'true', page_size: 100 } });
   });
 });

--- a/app/frontend/src/__tests__/storyService.test.js
+++ b/app/frontend/src/__tests__/storyService.test.js
@@ -46,7 +46,7 @@ describe('storyService — new functions', () => {
   it('fetchStories calls GET /api/stories/ and returns data', async () => {
     apiClient.get.mockResolvedValue({ data: [{ id: 1, title: 'Test' }] });
     const result = await storyService.fetchStories();
-    expect(apiClient.get).toHaveBeenCalledWith('/api/stories/');
+    expect(apiClient.get).toHaveBeenCalledWith('/api/stories/', { params: { page_size: 100 } });
     expect(result).toEqual([{ id: 1, title: 'Test' }]);
   });
 
@@ -97,12 +97,28 @@ describe('fetchMyStories', () => {
   it('GETs /api/stories/?author=<id> and returns the list', async () => {
     apiClient.get.mockResolvedValue({ data: [{ id: 3, title: 'Mine' }] });
     const result = await fetchMyStories(42);
-    expect(apiClient.get).toHaveBeenCalledWith('/api/stories/', { params: { author: 42 } });
+    expect(apiClient.get).toHaveBeenCalledWith('/api/stories/', { params: { author: 42, page_size: 100 } });
     expect(result).toEqual([{ id: 3, title: 'Mine' }]);
   });
 
   it('unwraps paginated DRF responses', async () => {
     apiClient.get.mockResolvedValue({ data: { results: [{ id: 8 }] } });
     expect(await fetchMyStories(42)).toEqual([{ id: 8 }]);
+  });
+});
+
+describe('fetchStories — pagination cap (#851)', () => {
+  it('passes page_size=100', async () => {
+    apiClient.get.mockResolvedValue({ data: { count: 1, next: null, results: [{ id: 1 }] } });
+    await storyService.fetchStories();
+    expect(apiClient.get).toHaveBeenCalledWith('/api/stories/', { params: { page_size: 100 } });
+  });
+});
+
+describe('fetchMyStories — pagination cap (#851)', () => {
+  it('keeps author param and adds page_size=100', async () => {
+    apiClient.get.mockResolvedValue({ data: [{ id: 7 }] });
+    await fetchMyStories(42);
+    expect(apiClient.get).toHaveBeenCalledWith('/api/stories/', { params: { author: 42, page_size: 100 } });
   });
 });

--- a/app/frontend/src/services/mapService.js
+++ b/app/frontend/src/services/mapService.js
@@ -10,6 +10,6 @@ export async function fetchMapRegions() {
 }
 
 export async function fetchMapRegionContent(regionId) {
-  const response = await apiClient.get(`/api/map/regions/${regionId}/content/`);
+  const response = await apiClient.get(`/api/map/regions/${regionId}/content/`, { params: { page_size: 100 } });
   return response.data.results ?? response.data;
 }

--- a/app/frontend/src/services/messageService.js
+++ b/app/frontend/src/services/messageService.js
@@ -33,18 +33,25 @@ export async function fetchThreads() {
 
 export async function fetchMessages(threadId) {
   if (USE_MOCK) return [...(MOCK_MESSAGES[Number(threadId)] || [])];
-  const res = await apiClient.get(`/api/threads/${threadId}/messages/`);
-  const items = Array.isArray(res.data?.results) ? res.data.results : res.data;
-  const list = Array.isArray(items) ? items : [];
-  return list.map((message) => ({
-    id: message.id,
-    body: message.body,
-    createdAt: message.created_at,
-    sender: {
-      id: message.sender,
-      username: message.sender_username,
-    },
-  }));
+  const collected = [];
+  let path = `/api/threads/${threadId}/messages/`;
+  while (path) {
+    const res = await apiClient.get(path);
+    const data = res.data;
+    const pageItems = Array.isArray(data?.results) ? data.results : (Array.isArray(data) ? data : []);
+    for (const message of pageItems) {
+      collected.push({
+        id: message.id,
+        body: message.body,
+        createdAt: message.created_at,
+        sender: { id: message.sender, username: message.sender_username },
+      });
+    }
+    if (!data?.next || Array.isArray(data)) break;
+    const nextUrl = new URL(data.next);
+    path = `${nextUrl.pathname}${nextUrl.search}`;
+  }
+  return collected;
 }
 
 export async function sendMessage(threadId, body) {

--- a/app/frontend/src/services/recipeService.js
+++ b/app/frontend/src/services/recipeService.js
@@ -69,7 +69,7 @@ export async function submitUnit(name) {
 
 export async function fetchRecipes() {
   if (USE_MOCK) return MOCK_RECIPES_LIST;
-  const response = await apiClient.get('/api/recipes/');
+  const response = await apiClient.get('/api/recipes/', { params: { page_size: 100 } });
   return response.data.results ?? response.data;
 }
 
@@ -124,7 +124,7 @@ export async function toggleBookmark(id) {
  */
 export async function fetchMyRecipes(authorId) {
   if (USE_MOCK) return MOCK_RECIPES_LIST.filter((r) => r.author === authorId);
-  const response = await apiClient.get('/api/recipes/', { params: { author: authorId } });
+  const response = await apiClient.get('/api/recipes/', { params: { author: authorId, page_size: 100 } });
   return response.data.results ?? response.data;
 }
 
@@ -134,6 +134,6 @@ export async function fetchMyRecipes(authorId) {
  */
 export async function fetchMyBookmarks() {
   if (USE_MOCK) return [];
-  const response = await apiClient.get('/api/recipes/', { params: { bookmarked: 'true' } });
+  const response = await apiClient.get('/api/recipes/', { params: { bookmarked: 'true', page_size: 100 } });
   return response.data.results ?? response.data;
 }

--- a/app/frontend/src/services/storyService.js
+++ b/app/frontend/src/services/storyService.js
@@ -11,7 +11,7 @@ export async function fetchStory(id) {
 
 export async function fetchStories() {
   if (USE_MOCK) return MOCK_STORIES_LIST;
-  const response = await apiClient.get('/api/stories/');
+  const response = await apiClient.get('/api/stories/', { params: { page_size: 100 } });
   return response.data.results ?? response.data;
 }
 
@@ -55,6 +55,6 @@ export async function unpublishStory(id) {
  */
 export async function fetchMyStories(authorId) {
   if (USE_MOCK) return MOCK_STORIES_LIST.filter((s) => s.author === authorId);
-  const response = await apiClient.get('/api/stories/', { params: { author: authorId } });
+  const response = await apiClient.get('/api/stories/', { params: { author: authorId, page_size: 100 } });
   return response.data.results ?? response.data;
 }


### PR DESCRIPTION
Closes #851.

Six list-fetch services were silently capped at one DRF page; the visible symptom was \`/recipes\` showing 10 of 84 recipes in prod. No backend changes — fix is purely client-side.

## Changes

- **\`page_size=100\` stop-gap** on the simple single-shot calls — backend's \`max_page_size\` is 100 (map's class included), so this is the largest legal request:
  - \`recipeService.fetchRecipes\` / \`fetchMyRecipes\` / \`fetchMyBookmarks\`
  - \`storyService.fetchStories\` / \`fetchMyStories\`
  - \`mapService.fetchMapRegionContent\`
- **Cursor follow** for messages — \`/api/threads/<id>/messages/\` uses cursor pagination, where \`page_size\` doesn't apply. \`messageService.fetchMessages\` now walks \`response.data.next\` and concatenates pages, mirroring the existing pattern in \`commentService.fetchCommentsForRecipe\`.
- \`commentService.fetchCommentsForRecipe\` already followed \`next\` on \`main\` — not modified.

## Test plan
- [x] +9 new service tests (page_size assertions + cursor walk + array fallback)
- [x] Pre-existing service tests updated to assert the new param shape
- [ ] Manual QA: \`/recipes\` shows all seeded recipes (>10); \`/stories\` same; ProfilePage 'My recipes / My stories / Saved' uncapped; map region content uncapped; thread view shows the full message history.

## Follow-up (out of scope per issue)
\`page_size=100\` breaks again past 100 rows. Proper fix is a 'load more' UI on \`RecipeListPage\` / \`StoryListPage\` with a generic 'follow next' helper — tracked separately.