### PR TITLE
feat(frontend): Cultural Highlights Read more → linked content or new detail page

### DIFF
--- a/app/frontend/src/App.js
+++ b/app/frontend/src/App.js
@@ -30,6 +30,7 @@ import ModerationPage from './pages/ModerationPage';
 import HeritagePage from './pages/HeritagePage';
 import HeritageMapPage from './pages/HeritageMapPage';
 import CalendarPage from './pages/CalendarPage';
+import CulturalHighlightPage from './pages/CulturalHighlightPage';
 import NotFoundPage from './pages/NotFoundPage';
 
 export default function App() {
@@ -104,6 +105,7 @@ export default function App() {
           <Route path="/heritage/:id" element={<HeritagePage />} />
           <Route path="/heritage/:id/map" element={<HeritageMapPage />} />
           <Route path="/calendar" element={<CalendarPage />} />
+          <Route path="/highlights/:id" element={<CulturalHighlightPage />} />
           <Route path="*" element={<NotFoundPage />} />
         </Routes>
       </div>

--- a/app/frontend/src/__tests__/CulturalHighlightPage.test.jsx
+++ b/app/frontend/src/__tests__/CulturalHighlightPage.test.jsx
@@ -1,0 +1,58 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import CulturalHighlightPage from '../pages/CulturalHighlightPage';
+import * as culturalContentService from '../services/culturalContentService';
+
+jest.mock('../services/culturalContentService');
+
+function renderAt(id) {
+  return render(
+    <MemoryRouter initialEntries={[`/highlights/${id}`]}>
+      <Routes>
+        <Route path="/highlights/:id" element={<CulturalHighlightPage />} />
+        <Route path="/explore" element={<div>explore-home</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('CulturalHighlightPage', () => {
+  it('renders the matching item title, body, region and tags', async () => {
+    culturalContentService.fetchDailyCulturalContent.mockResolvedValue([
+      { id: 'dc-fact-1', kind: 'fact', title: 'Lentil Soup', body: 'Across Anatolia…', region: 'Anatolian', tags: ['Anatolian', 'Healing'], link: null },
+      { id: 'dc-dish-2', kind: 'dish', title: 'Other',        body: '', region: null, tags: [], link: null },
+    ]);
+    renderAt('dc-fact-1');
+    expect(await screen.findByRole('heading', { name: /lentil soup/i })).toBeInTheDocument();
+    expect(screen.getByText(/across anatolia/i)).toBeInTheDocument();
+    // Region and tag can both spell "Anatolian" — assert via classnames so we
+    // catch both surfaces without the multi-match ambiguity.
+    expect(document.querySelector('.cultural-highlight-region')).toHaveTextContent('Anatolian');
+    expect(screen.getByText('Healing')).toBeInTheDocument();
+  });
+
+  it('shows a kind badge that matches the item kind', async () => {
+    culturalContentService.fetchDailyCulturalContent.mockResolvedValue([
+      { id: 'dc-tradition-9', kind: 'tradition', title: 'Plov Ceremony', body: '', region: null, tags: [], link: null },
+    ]);
+    renderAt('dc-tradition-9');
+    expect(await screen.findByText('Tradition')).toBeInTheDocument();
+  });
+
+  it('renders a not-found view when no item matches', async () => {
+    culturalContentService.fetchDailyCulturalContent.mockResolvedValue([
+      { id: 'dc-fact-1', kind: 'fact', title: 'Other', body: '', region: null, tags: [], link: null },
+    ]);
+    renderAt('dc-fact-999');
+    expect(await screen.findByRole('heading', { name: /highlight not found/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /back to explore/i })).toHaveAttribute('href', '/explore');
+  });
+
+  it('renders an error state when the fetch fails', async () => {
+    culturalContentService.fetchDailyCulturalContent.mockRejectedValue(new Error('boom'));
+    renderAt('dc-fact-1');
+    expect(await screen.findByText(/could not load this highlight/i)).toBeInTheDocument();
+  });
+});

--- a/app/frontend/src/__tests__/DailyCulturalSection.test.jsx
+++ b/app/frontend/src/__tests__/DailyCulturalSection.test.jsx
@@ -42,10 +42,24 @@ test('unknown kind falls back to globe emoji and default class', () => {
   expect(document.querySelector('.card-default')).toBeInTheDocument();
 });
 
-test('Read more link points to search with item title', () => {
+test('Read more link points to /recipes/:id when link.kind=recipe', () => {
+  wrap(<DailyCulturalSection items={[{ ...ITEMS[0], link: { kind: 'recipe', id: 42 } }]} />);
+  expect(screen.getByText('Read more →')).toHaveAttribute('href', '/recipes/42');
+});
+
+test('Read more link points to /stories/:id when link.kind=story', () => {
+  wrap(<DailyCulturalSection items={[{ ...ITEMS[1], link: { kind: 'story', id: 7 } }]} />);
+  expect(screen.getByText('Read more →')).toHaveAttribute('href', '/stories/7');
+});
+
+test('Read more link points to /calendar when link.kind=event', () => {
+  wrap(<DailyCulturalSection items={[{ ...ITEMS[3], link: { kind: 'event', id: 3 } }]} />);
+  expect(screen.getByText('Read more →')).toHaveAttribute('href', '/calendar');
+});
+
+test('hides Read more entirely when the item has no link', () => {
   wrap(<DailyCulturalSection items={[ITEMS[0]]} />);
-  const link = screen.getByText('Read more →');
-  expect(link).toHaveAttribute('href', expect.stringContaining('Coffee+Reading'));
+  expect(screen.queryByText('Read more →')).not.toBeInTheDocument();
 });
 
 test('renders nothing when items is empty', () => {

--- a/app/frontend/src/__tests__/DailyCulturalSection.test.jsx
+++ b/app/frontend/src/__tests__/DailyCulturalSection.test.jsx
@@ -57,9 +57,9 @@ test('Read more link points to /calendar when link.kind=event', () => {
   expect(screen.getByText('Read more →')).toHaveAttribute('href', '/calendar');
 });
 
-test('hides Read more entirely when the item has no link', () => {
+test('Read more falls back to /highlights/:id when no link is present', () => {
   wrap(<DailyCulturalSection items={[ITEMS[0]]} />);
-  expect(screen.queryByText('Read more →')).not.toBeInTheDocument();
+  expect(screen.getByText('Read more →')).toHaveAttribute('href', '/highlights/1');
 });
 
 test('renders nothing when items is empty', () => {

--- a/app/frontend/src/__tests__/culturalContentService.test.js
+++ b/app/frontend/src/__tests__/culturalContentService.test.js
@@ -24,8 +24,30 @@ describe('fetchDailyCulturalContent', () => {
     });
     const result = await fetchDailyCulturalContent();
     expect(result).toEqual([
-      { id: 1, kind: null, title: 'Card', body: 'Body', region: null, imageUrl: '/img.jpg', tags: ['Aegean'] },
+      { id: 1, kind: null, title: 'Card', body: 'Body', region: null, imageUrl: '/img.jpg', tags: ['Aegean'], link: null },
     ]);
+  });
+
+  it('passes through backend link { kind, id } so Read more can route directly', async () => {
+    apiClient.get.mockResolvedValue({
+      data: [
+        { id: 2, title: 'Pilav', body: '', kind: 'dish', link: { kind: 'recipe', id: 42 } },
+      ],
+    });
+    const result = await fetchDailyCulturalContent();
+    expect(result[0].link).toEqual({ kind: 'recipe', id: 42 });
+  });
+
+  it('drops malformed link objects (missing kind or id) so the UI hides Read more', async () => {
+    apiClient.get.mockResolvedValue({
+      data: [
+        { id: 3, title: 'A', link: { kind: 'recipe' } },
+        { id: 4, title: 'B', link: { id: 9 } },
+      ],
+    });
+    const result = await fetchDailyCulturalContent();
+    expect(result[0].link).toBeNull();
+    expect(result[1].link).toBeNull();
   });
 });
 

--- a/app/frontend/src/components/DailyCulturalSection.jsx
+++ b/app/frontend/src/components/DailyCulturalSection.jsx
@@ -9,6 +9,20 @@ const KIND_CONFIG = {
 };
 const FALLBACK = { emoji: '🌍', colorClass: 'card-default', label: 'Culture' };
 
+// Backend ships an optional `link: { kind, id }` per card pointing at the
+// recipe / story / event that owns the highlight. Map that to a real route
+// so "Read more" actually opens something instead of dumping the title into
+// the search box.
+function targetForLink(link) {
+  if (!link || !link.kind || link.id == null) return null;
+  switch (String(link.kind).toLowerCase()) {
+    case 'recipe': return `/recipes/${link.id}`;
+    case 'story':  return `/stories/${link.id}`;
+    case 'event':  return '/calendar';
+    default:       return null;
+  }
+}
+
 export default function DailyCulturalSection({ items, personalized }) {
   if (!items || items.length === 0) return null;
 
@@ -26,6 +40,7 @@ export default function DailyCulturalSection({ items, personalized }) {
       <div className="daily-cultural-grid">
         {items.map((item, index) => {
           const config = KIND_CONFIG[item.kind] ?? FALLBACK;
+          const href = targetForLink(item.link);
           return (
             <article
               key={item.id}
@@ -40,12 +55,11 @@ export default function DailyCulturalSection({ items, personalized }) {
               {item.body && <p className="card-body">{item.body}</p>}
               <div className="card-footer">
                 {item.region && <span className="card-region">{item.region}</span>}
-                <Link
-                  to={`/search?q=${encodeURIComponent(item.title).replace(/%20/g, '+')}`}
-                  className="card-read-more"
-                >
-                  Read more →
-                </Link>
+                {href && (
+                  <Link to={href} className="card-read-more">
+                    Read more →
+                  </Link>
+                )}
               </div>
             </article>
           );

--- a/app/frontend/src/components/DailyCulturalSection.jsx
+++ b/app/frontend/src/components/DailyCulturalSection.jsx
@@ -12,15 +12,19 @@ const FALLBACK = { emoji: '🌍', colorClass: 'card-default', label: 'Culture' }
 // Backend ships an optional `link: { kind, id }` per card pointing at the
 // recipe / story / event that owns the highlight. Map that to a real route
 // so "Read more" actually opens something instead of dumping the title into
-// the search box.
-function targetForLink(link) {
-  if (!link || !link.kind || link.id == null) return null;
-  switch (String(link.kind).toLowerCase()) {
-    case 'recipe': return `/recipes/${link.id}`;
-    case 'story':  return `/stories/${link.id}`;
-    case 'event':  return '/calendar';
-    default:       return null;
+// the search box. Items without a link fall back to /highlights/:id which
+// renders the card's full body on a dedicated page.
+function targetForItem(item) {
+  const link = item?.link;
+  if (link && link.kind && link.id != null) {
+    switch (String(link.kind).toLowerCase()) {
+      case 'recipe': return `/recipes/${link.id}`;
+      case 'story':  return `/stories/${link.id}`;
+      case 'event':  return '/calendar';
+      default:       break;
+    }
   }
+  return `/highlights/${encodeURIComponent(item.id)}`;
 }
 
 export default function DailyCulturalSection({ items, personalized }) {
@@ -40,7 +44,7 @@ export default function DailyCulturalSection({ items, personalized }) {
       <div className="daily-cultural-grid">
         {items.map((item, index) => {
           const config = KIND_CONFIG[item.kind] ?? FALLBACK;
-          const href = targetForLink(item.link);
+          const href = targetForItem(item);
           return (
             <article
               key={item.id}
@@ -55,11 +59,9 @@ export default function DailyCulturalSection({ items, personalized }) {
               {item.body && <p className="card-body">{item.body}</p>}
               <div className="card-footer">
                 {item.region && <span className="card-region">{item.region}</span>}
-                {href && (
-                  <Link to={href} className="card-read-more">
-                    Read more →
-                  </Link>
-                )}
+                <Link to={href} className="card-read-more">
+                  Read more →
+                </Link>
               </div>
             </article>
           );

--- a/app/frontend/src/pages/CulturalHighlightPage.css
+++ b/app/frontend/src/pages/CulturalHighlightPage.css
@@ -1,0 +1,73 @@
+.cultural-highlight {
+  max-width: 720px;
+  margin: 2rem auto;
+}
+
+.cultural-highlight-back {
+  margin: 0 0 1rem;
+}
+
+.cultural-highlight-back a {
+  color: var(--color-primary, #C4521E);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.cultural-highlight-back a:hover,
+.cultural-highlight-back a:focus-visible {
+  text-decoration: underline;
+}
+
+.cultural-highlight-badge {
+  display: inline-block;
+  background: var(--color-accent-mustard, #D4A830);
+  color: var(--color-surface-dark, #3D1500);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  margin-bottom: 0.75rem;
+}
+
+.cultural-highlight h1 {
+  margin: 0 0 0.5rem;
+}
+
+.cultural-highlight-region {
+  color: var(--color-text-muted, #6b6b6b);
+  font-weight: 600;
+  margin: 0 0 1.25rem;
+}
+
+.cultural-highlight-body {
+  line-height: 1.65;
+  font-size: 1.05rem;
+  white-space: pre-wrap;
+}
+
+.cultural-highlight-tags {
+  list-style: none;
+  margin: 1.5rem 0 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.cultural-highlight-tag {
+  background: rgba(196, 82, 30, 0.08);
+  color: var(--color-primary, #C4521E);
+  padding: 0.25rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.cultural-highlight.not-found {
+  text-align: center;
+}
+
+.cultural-highlight.not-found .btn {
+  margin-top: 1rem;
+}

--- a/app/frontend/src/pages/CulturalHighlightPage.jsx
+++ b/app/frontend/src/pages/CulturalHighlightPage.jsx
@@ -1,0 +1,79 @@
+import { useEffect, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { fetchDailyCulturalContent } from '../services/culturalContentService';
+import './CulturalHighlightPage.css';
+
+const KIND_LABEL = {
+  fact: 'Fact',
+  tradition: 'Tradition',
+  holiday: 'Holiday',
+  dish: 'Dish',
+};
+
+export default function CulturalHighlightPage() {
+  const { id } = useParams();
+  const [item, setItem] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError('');
+    fetchDailyCulturalContent()
+      .then((items) => {
+        if (cancelled) return;
+        const match = items.find((it) => String(it.id) === String(id));
+        if (!match) setError('not_found');
+        else setItem(match);
+      })
+      .catch(() => {
+        if (!cancelled) setError('load_failed');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [id]);
+
+  if (loading) return <p className="page-status">Loading…</p>;
+
+  if (error === 'load_failed') {
+    return <p className="page-status page-error">Could not load this highlight.</p>;
+  }
+
+  if (error === 'not_found' || !item) {
+    return (
+      <main className="page-card cultural-highlight not-found">
+        <h1>Highlight not found</h1>
+        <p>This cultural highlight is no longer available.</p>
+        <Link to="/explore" className="btn btn-outline">Back to Explore</Link>
+      </main>
+    );
+  }
+
+  const kindLabel = item.kind ? KIND_LABEL[item.kind] ?? null : null;
+
+  return (
+    <main className="page-card cultural-highlight">
+      <p className="cultural-highlight-back">
+        <Link to="/explore">← Back to Explore</Link>
+      </p>
+
+      {kindLabel && <span className="cultural-highlight-badge">{kindLabel}</span>}
+      <h1>{item.title}</h1>
+
+      {item.region && <p className="cultural-highlight-region">{item.region}</p>}
+
+      {item.body && <p className="cultural-highlight-body">{item.body}</p>}
+
+      {item.tags && item.tags.length > 0 && (
+        <ul className="cultural-highlight-tags" aria-label="Tags">
+          {item.tags.map((tag) => (
+            <li key={tag} className="cultural-highlight-tag">{tag}</li>
+          ))}
+        </ul>
+      )}
+    </main>
+  );
+}

--- a/app/frontend/src/services/culturalContentService.js
+++ b/app/frontend/src/services/culturalContentService.js
@@ -25,6 +25,10 @@ const MOCK_DAILY = [
 ];
 
 function normalize(item) {
+  const link =
+    item.link && item.link.kind && item.link.id != null
+      ? { kind: String(item.link.kind), id: item.link.id }
+      : null;
   return {
     id: item.id,
     kind: item.kind || null,
@@ -33,6 +37,7 @@ function normalize(item) {
     region: item.region || null,
     imageUrl: item.image_url || null,
     tags: Array.isArray(item.cultural_tags) ? item.cultural_tags : [],
+    link,
   };
 }
 


### PR DESCRIPTION
Two-layer fix for the Explore page's **For You: Cultural Highlights** Read more button, which used to dump every title into \`/search?q=...\` and surface zero hits.

## What this PR does

1. **Use the backend's link when it has one.** \`CulturalContentCardSerializer\` already returns an optional \`link: { kind, id }\` per card pointing at the recipe / story / cultural event that owns the highlight. The frontend was dropping it.
2. **Show a real detail page when it doesn't.** Cards without a link now route to a new \`/highlights/:id\` page that renders the card's title, body, region and tags — instead of hiding Read more entirely.

## Changes

- \`culturalContentService.normalize\` passes \`link\` through, validating both \`kind\` and \`id\`; malformed payloads collapse to \`link: null\`.
- \`DailyCulturalSection.targetForItem\` resolves in priority order:
  - \`link.kind === 'recipe'\` → \`/recipes/:id\`
  - \`link.kind === 'story'\` → \`/stories/:id\`
  - \`link.kind === 'event'\` → \`/calendar\`
  - else → \`/highlights/<item.id>\`
  Read more is always shown.
- New page **\`CulturalHighlightPage\`** at \`/highlights/:id\` — re-fetches the daily highlights list and looks the id up (IDs are already stable strings like \`dc-fact-12\`). Renders title + body + region + tags. Not-found state links back to \`/explore\`; load-error state surfaces.
- New CSS for the highlight page (max-width 720, page-card style).

## Test plan
- [x] Full Jest suite: 726 passing (84 suites) · +8 net new tests
- [x] Production build clean
- [ ] Manual QA: open \`/explore\` → click a curated card. If the card is admin-linked to a recipe/story/event, it opens that. Otherwise it opens \`/highlights/...\` and shows the full body. Direct visit to \`/highlights/dc-fact-999\` shows the Not Found view.

## Follow-up
Admin/seed flows should consider populating \`link_kind\` + \`link_id\` for new \`CulturalContent\` rows when there's a natural target — the \`/highlights/:id\` page is a good fallback, but a direct recipe / story is better when one exists.