### PR TITLE
feat(frontend): rework Explore — region rails, featured top, real images, skeletons (#863)

### DIFF
--- a/app/frontend/src/__tests__/ExplorePage.test.jsx
+++ b/app/frontend/src/__tests__/ExplorePage.test.jsx
@@ -2,39 +2,56 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import ExplorePage from '../pages/ExplorePage';
 import * as exploreService from '../services/exploreService';
+import { AuthContext } from '../context/AuthContext';
 
 jest.mock('../services/exploreService');
+jest.mock('../services/recipeService', () => ({
+  toggleBookmark: jest.fn().mockResolvedValue({ is_bookmarked: true }),
+}));
 
 const mockEvents = [
   {
-    id: 'wedding',
-    name: 'Weddings',
-    emoji: '💍',
+    id: 'featured',
+    name: 'Today on Genipe',
+    emoji: '⭐',
+    featuredRail: true,
     featured: [
-      { type: 'recipe', id: 1, title: 'Wedding Soup', author_username: 'eren' },
-      { type: 'story', id: 2, title: "Our Big Day", author_username: 'alice' },
+      { type: 'recipe', id: 1, title: 'Wedding Soup', author_username: 'eren', region: 'Aegean' },
     ],
   },
   {
-    id: 'newyear',
-    name: 'New Year',
-    emoji: '🎉',
+    id: 'region-aegean',
+    name: 'Aegean',
+    emoji: '🫒',
     featured: [
-      { type: 'recipe', id: 3, title: 'Lentil Salad', author_username: 'bob' },
+      { type: 'recipe', id: 1, title: 'Wedding Soup', author_username: 'eren', region: 'Aegean' },
+      { type: 'story', id: 2, title: "Our Big Day", author_username: 'alice', region: 'Aegean' },
+    ],
+  },
+  {
+    id: 'region-marmara',
+    name: 'Marmara',
+    emoji: '🌊',
+    featured: [
+      { type: 'recipe', id: 3, title: 'Lentil Salad', author_username: 'bob', region: 'Marmara' },
     ],
   },
 ];
 
-function renderPage() {
+function renderPage({ user = { id: 1, username: 'me' } } = {}) {
   return render(
-    <MemoryRouter initialEntries={['/explore']}>
-      <Routes>
-        <Route path="/explore" element={<ExplorePage />} />
-        <Route path="/explore/:eventId" element={<div>Event detail</div>} />
-        <Route path="/recipes/:id" element={<div>Recipe detail</div>} />
-        <Route path="/stories/:id" element={<div>Story detail</div>} />
-      </Routes>
-    </MemoryRouter>,
+    <AuthContext.Provider value={{ user, token: 't', login: jest.fn(), logout: jest.fn(), loading: false }}>
+      <MemoryRouter initialEntries={['/explore']}>
+        <Routes>
+          <Route path="/explore" element={<ExplorePage />} />
+          <Route path="/explore/:eventId" element={<div>Event detail</div>} />
+          <Route path="/recipes/:id" element={<div>Recipe detail</div>} />
+          <Route path="/stories/:id" element={<div>Story detail</div>} />
+          <Route path="/login" element={<div>Login</div>} />
+          <Route path="/map" element={<div>Map</div>} />
+        </Routes>
+      </MemoryRouter>
+    </AuthContext.Provider>,
   );
 }
 
@@ -44,54 +61,70 @@ beforeEach(() => {
 });
 
 describe('ExplorePage', () => {
-  it('shows a loading state while events load', () => {
+  it('shows skeleton rails while events load', () => {
     let resolve;
     exploreService.fetchExploreEvents.mockReturnValue(new Promise((r) => { resolve = r; }));
-    renderPage();
-    expect(screen.getByText(/loading/i)).toBeInTheDocument();
+    const { container } = renderPage();
+    expect(container.querySelectorAll('.explore-card-skeleton').length).toBeGreaterThan(0);
+    expect(screen.queryByText(/loading/i)).not.toBeInTheDocument();
     resolve([]);
   });
 
-  it('renders each event section after fetch resolves', async () => {
+  it('renders the featured rail + region rails after fetch resolves', async () => {
     renderPage();
     await waitFor(() => {
-      expect(screen.getByRole('heading', { name: /weddings/i })).toBeInTheDocument();
-      expect(screen.getByRole('heading', { name: /new year/i })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: /today on genipe/i })).toBeInTheDocument();
     });
-    expect(screen.getByText('Wedding Soup')).toBeInTheDocument();
-    expect(screen.getByText('Our Big Day')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /^aegean$/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /^marmara$/i })).toBeInTheDocument();
+    expect(screen.getAllByText('Wedding Soup').length).toBeGreaterThan(0);
     expect(screen.getByText('Lentil Salad')).toBeInTheDocument();
   });
 
-  it('renders "See all" links to /explore/<eventId>', async () => {
+  it('renders the region jump-nav with one chip per region rail', async () => {
     renderPage();
-    await screen.findByText('Wedding Soup');
+    await screen.findByRole('heading', { name: /^aegean$/i });
+    const nav = screen.getByRole('navigation', { name: /jump to region/i });
+    expect(nav).toBeInTheDocument();
+    expect(nav.querySelectorAll('a').length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('renders "See all" only on non-featured rails', async () => {
+    renderPage();
+    await screen.findByRole('heading', { name: /^aegean$/i });
     const seeAllLinks = screen.getAllByRole('link', { name: /see all/i });
-    expect(seeAllLinks).toHaveLength(2);
-    expect(seeAllLinks[0]).toHaveAttribute('href', '/explore/wedding');
-    expect(seeAllLinks[1]).toHaveAttribute('href', '/explore/newyear');
+    expect(seeAllLinks.map((a) => a.getAttribute('href'))).toEqual(
+      expect.arrayContaining(['/explore/region-aegean', '/explore/region-marmara']),
+    );
+    expect(seeAllLinks.some((a) => a.getAttribute('href') === '/explore/featured')).toBe(false);
   });
 
-  it('renders content cards pointing at /recipes/:id or /stories/:id', async () => {
-    renderPage();
-    await screen.findByText('Wedding Soup');
-    expect(screen.getByRole('link', { name: /wedding soup/i })).toHaveAttribute(
-      'href',
-      '/recipes/1',
-    );
-    expect(screen.getByRole('link', { name: /our big day/i })).toHaveAttribute(
-      'href',
-      '/stories/2',
-    );
-  });
-
-  it('renders no event sections when the API returns an empty list', async () => {
+  it('renders an empty state with CTAs when no rails have items', async () => {
     exploreService.fetchExploreEvents.mockResolvedValue([]);
     renderPage();
     await waitFor(() => {
-      expect(screen.getByRole('heading', { name: /explore/i })).toBeInTheDocument();
+      expect(screen.getByText(/no recipes or stories yet/i)).toBeInTheDocument();
     });
-    expect(screen.queryAllByRole('link', { name: /see all/i })).toHaveLength(0);
+    expect(screen.getByRole('link', { name: /open the map/i })).toHaveAttribute('href', '/map');
+    expect(screen.getByRole('link', { name: /share a recipe/i })).toHaveAttribute('href', '/recipes/new');
+  });
+
+  it('shows the sign-in banner only when not authenticated', async () => {
+    renderPage({ user: null });
+    await screen.findByRole('heading', { name: /^aegean$/i });
+    expect(screen.getByText(/sign in/i)).toBeInTheDocument();
+  });
+
+  it('hides the sign-in banner when authenticated', async () => {
+    renderPage();
+    await screen.findByRole('heading', { name: /^aegean$/i });
+    expect(screen.queryByText(/sign in to see recipes/i)).not.toBeInTheDocument();
+  });
+
+  it('shows the bookmark button on recipe cards only when signed in', async () => {
+    renderPage();
+    await screen.findByRole('heading', { name: /^aegean$/i });
+    expect(screen.getAllByRole('button', { name: /save recipe/i }).length).toBeGreaterThan(0);
   });
 
   it('shows an error message when fetchExploreEvents rejects', async () => {

--- a/app/frontend/src/__tests__/exploreService.test.js
+++ b/app/frontend/src/__tests__/exploreService.test.js
@@ -2,86 +2,115 @@ import { apiClient } from '../services/api';
 import { fetchExploreEvents, fetchEventDetail } from '../services/exploreService';
 
 jest.mock('../services/api', () => ({
-  apiClient: {
-    get: jest.fn(),
-  },
+  apiClient: { get: jest.fn() },
 }));
 
 beforeEach(() => jest.clearAllMocks());
 
 describe('fetchExploreEvents', () => {
-  it('GETs /api/recommendations/ with surface=explore and groups by type', async () => {
+  it('GETs /api/recommendations/ with surface=explore', async () => {
+    apiClient.get.mockResolvedValue({ data: { results: [] } });
+    await fetchExploreEvents();
+    expect(apiClient.get).toHaveBeenCalledWith('/api/recommendations/', {
+      params: { surface: 'explore', limit: 30 },
+    });
+  });
+
+  it('groups results into a featured rail + region rails when multiple regions are present', async () => {
     apiClient.get.mockResolvedValue({
       data: {
         results: [
-          { id: 1, type: 'recipe', title: 'R' },
-          { id: 2, type: 'story', title: 'S' },
+          { id: 1, result_type: 'recipe', title: 'A', region_tag: 'Aegean', rank_score: 9 },
+          { id: 2, result_type: 'story',  title: 'B', region_tag: 'Marmara', rank_score: 5 },
+          { id: 3, result_type: 'recipe', title: 'C', region_tag: 'Aegean', rank_score: 3 },
         ],
       },
     });
-    const result = await fetchExploreEvents();
-    expect(apiClient.get).toHaveBeenCalledWith('/api/recommendations/', {
-      params: { surface: 'explore', limit: 20 },
-    });
-    expect(result).toEqual([
-      { id: 'recipes', name: 'Recipes', emoji: '🍽️', featured: [{ id: 1, type: 'recipe', title: 'R' }] },
-      { id: 'stories', name: 'Stories', emoji: '📖', featured: [{ id: 2, type: 'story', title: 'S' }] },
-    ]);
+    const rails = await fetchExploreEvents();
+    expect(rails.map((r) => r.id)).toEqual(['featured', 'region-aegean', 'region-marmara']);
+    expect(rails[0].featuredRail).toBe(true);
+    expect(rails[1].name).toBe('Aegean');
+    expect(rails[1].featured).toHaveLength(2);
+    expect(rails[1].featured[0].type).toBe('recipe');
+    expect(rails[1].featured[0].region).toBe('Aegean');
   });
 
-  it('returns a Discover fallback when no recipes or stories are present', async () => {
+  it('caps duplicate authors within a rail at the configured limit', async () => {
     apiClient.get.mockResolvedValue({
-      data: { results: [{ id: 3, type: 'other' }] },
+      data: {
+        results: [
+          { id: 1, result_type: 'recipe', region_tag: 'Aegean', author_username: 'a' },
+          { id: 2, result_type: 'recipe', region_tag: 'Aegean', author_username: 'a' },
+          { id: 3, result_type: 'recipe', region_tag: 'Aegean', author_username: 'a' },
+          { id: 4, result_type: 'recipe', region_tag: 'Marmara', author_username: 'b' },
+        ],
+      },
     });
-    const result = await fetchExploreEvents();
-    expect(result).toEqual([
-      { id: 'explore', name: 'Discover', emoji: '✨', featured: [{ id: 3, type: 'other' }] },
-    ]);
+    const rails = await fetchExploreEvents();
+    const aegean = rails.find((r) => r.id === 'region-aegean');
+    expect(aegean.featured).toHaveLength(2);
+    expect(aegean.featured.every((i) => i.author_username === 'a')).toBe(true);
+  });
+
+  it('falls back to type-based rails when no regions are present', async () => {
+    apiClient.get.mockResolvedValue({
+      data: {
+        results: [
+          { id: 1, result_type: 'recipe', title: 'R' },
+          { id: 2, result_type: 'story',  title: 'S' },
+        ],
+      },
+    });
+    const rails = await fetchExploreEvents();
+    expect(rails.map((r) => r.id)).toEqual(['featured', 'recipes', 'stories']);
+    expect(rails[1].showRegionBadge).toBe(true);
+  });
+
+  it('returns an empty list when results are empty', async () => {
+    apiClient.get.mockResolvedValue({ data: { results: [] } });
+    expect(await fetchExploreEvents()).toEqual([]);
   });
 });
 
 describe('fetchEventDetail', () => {
-  it('returns the recipes bucket for id=recipes', async () => {
+  it('returns the matching region rail by id', async () => {
     apiClient.get.mockResolvedValue({
       data: {
         results: [
-          { id: 1, type: 'recipe' },
-          { id: 2, type: 'story' },
+          { id: 1, result_type: 'recipe', region_tag: 'Aegean' },
+          { id: 2, result_type: 'story',  region_tag: 'Marmara' },
+        ],
+      },
+    });
+    const event = await fetchEventDetail('region-aegean');
+    expect(apiClient.get).toHaveBeenCalledWith('/api/recommendations/', {
+      params: { surface: 'explore', limit: 50 },
+    });
+    expect(event.id).toBe('region-aegean');
+    expect(event.featured[0].region).toBe('Aegean');
+  });
+
+  it('returns the legacy recipes bucket for id=recipes', async () => {
+    apiClient.get.mockResolvedValue({
+      data: {
+        results: [
+          { id: 1, result_type: 'recipe' },
+          { id: 2, result_type: 'story' },
         ],
       },
     });
     const result = await fetchEventDetail('recipes');
-    expect(apiClient.get).toHaveBeenCalledWith('/api/recommendations/', {
-      params: { surface: 'explore', limit: 50 },
-    });
-    expect(result).toEqual({
-      id: 'recipes',
-      name: 'Recipes',
-      emoji: '🍽️',
-      featured: [{ id: 1, type: 'recipe' }],
-    });
-  });
-
-  it('returns the stories bucket for id=stories', async () => {
-    apiClient.get.mockResolvedValue({
-      data: { results: [{ id: 2, type: 'story' }] },
-    });
-    const result = await fetchEventDetail('stories');
-    expect(result.id).toBe('stories');
-    expect(result.featured).toEqual([{ id: 2, type: 'story' }]);
+    expect(result.id).toBe('recipes');
+    expect(result.featured).toEqual([expect.objectContaining({ id: 1, type: 'recipe' })]);
   });
 
   it('returns the Discover bucket for an unknown id', async () => {
     apiClient.get.mockResolvedValue({
-      data: { results: [{ id: 4, type: 'other' }] },
+      data: { results: [{ id: 4, result_type: 'other' }] },
     });
     const result = await fetchEventDetail('foobar');
-    expect(result).toEqual({
-      id: 'explore',
-      name: 'Discover',
-      emoji: '✨',
-      featured: [{ id: 4, type: 'other' }],
-    });
+    expect(result.id).toBe('explore');
+    expect(result.featured).toEqual([expect.objectContaining({ id: 4 })]);
   });
 
   it('propagates API errors to the caller', async () => {

--- a/app/frontend/src/pages/ExplorePage.css
+++ b/app/frontend/src/pages/ExplorePage.css
@@ -1,5 +1,5 @@
 .explore-page-header {
-  margin-bottom: 2rem;
+  margin-bottom: 1.5rem;
 }
 
 .explore-page-header h1 {
@@ -13,6 +13,54 @@
   font-size: 1rem;
 }
 
+.explore-signin-banner {
+  margin-top: 0.85rem;
+  padding: 0.55rem 0.85rem;
+  background: var(--color-primary-tint);
+  color: var(--color-text);
+  border-radius: var(--radius-md, 10px);
+  font-size: 0.875rem;
+  display: inline-block;
+}
+.explore-signin-banner a {
+  font-weight: 700;
+  color: var(--color-primary);
+  text-decoration: none;
+}
+.explore-signin-banner a:hover { text-decoration: underline; }
+
+/* ── Region nav ──────────────────── */
+.explore-region-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding-bottom: 1.5rem;
+  margin-bottom: 0.5rem;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.explore-region-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.8rem;
+  border: 1.5px solid var(--color-border);
+  border-radius: var(--radius-pill);
+  background: var(--color-surface);
+  color: var(--color-text);
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-decoration: none;
+  transition: background 0.15s, border-color 0.15s, transform 0.15s;
+}
+.explore-region-chip:hover {
+  background: var(--color-primary-tint);
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+  transform: translateY(-1px);
+  text-decoration: none;
+}
+
 /* ── Rails ───────────────────────── */
 .explore-rails {
   display: flex;
@@ -24,6 +72,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.875rem;
+  scroll-margin-top: 1rem;
 }
 
 .event-rail-header {
@@ -44,6 +93,10 @@
   flex: 1;
 }
 
+.event-rail-featured .event-rail-name {
+  font-size: 1.4rem;
+}
+
 .event-rail-see-all {
   font-size: 0.875rem;
   font-weight: 600;
@@ -52,33 +105,36 @@
   white-space: nowrap;
   flex-shrink: 0;
 }
+.event-rail-see-all:hover { text-decoration: underline; }
 
-.event-rail-see-all:hover {
-  text-decoration: underline;
-}
-
-/* ── Horizontal scroll ───────────── */
-.event-rail-scroll {
+/* ── Track layouts ───────────────── */
+.event-rail-track {
   display: flex;
   gap: 1rem;
+}
+
+.event-rail-track.is-scroll {
   overflow-x: auto;
   padding-bottom: 0.5rem;
   scrollbar-width: thin;
   scrollbar-color: var(--color-border) transparent;
 }
-
-.event-rail-scroll::-webkit-scrollbar {
-  height: 4px;
-}
-
-.event-rail-scroll::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-.event-rail-scroll::-webkit-scrollbar-thumb {
+.event-rail-track.is-scroll::-webkit-scrollbar { height: 4px; }
+.event-rail-track.is-scroll::-webkit-scrollbar-track { background: transparent; }
+.event-rail-track.is-scroll::-webkit-scrollbar-thumb {
   background: var(--color-border);
   border-radius: var(--radius-pill);
 }
+
+.event-rail-track.is-grid {
+  flex-wrap: wrap;
+}
+.event-rail-track.is-grid .explore-card { flex: 0 0 220px; }
+
+.event-rail-track.is-featured {
+  gap: 1.25rem;
+}
+.event-rail-track.is-featured .explore-card { flex: 1 1 0; min-width: 220px; }
 
 /* ── Content card ────────────────── */
 .explore-card {
@@ -99,16 +155,128 @@
   text-decoration: none;
 }
 
+.explore-card-featured {
+  border-color: var(--color-primary);
+  box-shadow: 0 2px 10px rgba(196, 82, 30, 0.12);
+}
+
+.explore-card-media {
+  position: relative;
+  height: 130px;
+  overflow: hidden;
+}
+.event-rail-track.is-featured .explore-card-media { height: 180px; }
+
+.explore-card-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
 .explore-card-placeholder {
-  height: 110px;
+  height: 100%;
   background: linear-gradient(135deg, var(--color-accent-green-tint), var(--color-primary-subtle));
+}
+
+.explore-card-region-badge {
+  position: absolute;
+  top: 0.5rem;
+  left: 0.5rem;
+  background: rgba(255, 255, 255, 0.92);
+  color: var(--color-text);
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 0.15rem 0.5rem;
+  border-radius: var(--radius-pill);
+  max-width: calc(100% - 1rem);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  backdrop-filter: blur(2px);
+}
+
+.explore-card-story-glyph {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.92);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.9rem;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.15);
+}
+
+.explore-card-bookmark {
+  position: absolute;
+  bottom: 0.5rem;
+  right: 0.5rem;
+  width: 1.9rem;
+  height: 1.9rem;
+  border-radius: 50%;
+  border: none;
+  background: rgba(255, 255, 255, 0.92);
+  cursor: pointer;
+  font-size: 0.95rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.15);
+  transition: transform 0.15s, background 0.15s;
+}
+.explore-card-bookmark:hover { transform: scale(1.08); }
+.explore-card-bookmark.active { background: var(--color-primary); color: white; }
+
+.explore-card-hover {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to top, rgba(61, 21, 0, 0.94) 35%, rgba(61, 21, 0, 0.55) 75%, rgba(61, 21, 0, 0) 100%);
+  color: var(--color-surface);
+  padding: 0.6rem 0.7rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  gap: 0.35rem;
+  opacity: 0;
+  transition: opacity 0.18s;
+}
+.explore-card:hover .explore-card-hover,
+.explore-card:focus-visible .explore-card-hover { opacity: 1; }
+
+.explore-card-hover-text {
+  font-size: 0.78rem;
+  line-height: 1.35;
+  margin: 0;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.explore-card-hover-reason {
+  font-size: 0.7rem;
+  line-height: 1.3;
+  margin: 0;
+  opacity: 0.85;
+  font-style: italic;
 }
 
 .explore-card-body {
   padding: 0.75rem;
   display: flex;
   flex-direction: column;
-  gap: 0.2rem;
+  gap: 0.25rem;
+}
+
+.explore-card-meta-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
 }
 
 .explore-card-type {
@@ -120,16 +288,19 @@
   padding: 0.15rem 0.5rem;
   width: fit-content;
 }
+.explore-card-type.recipe { background: var(--color-primary-tint); color: var(--color-primary); }
+.explore-card-type.story  { background: var(--color-accent-green-tint); color: var(--color-accent-green); }
 
-.explore-card-type.recipe {
-  background: var(--color-primary-tint);
+.explore-card-linked {
+  font-size: 0.7rem;
+  font-weight: 600;
   color: var(--color-primary);
+  text-decoration: none;
+  padding: 0.1rem 0.45rem;
+  border-radius: var(--radius-pill);
+  background: var(--color-primary-subtle);
 }
-
-.explore-card-type.story {
-  background: var(--color-accent-green-tint);
-  color: var(--color-accent-green);
-}
+.explore-card-linked:hover { text-decoration: underline; }
 
 .explore-card-title {
   font-size: 0.9rem;
@@ -146,3 +317,48 @@
   font-size: 0.8rem;
   color: var(--color-text-muted);
 }
+
+/* ── Empty state ─────────────────── */
+.explore-empty {
+  padding: 3rem 1rem;
+  text-align: center;
+  border: 1.5px dashed var(--color-border);
+  border-radius: var(--radius-lg);
+}
+.explore-empty-title { font-size: 1.1rem; font-weight: 700; color: var(--color-text); }
+.explore-empty-body  { color: var(--color-text-muted); margin-top: 0.35rem; }
+.explore-empty-actions {
+  margin-top: 1rem;
+  display: flex;
+  gap: 0.75rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+/* ── Skeletons ───────────────────── */
+@keyframes explore-skeleton-shimmer {
+  0%   { background-position: -200px 0; }
+  100% { background-position: calc(200px + 100%) 0; }
+}
+
+.explore-skeleton {
+  display: block;
+  background: linear-gradient(
+    90deg,
+    var(--color-border) 0%,
+    var(--color-surface-input) 50%,
+    var(--color-border) 100%
+  );
+  background-size: 200px 100%;
+  background-repeat: no-repeat;
+  border-radius: 6px;
+  animation: explore-skeleton-shimmer 1.4s ease-in-out infinite;
+}
+
+.explore-skeleton-title { height: 1.25rem; width: 180px; }
+.explore-skeleton-image { height: 100%; width: 100%; border-radius: 0; }
+.explore-skeleton-pill  { height: 0.9rem; width: 56px; border-radius: var(--radius-pill); }
+.explore-skeleton-line  { height: 0.85rem; width: 100%; }
+.explore-skeleton-line.short { width: 60%; }
+
+.explore-card-skeleton { pointer-events: none; }

--- a/app/frontend/src/pages/ExplorePage.jsx
+++ b/app/frontend/src/pages/ExplorePage.jsx
@@ -1,15 +1,94 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useContext, useMemo, useRef } from 'react';
 import { Link } from 'react-router-dom';
 import { fetchExploreEvents } from '../services/exploreService';
+import { AuthContext } from '../context/AuthContext';
+import { toggleBookmark } from '../services/recipeService';
 import './ExplorePage.css';
 
-function ContentCard({ item }) {
-  const href = item.type === 'recipe' ? `/recipes/${item.id}` : `/stories/${item.id}`;
+const SPARSE_RAIL_THRESHOLD = 3;
+
+function StoryGlyph() {
   return (
-    <Link to={href} className="explore-card">
-      <div className="explore-card-placeholder" />
+    <span className="explore-card-story-glyph" aria-hidden="true" title="Story">📖</span>
+  );
+}
+
+function ContentCard({ item, showRegionBadge, featured, canBookmark }) {
+  const href = item.type === 'recipe' ? `/recipes/${item.id}` : `/stories/${item.id}`;
+  const [imageBroken, setImageBroken] = useState(false);
+  const [bookmarked, setBookmarked] = useState(false);
+  const [bookmarkBusy, setBookmarkBusy] = useState(false);
+  const showImage = item.image && !imageBroken;
+  const isRecipe = item.type === 'recipe';
+
+  const handleBookmark = async (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (bookmarkBusy) return;
+    setBookmarkBusy(true);
+    try {
+      const result = await toggleBookmark(item.id);
+      setBookmarked(Boolean(result?.is_bookmarked));
+    } catch {
+      // Silent: card stays linkable; bookmarking is best-effort.
+    } finally {
+      setBookmarkBusy(false);
+    }
+  };
+
+  return (
+    <Link to={href} className={`explore-card${featured ? ' explore-card-featured' : ''}`}>
+      <div className="explore-card-media">
+        {showImage ? (
+          <img
+            src={item.image}
+            alt=""
+            className="explore-card-image"
+            loading="lazy"
+            onError={() => setImageBroken(true)}
+          />
+        ) : (
+          <div className="explore-card-placeholder" aria-hidden="true" />
+        )}
+        {!isRecipe && <StoryGlyph />}
+        {showRegionBadge && item.region && (
+          <span className="explore-card-region-badge">📍 {item.region}</span>
+        )}
+        {canBookmark && isRecipe && (
+          <button
+            type="button"
+            className={`explore-card-bookmark${bookmarked ? ' active' : ''}`}
+            onClick={handleBookmark}
+            aria-label={bookmarked ? 'Remove bookmark' : 'Save recipe'}
+            aria-pressed={bookmarked}
+          >
+            {bookmarked ? '🔖' : '🏷️'}
+          </button>
+        )}
+        {(item.description || item.rank_reason) && (
+          <div className="explore-card-hover">
+            {item.description && <p className="explore-card-hover-text">{item.description}</p>}
+            {item.rank_reason && (
+              <p className="explore-card-hover-reason">
+                <span aria-hidden="true">ⓘ</span> {item.rank_reason}
+              </p>
+            )}
+          </div>
+        )}
+      </div>
       <div className="explore-card-body">
-        <span className={`explore-card-type ${item.type}`}>{item.type}</span>
+        <div className="explore-card-meta-row">
+          <span className={`explore-card-type ${item.type}`}>{item.type}</span>
+          {item.linked_recipe_id && !isRecipe && (
+            <Link
+              to={`/recipes/${item.linked_recipe_id}`}
+              className="explore-card-linked"
+              onClick={(e) => e.stopPropagation()}
+            >
+              → recipe
+            </Link>
+          )}
+        </div>
         <p className="explore-card-title">{item.title}</p>
         <p className="explore-card-author">@{item.author_username}</p>
       </div>
@@ -17,26 +96,94 @@ function ContentCard({ item }) {
   );
 }
 
-function EventRail({ event }) {
+function EventRail({ event, showRegionBadge, canBookmark }) {
+  const items = event.featured || [];
+  const isSparse = items.length > 0 && items.length <= SPARSE_RAIL_THRESHOLD;
+  const isFeatured = Boolean(event.featuredRail);
+  if (!items.length) return null;
   return (
-    <section className="event-rail">
+    <section
+      className={`event-rail${isFeatured ? ' event-rail-featured' : ''}`}
+      id={`rail-${event.id}`}
+    >
       <div className="event-rail-header">
         <span className="event-rail-emoji" aria-hidden="true">{event.emoji}</span>
         <h2 className="event-rail-name">{event.name}</h2>
-        <Link to={`/explore/${event.id}`} className="event-rail-see-all">
-          See all →
-        </Link>
+        {!isFeatured && (
+          <Link to={`/explore/${event.id}`} className="event-rail-see-all">
+            See all →
+          </Link>
+        )}
       </div>
-      <div className="event-rail-scroll">
-        {event.featured.map((item) => (
-          <ContentCard key={`${item.type}-${item.id}`} item={item} />
+      <div className={`event-rail-track${isSparse ? ' is-grid' : ' is-scroll'}${isFeatured ? ' is-featured' : ''}`}>
+        {items.map((item) => (
+          <ContentCard
+            key={`${item.type}-${item.id}`}
+            item={item}
+            showRegionBadge={showRegionBadge || isFeatured}
+            featured={isFeatured}
+            canBookmark={canBookmark}
+          />
         ))}
       </div>
     </section>
   );
 }
 
+function SkeletonRail() {
+  return (
+    <section className="event-rail" aria-hidden="true">
+      <div className="event-rail-header">
+        <span className="explore-skeleton explore-skeleton-title" />
+      </div>
+      <div className="event-rail-track is-scroll">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="explore-card explore-card-skeleton">
+            <div className="explore-card-media">
+              <div className="explore-skeleton explore-skeleton-image" />
+            </div>
+            <div className="explore-card-body">
+              <span className="explore-skeleton explore-skeleton-pill" />
+              <span className="explore-skeleton explore-skeleton-line" />
+              <span className="explore-skeleton explore-skeleton-line short" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function RegionNav({ rails }) {
+  const ref = useRef(null);
+  const regionRails = rails.filter((r) => r.id.startsWith('region-') || r.id === 'featured');
+  if (regionRails.length < 2) return null;
+
+  const jump = (e, id) => {
+    e.preventDefault();
+    const el = document.getElementById(`rail-${id}`);
+    if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  };
+
+  return (
+    <nav className="explore-region-nav" aria-label="Jump to region" ref={ref}>
+      {regionRails.map((r) => (
+        <a
+          key={r.id}
+          href={`#rail-${r.id}`}
+          onClick={(e) => jump(e, r.id)}
+          className="explore-region-chip"
+        >
+          <span aria-hidden="true">{r.emoji}</span>
+          <span>{r.name}</span>
+        </a>
+      ))}
+    </nav>
+  );
+}
+
 export default function ExplorePage() {
+  const { user } = useContext(AuthContext) || {};
   const [events, setEvents] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
@@ -50,22 +197,57 @@ export default function ExplorePage() {
     return () => { cancelled = true; };
   }, []);
 
-  if (loading) return <p className="page-status">Loading…</p>;
-  if (error) return <p className="page-status page-error">{error}</p>;
+  const hasContent = useMemo(
+    () => events.some((r) => (r.featured || []).length > 0),
+    [events],
+  );
 
   return (
     <main className="page-card explore-page">
       <div className="explore-page-header">
         <h1>Explore</h1>
         <p className="explore-page-subtitle">
-          Discover recipes and stories curated around life's most meaningful moments.
+          Taste the regions of the table — recipes and stories grouped by where they come from.
         </p>
+        {!user && !loading && !error && (
+          <div className="explore-signin-banner">
+            <Link to="/login">Sign in</Link> to see recipes from your region first.
+          </div>
+        )}
       </div>
-      <div className="explore-rails">
-        {events.map((event) => (
-          <EventRail key={event.id} event={event} />
-        ))}
-      </div>
+
+      {error ? (
+        <p className="page-status page-error">{error}</p>
+      ) : loading ? (
+        <div className="explore-rails">
+          {Array.from({ length: 3 }).map((_, i) => <SkeletonRail key={i} />)}
+        </div>
+      ) : !hasContent ? (
+        <div className="explore-empty">
+          <p className="explore-empty-title">No recipes or stories yet.</p>
+          <p className="explore-empty-body">
+            Explore the world's culinary regions on the map, or be the first to share.
+          </p>
+          <div className="explore-empty-actions">
+            <Link to="/map" className="btn btn-outline btn-sm">Open the map</Link>
+            <Link to="/recipes/new" className="btn btn-primary btn-sm">Share a recipe</Link>
+          </div>
+        </div>
+      ) : (
+        <>
+          <RegionNav rails={events} />
+          <div className="explore-rails">
+            {events.map((event) => (
+              <EventRail
+                key={event.id}
+                event={event}
+                showRegionBadge={Boolean(event.showRegionBadge)}
+                canBookmark={Boolean(user)}
+              />
+            ))}
+          </div>
+        </>
+      )}
     </main>
   );
 }

--- a/app/frontend/src/services/exploreService.js
+++ b/app/frontend/src/services/exploreService.js
@@ -3,19 +3,125 @@ import { MOCK_EXPLORE_EVENTS, getMockEventById } from '../mocks/exploreEvents';
 
 const USE_MOCK = process.env.REACT_APP_USE_MOCK === 'true';
 
+const REGION_EMOJI = {
+  Anatolia: '🌾',
+  'Central Anatolia': '🌾',
+  'Eastern Anatolia': '⛰️',
+  'Southeast Anatolia': '🌶️',
+  'Southeastern Anatolia': '🌶️',
+  Marmara: '🌊',
+  Aegean: '🫒',
+  Mediterranean: '☀️',
+  'Black Sea': '🌿',
+  Arabian: '🌶️',
+};
+
+const MAX_PER_AUTHOR_PER_RAIL = 2;
+const FEATURED_COUNT = 3;
+const SPARSE_RAIL_THRESHOLD = 3;
+
+function regionEmoji(name) {
+  return REGION_EMOJI[name] || '📍';
+}
+
+function normalizeItem(raw) {
+  // Backend `/api/recommendations/` returns `result_type`; mocks use `type`.
+  const type = raw.type || raw.result_type;
+  const description = raw.description || raw.body || '';
+  return {
+    ...raw,
+    type,
+    description,
+    region: raw.region || raw.region_tag || null,
+    rank_score: raw.rank_score ?? 0,
+    rank_reason: raw.rank_reason || null,
+    linked_recipe_id: raw.linked_recipe_id ?? null,
+  };
+}
+
+function capPerAuthor(items, limit = MAX_PER_AUTHOR_PER_RAIL) {
+  const counts = new Map();
+  const kept = [];
+  for (const item of items) {
+    const key = item.author_username || '__anon__';
+    const n = counts.get(key) || 0;
+    if (n < limit) {
+      counts.set(key, n + 1);
+      kept.push(item);
+    }
+  }
+  return kept;
+}
+
+function pickFeatured(items, n = FEATURED_COUNT) {
+  return [...items].sort((a, b) => (b.rank_score || 0) - (a.rank_score || 0)).slice(0, n);
+}
+
+function buildRails(rawResults) {
+  const items = rawResults.map(normalizeItem);
+  if (!items.length) return [];
+
+  const rails = [];
+
+  const featured = pickFeatured(items);
+  if (featured.length) {
+    rails.push({
+      id: 'featured',
+      name: 'Today on Genipe',
+      emoji: '⭐',
+      featured,
+      featuredRail: true,
+    });
+  }
+
+  const buckets = new Map();
+  for (const item of items) {
+    const key = item.region || '__unknown__';
+    if (!buckets.has(key)) buckets.set(key, []);
+    buckets.get(key).push(item);
+  }
+  const namedRegions = [...buckets.keys()].filter((k) => k !== '__unknown__').sort();
+
+  if (namedRegions.length >= 2) {
+    for (const region of namedRegions) {
+      rails.push({
+        id: `region-${region.toLowerCase().replace(/\s+/g, '-')}`,
+        name: region,
+        emoji: regionEmoji(region),
+        region,
+        featured: capPerAuthor(buckets.get(region)),
+      });
+    }
+    const unknowns = buckets.get('__unknown__');
+    if (unknowns && unknowns.length) {
+      rails.push({
+        id: 'explore',
+        name: 'More to discover',
+        emoji: '✨',
+        featured: capPerAuthor(unknowns),
+        showRegionBadge: true,
+      });
+    }
+    return rails;
+  }
+
+  // Fallback: type-based rails when region data is sparse.
+  const recipes = items.filter((r) => r.type === 'recipe');
+  const stories = items.filter((r) => r.type === 'story');
+  if (recipes.length) rails.push({ id: 'recipes', name: 'Recipes', emoji: '🍽️', featured: capPerAuthor(recipes), showRegionBadge: true });
+  if (stories.length) rails.push({ id: 'stories', name: 'Stories', emoji: '📖', featured: capPerAuthor(stories), showRegionBadge: true });
+  if (rails.length === 1 && rails[0].id === 'featured') {
+    rails.push({ id: 'explore', name: 'Discover', emoji: '✨', featured: capPerAuthor(items), showRegionBadge: true });
+  }
+  return rails;
+}
+
 export async function fetchExploreEvents() {
   if (USE_MOCK) return MOCK_EXPLORE_EVENTS;
   const response = await apiClient.get('/api/recommendations/', {
-    params: { surface: 'explore', limit: 20 },
+    params: { surface: 'explore', limit: 30 },
   });
-  const results = response.data.results || [];
-  const recipes = results.filter((r) => r.type === 'recipe');
-  const stories = results.filter((r) => r.type === 'story');
-  const events = [];
-  if (recipes.length) events.push({ id: 'recipes', name: 'Recipes', emoji: '🍽️', featured: recipes });
-  if (stories.length) events.push({ id: 'stories', name: 'Stories', emoji: '📖', featured: stories });
-  if (!events.length) events.push({ id: 'explore', name: 'Discover', emoji: '✨', featured: results });
-  return events;
+  return buildRails(response.data.results || []);
 }
 
 export async function fetchEventDetail(id) {
@@ -27,10 +133,13 @@ export async function fetchEventDetail(id) {
   const response = await apiClient.get('/api/recommendations/', {
     params: { surface: 'explore', limit: 50 },
   });
-  const results = response.data.results || [];
-  const recipes = results.filter((r) => r.type === 'recipe');
-  const stories = results.filter((r) => r.type === 'story');
-  if (id === 'recipes') return { id: 'recipes', name: 'Recipes', emoji: '🍽️', featured: recipes };
-  if (id === 'stories') return { id: 'stories', name: 'Stories', emoji: '📖', featured: stories };
-  return { id: 'explore', name: 'Discover', emoji: '✨', featured: results };
+  const rails = buildRails(response.data.results || []);
+  const match = rails.find((r) => r.id === id);
+  if (match) return match;
+  const items = (response.data.results || []).map(normalizeItem);
+  if (id === 'recipes') return { id: 'recipes', name: 'Recipes', emoji: '🍽️', featured: items.filter((r) => r.type === 'recipe') };
+  if (id === 'stories') return { id: 'stories', name: 'Stories', emoji: '📖', featured: items.filter((r) => r.type === 'story') };
+  return { id: 'explore', name: 'Discover', emoji: '✨', featured: items };
 }
+
+export const __testing__ = { SPARSE_RAIL_THRESHOLD, MAX_PER_AUTHOR_PER_RAIL };


### PR DESCRIPTION
Summary
Explore page: The page was broken because `exploreService` filtered API results by `r.type` while `/api/recommendations/` returns `result_type` — every card fell through to a single generic "Discover" rail with empty placeholders. Normalized the payload, grouped by `region_tag`, surfaced the real `image` / `description` / `region_tag` / `rank_reason` fields that were already in the response, and reshaped the page around the regional-table framing.

Explore page: Added a "Today on Genipe" featured rail (top items by `rank_score`, taller cards), a region jump-nav chip bar, a sparse-rail grid layout (≤3 items), a per-rail author cap (max 2 per author), a 📖 glyph + `→ recipe` chip on story cards, a bookmark button on recipe cards for signed-in users, a hover overlay with description + `rank_reason`, skeleton rails during load, a sign-in banner for anonymous users, and an empty state with CTAs to /map and /recipes/new.

No backend changes.

Test plan
 [ ] Go to /explore — featured rail at top, then one rail per region (e.g. *Aegean*, *Marmara*, *Black Sea*); region badge is hidden inside region rails but visible on featured / catch-all
 [ ] Click a chip in the region jump-nav under the title — page scrolls to that rail
 [ ] A rail with 2 items renders as a left-aligned grid; a rail with 4+ items renders as a horizontal scroll
 [ ] Within a single rail, no author appears more than twice
 [ ] Each card shows the real cover image; force a broken `image` URL and confirm the gradient fallback shows with no console error
 [ ] Hover a card — description appears; if the item has a `rank_reason`, it shows under the description in italics
 [ ] Sign in, click the 🏷️ bookmark on a recipe card — icon flips to 🔖 (one network call to `/api/recipes/<id>/bookmark/`); click again — reverts
 [ ] Sign out — bookmark icon is gone; sign-in banner appears under the title
 [ ] Stub the API to return `[]` — empty state renders with "Open the map" and "Share a recipe" CTAs
 [ ] Stub the API to reject — error message renders
 [ ] During load, three skeleton rails are visible; no "Loading…" text; no layout jump when data arrives
 [ ] Story cards show 📖; stories with `linked_recipe_id` show a `→ recipe` chip that navigates to the linked recipe
 [ ] Open `/explore/region-aegean` (or whichever region exists) — EventDetailPage loads with the same items
 [ ] Run `CI=true npm test -- --testPathPattern="(ExplorePage|exploreService|EventDetailPage)"` — 19 tests pass