### PR TITLE
feat(frontend): collapsible chip groups + enable Story Type filter

### DIFF
--- a/app/frontend/src/__tests__/ChipGroup.test.jsx
+++ b/app/frontend/src/__tests__/ChipGroup.test.jsx
@@ -1,0 +1,81 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import ChipGroup from '../components/ChipGroup';
+
+function chips(count, prefix = 'item') {
+  return Array.from({ length: count }, (_, i) => (
+    <button key={`${prefix}-${i}`} type="button">{`${prefix}-${i}`}</button>
+  ));
+}
+
+describe('ChipGroup', () => {
+  it('renders all children and no toggle when items fit within visibleCount', () => {
+    render(
+      <ChipGroup label="Region" visibleCount={5}>
+        {chips(3)}
+      </ChipGroup>,
+    );
+    expect(screen.getByText('Region')).toBeInTheDocument();
+    expect(screen.getAllByRole('button')).toHaveLength(3);
+    expect(screen.queryByRole('button', { name: /more|less/i })).toBeNull();
+  });
+
+  it('hides overflow chips and shows "+ N more" toggle when items exceed visibleCount', () => {
+    render(
+      <ChipGroup label="Region" visibleCount={3}>
+        {chips(10)}
+      </ChipGroup>,
+    );
+    expect(screen.queryByText('item-0')).toBeInTheDocument();
+    expect(screen.queryByText('item-2')).toBeInTheDocument();
+    expect(screen.queryByText('item-3')).toBeNull();
+    expect(screen.queryByText('item-9')).toBeNull();
+    expect(
+      screen.getByRole('button', { name: /Show 7 more Region/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('expands to show all chips when toggle is clicked, then collapses again', () => {
+    render(
+      <ChipGroup label="Region" visibleCount={2}>
+        {chips(6)}
+      </ChipGroup>,
+    );
+    const toggleExpand = screen.getByRole('button', { name: /Show 4 more Region/i });
+    fireEvent.click(toggleExpand);
+
+    expect(screen.getByText('item-5')).toBeInTheDocument();
+
+    const toggleCollapse = screen.getByRole('button', { name: /Show fewer Region/i });
+    expect(toggleCollapse).toHaveAttribute('aria-expanded', 'true');
+    fireEvent.click(toggleCollapse);
+
+    expect(screen.queryByText('item-5')).toBeNull();
+    expect(
+      screen.getByRole('button', { name: /Show 4 more Region/i }),
+    ).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('renders an optional icon next to the label', () => {
+    const { container } = render(
+      <ChipGroup label="Region" icon="🌍" visibleCount={5}>
+        {chips(2)}
+      </ChipGroup>,
+    );
+    expect(container.querySelector('.chip-group-icon')).not.toBeNull();
+    expect(container.querySelector('.chip-group-icon')).toHaveTextContent('🌍');
+  });
+
+  it('starts collapsed once async children arrive past the visibleCount', () => {
+    const { rerender } = render(
+      <ChipGroup label="Region" visibleCount={3}>{chips(0)}</ChipGroup>,
+    );
+    // Async load lands a moment later
+    rerender(
+      <ChipGroup label="Region" visibleCount={3}>{chips(10)}</ChipGroup>,
+    );
+    expect(screen.queryByText('item-9')).toBeNull();
+    expect(
+      screen.getByRole('button', { name: /Show 7 more Region/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/app/frontend/src/__tests__/HomePage.test.jsx
+++ b/app/frontend/src/__tests__/HomePage.test.jsx
@@ -66,17 +66,18 @@ describe('HomePage', () => {
     expect(screen.getByRole('button', { name: 'Soup' })).toBeInTheDocument();
   });
 
-  it('navigates to /search with region and meal_type on submit', async () => {
+  it('navigates to /search with region, meal_type and story_type on submit', async () => {
     renderPage();
     await waitFor(() => screen.getByRole('button', { name: 'Aegean' }));
 
     fireEvent.change(screen.getByRole('searchbox'), { target: { value: 'baklava' } });
     fireEvent.click(screen.getByRole('button', { name: 'Aegean' }));
     fireEvent.click(screen.getByRole('button', { name: 'Soup' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Family' }));
     fireEvent.click(screen.getByRole('button', { name: /^search$/i }));
 
     expect(mockNavigate).toHaveBeenCalledWith(
-      '/search?q=baklava&region=Aegean&meal_type=Soup'
+      '/search?q=baklava&region=Aegean&meal_type=Soup&story_type=family'
     );
   });
 
@@ -84,8 +85,16 @@ describe('HomePage', () => {
     renderPage();
     fireEvent.click(screen.getByRole('button', { name: /^search$/i }));
     expect(mockNavigate).toHaveBeenCalledWith(
-      '/search?q=&region=&meal_type='
+      '/search?q=&region=&meal_type=&story_type='
     );
+  });
+
+  it('renders Story Type chips that are enabled and clickable', () => {
+    renderPage();
+    const familyChip = screen.getByRole('button', { name: 'Family' });
+    expect(familyChip).toBeEnabled();
+    fireEvent.click(familyChip);
+    expect(familyChip.className).toMatch(/active/);
   });
 
   it('shows onboarding nudge for logged-in users without onboarding data', () => {

--- a/app/frontend/src/__tests__/SearchPage.test.jsx
+++ b/app/frontend/src/__tests__/SearchPage.test.jsx
@@ -84,6 +84,27 @@ describe('SearchPage', () => {
     expect(screen.queryByText('Yogurt Salad')).not.toBeInTheDocument();
   });
 
+  it('applies story_type client-side to filter story results only', async () => {
+    searchService.search.mockResolvedValue([
+      { type: 'recipe', id: 1, title: 'Yogurt Soup', region: 'Black Sea', thumbnail: null },
+      { type: 'story',  id: 2, title: 'Family Feast',  region: 'Aegean', story_type: 'family', thumbnail: null },
+      { type: 'story',  id: 3, title: 'Old Customs',   region: 'Aegean', story_type: 'traditional', thumbnail: null },
+    ]);
+    renderPage('?q=&region=&ingredient=&meal_type=&story_type=family');
+    await waitFor(() => screen.getByText('Family Feast'));
+    expect(screen.getByText('Family Feast')).toBeInTheDocument();
+    expect(screen.queryByText('Old Customs')).not.toBeInTheDocument();
+    // Recipes are unaffected by story_type.
+    expect(screen.getByText('Yogurt Soup')).toBeInTheDocument();
+  });
+
+  it('renders a story_type active-filter chip when the URL carries one', async () => {
+    searchService.search.mockResolvedValue([]);
+    renderPage('?q=&region=&ingredient=&meal_type=&story_type=festive');
+    await waitFor(() => screen.getByText(/no results/i));
+    expect(screen.getByText(/story type: festive/i)).toBeInTheDocument();
+  });
+
   it('shows active filter chips for non-empty filters', async () => {
     searchService.search.mockResolvedValue([]);
     renderPage('?q=&region=Aegean&ingredient=yogurt&meal_type=');

--- a/app/frontend/src/components/ChipGroup.css
+++ b/app/frontend/src/components/ChipGroup.css
@@ -1,0 +1,35 @@
+.chip-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.chip-group-icon {
+  font-size: 0.95rem;
+  margin-right: 0.1rem;
+}
+
+.chip-group-toggle {
+  background: transparent;
+  border: 1.5px dashed var(--color-border);
+  border-radius: var(--radius-pill);
+  padding: 0.3rem 0.85rem;
+  font-size: 0.8125rem;
+  font-weight: 700;
+  color: var(--color-primary);
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease, color 0.15s ease;
+  font-family: inherit;
+  letter-spacing: 0.02em;
+}
+
+.chip-group-toggle:hover {
+  border-color: var(--color-primary);
+  background: rgba(196, 82, 30, 0.08);
+}
+
+.chip-group-toggle:focus-visible {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: var(--shadow-focus);
+}

--- a/app/frontend/src/components/ChipGroup.jsx
+++ b/app/frontend/src/components/ChipGroup.jsx
@@ -1,0 +1,50 @@
+import { Children, useMemo, useState } from 'react';
+import './ChipGroup.css';
+
+export default function ChipGroup({
+  label,
+  icon,
+  visibleCount = 12,
+  children,
+  className = '',
+  labelClassName = 'chip-group-label',
+  itemsClassName = 'chip-group-items',
+}) {
+  const childArray = useMemo(
+    () => Children.toArray(children).filter(Boolean),
+    [children],
+  );
+  const total = childArray.length;
+  const overflowing = total > visibleCount;
+
+  const [userToggle, setUserToggle] = useState(null);
+  const expanded = userToggle === null ? !overflowing : userToggle;
+
+  const visibleChildren = expanded ? childArray : childArray.slice(0, visibleCount);
+  const hiddenCount = total - visibleCount;
+
+  return (
+    <div className={`chip-group ${className}`.trim()}>
+      <span className={labelClassName}>
+        {icon ? (
+          <span className="chip-group-icon" aria-hidden="true">{icon}</span>
+        ) : null}
+        {label}
+      </span>
+      <div className={itemsClassName}>
+        {visibleChildren}
+        {overflowing ? (
+          <button
+            type="button"
+            className="chip-group-toggle"
+            onClick={() => setUserToggle(!expanded)}
+            aria-expanded={expanded}
+            aria-label={expanded ? `Show fewer ${label}` : `Show ${hiddenCount} more ${label}`}
+          >
+            {expanded ? 'Show less ▴' : `+ ${hiddenCount} more ▾`}
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/app/frontend/src/components/FloatingCulturalPrompt.jsx
+++ b/app/frontend/src/components/FloatingCulturalPrompt.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { Link } from 'react-router-dom';
 import { fetchRegionStories } from '../services/culturalContentService';
+import ChipGroup from './ChipGroup';
 import './FloatingCulturalPrompt.css';
 
 const PROMPTS = [
@@ -124,7 +125,13 @@ export default function FloatingCulturalPrompt({ regions }) {
       <div className="floating-prompt" role="complementary" aria-label="Cultural discovery prompt">
         <button className="floating-prompt-close" onClick={handleDismiss} aria-label="Dismiss">×</button>
         <p className="floating-prompt-question">{prompt.question}</p>
-        <div className="floating-prompt-chips">
+        <ChipGroup
+          label=""
+          visibleCount={8}
+          className="floating-prompt-chip-group"
+          labelClassName="sr-only"
+          itemsClassName="floating-prompt-chips"
+        >
           {regions.map((r) => (
             <button
               key={r.id}
@@ -134,7 +141,7 @@ export default function FloatingCulturalPrompt({ regions }) {
               {r.name}
             </button>
           ))}
-        </div>
+        </ChipGroup>
       </div>
 
       {modalOpen && (

--- a/app/frontend/src/pages/HomePage.jsx
+++ b/app/frontend/src/pages/HomePage.jsx
@@ -3,6 +3,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import { AuthContext } from '../context/AuthContext';
 import { fetchRegions } from '../services/searchService';
 import { fetchDailyCulturalContent } from '../services/culturalContentService';
+import ChipGroup from '../components/ChipGroup';
 import DailyCulturalSection from '../components/DailyCulturalSection';
 import FloatingCulturalPrompt from '../components/FloatingCulturalPrompt';
 import RandomCulturalFact from '../components/RandomCulturalFact';
@@ -10,7 +11,15 @@ import useKeyboardShortcuts from '../hooks/useKeyboardShortcuts';
 import './HomePage.css';
 
 const MEAL_TYPES = ['Breakfast', 'Soup', 'Main Course', 'Dessert', 'Snack', 'Drink'];
-const STORY_TYPES = ['Traditional', 'Historical', 'Family', 'Festive', 'Personal'];
+// Display labels paired with API slugs (matches Story.StoryType choices on the
+// backend — see app/backend/apps/stories/models.py).
+const STORY_TYPES = [
+  { label: 'Traditional', value: 'traditional' },
+  { label: 'Historical', value: 'historical' },
+  { label: 'Family', value: 'family' },
+  { label: 'Festive', value: 'festive' },
+  { label: 'Personal', value: 'personal' },
+];
 
 export default function HomePage() {
   const auth = useContext(AuthContext) || {};
@@ -64,7 +73,10 @@ export default function HomePage() {
   function handleSubmit(e) {
     e.preventDefault();
     navigate(
-      `/search?q=${encodeURIComponent(q)}&region=${encodeURIComponent(selectedRegion)}&meal_type=${encodeURIComponent(selectedMealType)}`
+      `/search?q=${encodeURIComponent(q)}` +
+      `&region=${encodeURIComponent(selectedRegion)}` +
+      `&meal_type=${encodeURIComponent(selectedMealType)}` +
+      `&story_type=${encodeURIComponent(selectedStoryType)}`
     );
   }
 
@@ -112,56 +124,63 @@ export default function HomePage() {
         </div>
 
         <div className="home-chip-filters">
-          <div className="home-chip-group">
-            <span className="home-chip-label">Region</span>
-            <div className="home-chips">
-              {regions.map((r) => (
-                <button
-                  key={r.id}
-                  type="button"
-                  className={`home-chip${selectedRegion === r.name ? ' active' : ''}`}
-                  onClick={() => setSelectedRegion(selectedRegion === r.name ? '' : r.name)}
-                >
-                  {r.name}
-                </button>
-              ))}
-            </div>
-          </div>
+          <ChipGroup
+            label="Region"
+            icon="🌍"
+            visibleCount={12}
+            className="home-chip-group"
+            labelClassName="home-chip-label"
+            itemsClassName="home-chips"
+          >
+            {regions.map((r) => (
+              <button
+                key={r.id}
+                type="button"
+                className={`home-chip${selectedRegion === r.name ? ' active' : ''}`}
+                onClick={() => setSelectedRegion(selectedRegion === r.name ? '' : r.name)}
+              >
+                {r.name}
+              </button>
+            ))}
+          </ChipGroup>
 
-          <div className="home-chip-group">
-            <span className="home-chip-label">Meal Type</span>
-            <div className="home-chips">
-              {MEAL_TYPES.map((m) => (
-                <button
-                  key={m}
-                  type="button"
-                  className={`home-chip${selectedMealType === m ? ' active' : ''}`}
-                  onClick={() => setSelectedMealType(selectedMealType === m ? '' : m)}
-                >
-                  {m}
-                </button>
-              ))}
-            </div>
-          </div>
+          <ChipGroup
+            label="Meal Type"
+            icon="🍽"
+            className="home-chip-group"
+            labelClassName="home-chip-label"
+            itemsClassName="home-chips"
+          >
+            {MEAL_TYPES.map((m) => (
+              <button
+                key={m}
+                type="button"
+                className={`home-chip${selectedMealType === m ? ' active' : ''}`}
+                onClick={() => setSelectedMealType(selectedMealType === m ? '' : m)}
+              >
+                {m}
+              </button>
+            ))}
+          </ChipGroup>
 
-          <div className="home-chip-group">
-            <span className="home-chip-label">
-              Story Type <span className="chip-soon">coming soon</span>
-            </span>
-            <div className="home-chips">
-              {STORY_TYPES.map((s) => (
-                <button
-                  key={s}
-                  type="button"
-                  className={`home-chip${selectedStoryType === s ? ' active' : ''}`}
-                  onClick={() => setSelectedStoryType(selectedStoryType === s ? '' : s)}
-                  disabled
-                >
-                  {s}
-                </button>
-              ))}
-            </div>
-          </div>
+          <ChipGroup
+            label="Story Type"
+            icon="📜"
+            className="home-chip-group"
+            labelClassName="home-chip-label"
+            itemsClassName="home-chips"
+          >
+            {STORY_TYPES.map((s) => (
+              <button
+                key={s.value}
+                type="button"
+                className={`home-chip${selectedStoryType === s.value ? ' active' : ''}`}
+                onClick={() => setSelectedStoryType(selectedStoryType === s.value ? '' : s.value)}
+              >
+                {s.label}
+              </button>
+            ))}
+          </ChipGroup>
         </div>
       </form>
 

--- a/app/frontend/src/pages/SearchPage.jsx
+++ b/app/frontend/src/pages/SearchPage.jsx
@@ -58,6 +58,7 @@ export default function SearchPage() {
   const event = searchParams.get('event') || '';
   const eventExclude = searchParams.get('event_exclude') || '';
   const mealType = searchParams.get('meal_type') || '';
+  const storyType = searchParams.get('story_type') || '';
   const language = searchParams.get('language') || '';
 
   const [localQ, setLocalQ] = useState(q);
@@ -129,11 +130,24 @@ export default function SearchPage() {
     ].some((list) => Array.isArray(list) && list.length > 0);
   }, [user]);
 
-  const displayResults = mealType.trim()
-    ? results.filter((r) =>
-        r.title.toLowerCase().includes(mealType.toLowerCase())
-      )
-    : results;
+  // Client-side filters that complement the backend search:
+  //   * meal_type — Recipe.meal_type is not yet a backend field; we fall back to
+  //     a title substring match. Tracked in #849 (backend will add the field
+  //     and the same filter at the API layer).
+  //   * story_type — Story.story_type exists on the backend but the unified
+  //     /api/search/ endpoint does not yet pass the query param through (also
+  //     #849). Filter story results by story_type here until backend lands.
+  // Recipes are never filtered out by story_type, stories are never filtered
+  // out by meal_type — each filter only applies to its own content type.
+  const displayResults = results.filter((r) => {
+    if (mealType.trim() && r.type === 'recipe') {
+      if (!r.title.toLowerCase().includes(mealType.toLowerCase())) return false;
+    }
+    if (storyType.trim() && r.type === 'story') {
+      if ((r.story_type || '').toLowerCase() !== storyType.toLowerCase()) return false;
+    }
+    return true;
+  });
 
   function removeFilter(paramKey) {
     const next = new URLSearchParams(searchParams);
@@ -149,6 +163,7 @@ export default function SearchPage() {
     event && { label: `Event+: ${event}`, key: 'event' },
     eventExclude && { label: `Event-: ${eventExclude}`, key: 'event_exclude' },
     mealType && { label: `Meal type: ${mealType}`, key: 'meal_type' },
+    storyType && { label: `Story type: ${storyType}`, key: 'story_type' },
     region && { label: `Region: ${region}`, key: 'region' },
   ].filter(Boolean);
 
@@ -183,7 +198,9 @@ export default function SearchPage() {
       `&diet_exclude=${encodeURIComponent(formatCsv(localDietExclude))}` +
       `&event=${encodeURIComponent(formatCsv(localEventInclude))}` +
       `&event_exclude=${encodeURIComponent(formatCsv(localEventExclude))}` +
-      `&meal_type=${encodeURIComponent(localMealType)}&language=${encodeURIComponent(language)}`
+      `&meal_type=${encodeURIComponent(localMealType)}` +
+      `&story_type=${encodeURIComponent(storyType)}` +
+      `&language=${encodeURIComponent(language)}`
     );
   }
 


### PR DESCRIPTION
## Summary

- **HomePage hero search filters**: Region / Meal Type / Story Type chip rows overflowed with all ~40 regions, pushing the group labels and the search button out of view. Replaced inline chip rendering with a new reusable `ChipGroup` that shows the first N chips and tucks the rest behind a `+ N more ▾` / `Show less ▴` pill. Region defaults to 12 visible, the smaller groups render in full. Subtle cultural-vibe icon next to each label (🌍 Region, 🍽 Meal Type, 📜 Story Type).
- **Story Type filter**: chips were hard-coded `disabled` with a "coming soon" label. Removed the disable + label and wired the chips to actual backend slugs (`traditional`, `historical`, `family`, `festive`, `personal` — matching `Story.StoryType.choices`). HomePage submit URL now carries `&story_type=…`.
- **FloatingCulturalPrompt**: the floating discovery card on scroll also dumped every region as a chip, pushing its prompt question off-screen. Same `ChipGroup` wrap with `visibleCount=8` so the question stays visible.
- **SearchPage**: reads `story_type` from the URL, filters story rows client-side (recipes are not touched — each filter applies only to its own content type), surfaces a `Story type: <slug>` pill in the active-filter row, and threads `story_type` through the refine-form submit URL.
- **Backend coordination**: client-side `meal_type` (title-substring) and `story_type` filters are explicitly marked as workarounds for #849. Once that backend issue lands (`Recipe.meal_type` field + `meal_type`/`story_type` query params on the unified `/api/search/` endpoint), a small follow-up PR will delete both client-side filters and pass the query params straight through.

## Test plan

- [ ] Open the home page on a wide window — Region chips collapse to one wrapped row with a `+ N more ▾` pill at the end; clicking it expands the full grid and the pill toggles to `Show less ▴`.
- [ ] Repeat on a narrower window — the row count is governed by `flex-wrap`, the pill always sits at the trailing edge.
- [ ] Click a Story Type chip (e.g. `Family`) → chip becomes active; submit and verify the URL is `/search?q=&region=&meal_type=&story_type=family`.
- [ ] On `/search?...&story_type=family` with mixed recipe + story results, only family-typed stories remain; recipes are unaffected.
- [ ] The active-filter row on SearchPage shows a `Story type: family ×` pill — clicking the × clears the param.
- [ ] Scroll past 300px on the home page → FloatingCulturalPrompt card appears with prompt question on top and region chips below; with many regions the chips collapse to 8 + a `+ N more ▾` pill, question stays visible.
- [ ] `cd app/frontend && CI=true npm test -- --watchAll=false` — 82 suites / 693 tests pass.

Coordinated with backend work tracked in #849 (adds `Recipe.meal_type` and wires `meal_type`/`story_type` through `/api/search/`). This PR ships the FE-only changes today so the UI is usable; a follow-up FE PR will remove the client-side filter shims once #849 ships.