### PR TITLE
fix(frontend): resolve more lunar events on the cultural calendar

### DIFF
--- a/app/frontend/src/__tests__/CalendarPage.test.jsx
+++ b/app/frontend/src/__tests__/CalendarPage.test.jsx
@@ -139,4 +139,31 @@ describe('CalendarPage — lunar resolution + subline (#669)', () => {
     expect(container.querySelectorAll('.calendar-event-badge.is-lunar').length).toBeGreaterThan(0);
     expect(container.querySelectorAll('.calendar-event-badge:not(.is-lunar)').length).toBeGreaterThan(0);
   });
+
+  it('resolves backend snake_case slugs (eid_al_adha) the same as kebab-case', async () => {
+    culturalEventService.fetchCulturalEvents.mockResolvedValue([
+      { id: 6, name: 'Eid al-Adha', date_rule: 'lunar:eid_al_adha', region: { id: 1, name: 'All Regions' }, description: '', recipes: [] },
+    ]);
+    renderPage();
+    expect(await screen.findByText(/on the lunar calendar/i)).toBeInTheDocument();
+    // (movable) only appears when unresolved; with the table entry it must NOT appear.
+    expect(screen.queryByText(/\(movable\)/i)).not.toBeInTheDocument();
+  });
+
+  it('resolves Diwali (newly added to the lookup) instead of marking it movable', async () => {
+    culturalEventService.fetchCulturalEvents.mockResolvedValue([
+      { id: 7, name: 'Diwali', date_rule: 'lunar:diwali', region: { id: 1, name: 'Indian' }, description: '', recipes: [] },
+    ]);
+    renderPage();
+    expect(await screen.findByText(/on the lunar calendar/i)).toBeInTheDocument();
+    expect(screen.queryByText(/\(movable\)/i)).not.toBeInTheDocument();
+  });
+
+  it('shows the pretty event name in the subline rather than the raw slug', async () => {
+    culturalEventService.fetchCulturalEvents.mockResolvedValue([
+      { id: 8, name: 'Eid al-Adha', date_rule: 'lunar:eid_al_adha', region: { id: 1, name: 'All Regions' }, description: '', recipes: [] },
+    ]);
+    renderPage();
+    expect(await screen.findByText(/On the lunar calendar: Eid al-Adha this year/i)).toBeInTheDocument();
+  });
 });

