### PR TITLE
feat(frontend): inline action buttons and fix save-as-draft on recipe/story forms (#857)

### DIFF
--- a/app/frontend/src/__tests__/RecipeCreatePage.test.jsx
+++ b/app/frontend/src/__tests__/RecipeCreatePage.test.jsx
@@ -128,6 +128,30 @@ describe('RecipeCreatePage', () => {
     );
   });
 
+  it('saves draft with only a title — no description or ingredients required', async () => {
+    recipeService.createRecipe.mockResolvedValue({ id: 3 });
+    renderPage();
+    await waitFor(() => screen.getByLabelText(/title/i));
+    fireEvent.change(screen.getByLabelText(/title/i), { target: { value: 'Incomplete Draft' } });
+    fireEvent.click(screen.getByRole('button', { name: /save as draft/i }));
+    await waitFor(() =>
+      expect(screen.getByText(/draft saved/i)).toBeInTheDocument()
+    );
+    expect(recipeService.createRecipe).toHaveBeenCalledWith(
+      expect.objectContaining({ is_published: false, title: 'Incomplete Draft' })
+    );
+  });
+
+  it('draft save still rejects invalid ingredient amount', async () => {
+    renderPage();
+    await waitFor(() => screen.getByPlaceholderText('Amount'));
+    fireEvent.change(screen.getByLabelText(/title/i), { target: { value: 'Draft' } });
+    fireEvent.change(screen.getByPlaceholderText('Amount'), { target: { value: '-5' } });
+    fireEvent.click(screen.getByRole('button', { name: /save as draft/i }));
+    expect(screen.getByText(/amount must be a positive number/i)).toBeInTheDocument();
+    expect(recipeService.createRecipe).not.toHaveBeenCalled();
+  });
+
   it('shows error toast when API call fails', async () => {
     recipeService.createRecipe.mockRejectedValue(new Error('Server error'));
     renderPage();

--- a/app/frontend/src/__tests__/StoryCreatePage.test.jsx
+++ b/app/frontend/src/__tests__/StoryCreatePage.test.jsx
@@ -85,6 +85,13 @@ describe('StoryCreatePage', () => {
     expect(fd.get('is_published')).toBe('false');
   });
 
+  it('renders hint text below action buttons', async () => {
+    renderPage();
+    expect(
+      screen.getByText(/drafts stay private to you\. published stories are visible to everyone\./i)
+    ).toBeInTheDocument();
+  });
+
   it('navigates to story detail page after successful submission', async () => {
     renderPage();
     fireEvent.change(screen.getByLabelText(/title/i), { target: { value: 'My Story' } });

--- a/app/frontend/src/pages/RecipeCreatePage.css
+++ b/app/frontend/src/pages/RecipeCreatePage.css
@@ -168,8 +168,15 @@
   margin-top: 0.5rem;
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
+  align-items: flex-end;
   gap: 0.75rem;
+}
+
+.recipe-form-actions-buttons {
+  display: flex;
+  flex-direction: row;
+  gap: 0.75rem;
+  align-items: center;
 }
 
 .publish-btn {

--- a/app/frontend/src/pages/RecipeCreatePage.jsx
+++ b/app/frontend/src/pages/RecipeCreatePage.jsx
@@ -139,25 +139,27 @@ export default function RecipeCreatePage() {
     return newUnit;
   }, []);
 
-  function validate() {
+  function validate(publish) {
     const e = {};
     if (!title.trim()) e.title = 'Title is required.';
-    if (!description.trim() && !video) e.content = 'A description or video is required.';
+    if (publish) {
+      if (!description.trim() && !video) e.content = 'A description or video is required.';
+      const filledRows = rows.filter((r) => r.ingredientId && r.amount && r.unitId);
+      if (filledRows.length === 0) e.ingredients = 'Please add at least one ingredient with an amount.';
+    }
     for (const row of rows) {
       if (row.amount !== '' && (isNaN(Number(row.amount)) || Number(row.amount) <= 0)) {
         e.amount = 'Amount must be a positive number.';
         break;
       }
     }
-    const filledRows = rows.filter((r) => r.ingredientId && r.amount && r.unitId);
-    if (filledRows.length === 0) e.ingredients = 'Please add at least one ingredient with an amount.';
     setErrors(e);
     return Object.keys(e).length === 0;
   }
 
   async function submit(publish) {
     if (submitting) return;
-    if (!validate()) {
+    if (!validate(publish)) {
       document.getElementById('error-summary')?.focus();
       return;
     }
@@ -411,22 +413,24 @@ export default function RecipeCreatePage() {
         </section>
 
         <div className="recipe-form-actions">
-          <button
-            type="button"
-            className="btn btn-outline"
-            disabled={submitting}
-            onClick={() => submit(false)}
-          >
-            Save as draft
-          </button>
-          <button
-            type="button"
-            className="btn btn-primary publish-btn"
-            disabled={submitting}
-            onClick={() => submit(true)}
-          >
-            {submitting ? 'Publishing…' : 'Publish Recipe'}
-          </button>
+          <div className="recipe-form-actions-buttons">
+            <button
+              type="button"
+              className="btn btn-outline"
+              disabled={submitting}
+              onClick={() => submit(false)}
+            >
+              Save as draft
+            </button>
+            <button
+              type="button"
+              className="btn btn-primary publish-btn"
+              disabled={submitting}
+              onClick={() => submit(true)}
+            >
+              {submitting ? 'Publishing…' : 'Publish Recipe'}
+            </button>
+          </div>
           <p className="publish-note">
             Drafts stay private to you. Published recipes are visible to everyone.
           </p>

--- a/app/frontend/src/pages/StoryCreatePage.css
+++ b/app/frontend/src/pages/StoryCreatePage.css
@@ -78,4 +78,15 @@
 .story-form-actions {
   border-top: 1.5px solid var(--color-border);
   padding-top: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.75rem;
+}
+
+.story-form-actions-buttons {
+  display: flex;
+  flex-direction: row;
+  gap: 0.75rem;
+  align-items: center;
 }

--- a/app/frontend/src/pages/StoryCreatePage.jsx
+++ b/app/frontend/src/pages/StoryCreatePage.jsx
@@ -179,22 +179,27 @@ export default function StoryCreatePage() {
         </section>
 
         <div className="story-form-actions">
-          <button
-            type="button"
-            className="btn btn-outline"
-            disabled={submitting}
-            onClick={() => submit(false)}
-          >
-            Save as draft
-          </button>
-          <button
-            type="button"
-            className="btn btn-primary"
-            disabled={submitting}
-            onClick={() => submit(true)}
-          >
-            {submitting ? 'Publishing…' : 'Publish Story'}
-          </button>
+          <div className="story-form-actions-buttons">
+            <button
+              type="button"
+              className="btn btn-outline"
+              disabled={submitting}
+              onClick={() => submit(false)}
+            >
+              Save as draft
+            </button>
+            <button
+              type="button"
+              className="btn btn-primary"
+              disabled={submitting}
+              onClick={() => submit(true)}
+            >
+              {submitting ? 'Publishing…' : 'Publish Story'}
+            </button>
+          </div>
+          <p className="publish-note">
+            Drafts stay private to you. Published stories are visible to everyone.
+          </p>
         </div>
       </form>
 


### PR DESCRIPTION
## Summary

RecipeCreatePage: \"Save as draft\" and \"Publish Recipe\" buttons were stacked vertically on the left. Moved them inline (side by side), right-aligned, with a hint text below (\"Drafts stay private to you. Published recipes are visible to everyone.\"). Draft save validation relaxed to require only a title — description and ingredients are no longer required to save a partial draft.

StoryCreatePage: Same button layout applied for visual consistency. Added matching hint text (\"Drafts stay private to you. Published stories are visible to everyone.\").

Closes #857

## Test plan

 - [ ] `/recipes/new` — buttons appear side by side, right-aligned
 - [ ] `/recipes/new` — click \"Save as draft\" with only a title filled in → draft saves without validation errors
 - [ ] `/recipes/new` — fill all fields, click \"Publish Recipe\" → publishes normally
 - [ ] `/stories/new` — buttons appear side by side, right-aligned with hint text below
 - [ ] `/stories/new` — click \"Save as draft\" with title + body → draft saves
 - [ ] Both pages: hint text visible below buttons