--- a/app/frontend/src/pages/CalendarPage.jsx
+++ b/app/frontend/src/pages/CalendarPage.jsx
@@ -13,16 +13,27 @@ const MONTHS = [
 const LUNAR_PRETTY = {
   'ramadan': 'Ramadan',
   'eid-fitr': 'Eid al-Fitr',
+  'eid-al-fitr': 'Eid al-Fitr',
   'eid-adha': 'Eid al-Adha',
+  'eid-al-adha': 'Eid al-Adha',
   'kurban-bayrami': 'Eid al-Adha',
   'mevlid': 'Mevlid',
   'ashura': 'Ashura',
+  'diwali': 'Diwali',
+  'chuseok': 'Chuseok',
+  'carnaval': 'Carnaval',
+  'chinese-new-year': 'Chinese New Year',
+  'lunar-new-year': 'Lunar New Year',
+  'chunjie': 'Lunar New Year',
+  'homowo': 'Homowo',
+  'maslenitsa': 'Maslenitsa',
 };
 
 function prettyLunar(slug) {
   if (!slug) return '';
-  if (LUNAR_PRETTY[slug]) return LUNAR_PRETTY[slug];
-  return slug.split('-').map((p) => p.charAt(0).toUpperCase() + p.slice(1)).join(' ');
+  const normalized = slug.toLowerCase().replace(/_/g, '-');
+  if (LUNAR_PRETTY[normalized]) return LUNAR_PRETTY[normalized];
+  return normalized.split('-').map((p) => p.charAt(0).toUpperCase() + p.slice(1)).join(' ');
 }
 
 function ruleFromEvent(event) {

--- a/app/frontend/src/services/calendarService.js
+++ b/app/frontend/src/services/calendarService.js
@@ -7,17 +7,35 @@ const USE_MOCK = process.env.REACT_APP_USE_MOCK === 'true';
 export const LUNAR_YEARLY = {
   2024: { ramadan: { month: 2, day: 10 }, 'eid-fitr': { month: 3, day: 10 }, 'eid-adha': { month: 5, day: 16 }, mevlid: { month: 9, day: 15 }, ashura: { month: 7, day: 17 } },
   2025: { ramadan: { month: 2, day: 28 }, 'eid-fitr': { month: 3, day: 30 }, 'eid-adha': { month: 5, day: 6 }, mevlid: { month: 9, day: 4 }, ashura: { month: 7, day: 5 } },
-  2026: { ramadan: { month: 2, day: 17 }, 'eid-fitr': { month: 3, day: 19 }, 'eid-adha': { month: 4, day: 26 }, mevlid: { month: 8, day: 24 }, ashura: { month: 6, day: 24 } },
+  2026: {
+    ramadan: { month: 2, day: 17 },
+    'eid-fitr': { month: 3, day: 19 },
+    'eid-al-fitr': { month: 3, day: 19 },
+    'eid-adha': { month: 5, day: 27 },
+    'eid-al-adha': { month: 5, day: 27 },
+    mevlid: { month: 8, day: 24 },
+    ashura: { month: 6, day: 24 },
+    diwali: { month: 11, day: 8 },
+    chuseok: { month: 9, day: 25 },
+    carnaval: { month: 2, day: 17 },
+    'chinese-new-year': { month: 2, day: 17 },
+    'lunar-new-year': { month: 2, day: 17 },
+    chunjie: { month: 2, day: 17 },
+    homowo: { month: 8, day: 30 },
+    maslenitsa: { month: 2, day: 16 },
+  },
 };
 
 
 // Extracts month index (0-based) and day from a date_rule string.
 // date_rule formats: "YYYY-MM-DD", "MM-DD", "lunar:ramadan", etc.
+// Lunar slugs are normalized (lowercased, `_` → `-`) before lookup so that
+// snake_case payloads from the backend (e.g. `lunar:eid_al_adha`) resolve.
 export function parseEventDate(rule) {
   if (!rule) return null;
 
   if (rule.startsWith('lunar:')) {
-    const lunarName = rule.replace('lunar:', '');
+    const lunarName = rule.replace('lunar:', '').toLowerCase().replace(/_/g, '-');
     const year = new Date().getFullYear();
     const yearTable = LUNAR_YEARLY[year];
     if (yearTable && yearTable[lunarName]) {


### PR DESCRIPTION
Follow-up to #669 — the Lunar / movable feasts panel was marking too many events as \`(movable)\`. Two root causes, both client-side.

## Causes

1. **Snake_case mismatch.** Backend ships slugs like \`lunar:eid_al_adha\` / \`lunar:eid_al_fitr\` / \`lunar:chinese_new_year\` but the lookup table keyed events kebab-case. The lookup missed and the UI fell back to \`(movable)\`. The italic subline also rendered the raw slug (\"Eid_al_adha this year\") because \`prettyLunar\` only split on \`-\`.
2. **Missing 2026 entries.** Diwali, Chuseok, Carnaval, Chinese / Lunar New Year, Homowo, Maslenitsa were genuinely not in the table — \`(movable)\` was the correct fallback, but ugly. Filled them in for 2026.

## Changes

- \`parseEventDate\` lowercases + normalizes \`_\` → \`-\` before the table lookup.
- \`LUNAR_YEARLY[2026]\` grows: \`eid-al-fitr\` / \`eid-al-adha\` aliases, \`diwali\`, \`chuseok\`, \`carnaval\`, \`chinese-new-year\` / \`lunar-new-year\` / \`chunjie\`, \`homowo\`, \`maslenitsa\`.
- \`prettyLunar\` handles both \`_\` and \`-\`; \`LUNAR_PRETTY\` covers the new event names.
- **Bonus fix:** \`eid-adha\` 2026 corrected from April 26 → May 27 (existing data was off by a month).

## Test plan
- [x] Full Jest suite: 720 passing (83 suites) · +3 new CalendarPage tests
- [x] Production build clean
- [ ] Manual QA: open \`/calendar\` → Eid al-Adha & Eid al-Fitr appear in their resolved months with proper subline; Diwali / Chuseok / Carnaval / Lunar New Year drop into their resolved months; Lunar / movable feasts panel only contains genuinely unmapped events.