### PR TITLE
fix(frontend): floating prompt scroll + cultural highlights always to detail page

### DIFF
--- a/app/frontend/src/__tests__/CulturalHighlightPage.test.jsx
+++ b/app/frontend/src/__tests__/CulturalHighlightPage.test.jsx
@@ -55,4 +55,32 @@ describe('CulturalHighlightPage', () => {
     renderAt('dc-fact-1');
     expect(await screen.findByText(/could not load this highlight/i)).toBeInTheDocument();
   });
+
+  it('surfaces a "View the linked recipe" link when item.link.kind=recipe', async () => {
+    culturalContentService.fetchDailyCulturalContent.mockResolvedValue([
+      { id: 'dc-fact-1', kind: 'fact', title: 'X', body: '', region: null, tags: [], link: { kind: 'recipe', id: 42 } },
+    ]);
+    renderAt('dc-fact-1');
+    const link = await screen.findByRole('link', { name: /view the linked recipe/i });
+    expect(link).toHaveAttribute('href', '/recipes/42');
+  });
+
+  it('surfaces a "Read the linked story" link when item.link.kind=story', async () => {
+    culturalContentService.fetchDailyCulturalContent.mockResolvedValue([
+      { id: 'dc-fact-2', kind: 'fact', title: 'X', body: '', region: null, tags: [], link: { kind: 'story', id: 7 } },
+    ]);
+    renderAt('dc-fact-2');
+    const link = await screen.findByRole('link', { name: /read the linked story/i });
+    expect(link).toHaveAttribute('href', '/stories/7');
+  });
+
+  it('omits the related link when item has no link', async () => {
+    culturalContentService.fetchDailyCulturalContent.mockResolvedValue([
+      { id: 'dc-fact-3', kind: 'fact', title: 'X', body: '', region: null, tags: [], link: null },
+    ]);
+    renderAt('dc-fact-3');
+    await screen.findByRole('heading', { name: /x/i });
+    expect(screen.queryByRole('link', { name: /view the linked/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /read the linked/i })).not.toBeInTheDocument();
+  });
 });

--- a/app/frontend/src/__tests__/DailyCulturalSection.test.jsx
+++ b/app/frontend/src/__tests__/DailyCulturalSection.test.jsx
@@ -42,24 +42,19 @@ test('unknown kind falls back to globe emoji and default class', () => {
   expect(document.querySelector('.card-default')).toBeInTheDocument();
 });
 
-test('Read more link points to /recipes/:id when link.kind=recipe', () => {
+test('Read more always routes to /highlights/:id (link target may be stale)', () => {
   wrap(<DailyCulturalSection items={[{ ...ITEMS[0], link: { kind: 'recipe', id: 42 } }]} />);
-  expect(screen.getByText('Read more →')).toHaveAttribute('href', '/recipes/42');
+  expect(screen.getByText('Read more →')).toHaveAttribute('href', '/highlights/1');
 });
 
-test('Read more link points to /stories/:id when link.kind=story', () => {
-  wrap(<DailyCulturalSection items={[{ ...ITEMS[1], link: { kind: 'story', id: 7 } }]} />);
-  expect(screen.getByText('Read more →')).toHaveAttribute('href', '/stories/7');
-});
-
-test('Read more link points to /calendar when link.kind=event', () => {
-  wrap(<DailyCulturalSection items={[{ ...ITEMS[3], link: { kind: 'event', id: 3 } }]} />);
-  expect(screen.getByText('Read more →')).toHaveAttribute('href', '/calendar');
-});
-
-test('Read more falls back to /highlights/:id when no link is present', () => {
+test('Read more routes to /highlights/:id when there is no link at all', () => {
   wrap(<DailyCulturalSection items={[ITEMS[0]]} />);
   expect(screen.getByText('Read more →')).toHaveAttribute('href', '/highlights/1');
+});
+
+test('Read more URL-encodes the highlight id', () => {
+  wrap(<DailyCulturalSection items={[{ ...ITEMS[0], id: 'dc-fact-7' }]} />);
+  expect(screen.getByText('Read more →')).toHaveAttribute('href', '/highlights/dc-fact-7');
 });
 
 test('renders nothing when items is empty', () => {

--- a/app/frontend/src/components/DailyCulturalSection.jsx
+++ b/app/frontend/src/components/DailyCulturalSection.jsx
@@ -9,21 +9,14 @@ const KIND_CONFIG = {
 };
 const FALLBACK = { emoji: '🌍', colorClass: 'card-default', label: 'Culture' };
 
-// Backend ships an optional `link: { kind, id }` per card pointing at the
-// recipe / story / event that owns the highlight. Map that to a real route
-// so "Read more" actually opens something instead of dumping the title into
-// the search box. Items without a link fall back to /highlights/:id which
-// renders the card's full body on a dedicated page.
+// Always route Read more to the dedicated highlight detail page. The backend
+// ships an optional `link: { kind, id }` per card, but its target may have
+// been deleted between when the highlight was authored and when the user
+// clicks — sending the user straight to /recipes/:id only to greet them with
+// "could not load recipe" is worse than landing on the highlight page where
+// the body is always available. The detail page itself surfaces the linked
+// content as a secondary action.
 function targetForItem(item) {
-  const link = item?.link;
-  if (link && link.kind && link.id != null) {
-    switch (String(link.kind).toLowerCase()) {
-      case 'recipe': return `/recipes/${link.id}`;
-      case 'story':  return `/stories/${link.id}`;
-      case 'event':  return '/calendar';
-      default:       break;
-    }
-  }
   return `/highlights/${encodeURIComponent(item.id)}`;
 }
 

--- a/app/frontend/src/components/FloatingCulturalPrompt.css
+++ b/app/frontend/src/components/FloatingCulturalPrompt.css
@@ -13,6 +13,8 @@
   border-radius: var(--radius-xl);
   padding: 1.25rem 1.5rem;
   max-width: 320px;
+  max-height: calc(100vh - 4rem);
+  overflow-y: auto;
   box-shadow: var(--shadow-md);
   animation: prompt-slide-up 0.4s cubic-bezier(0.22, 1, 0.36, 1) both;
 }

--- a/app/frontend/src/pages/CulturalHighlightPage.css
+++ b/app/frontend/src/pages/CulturalHighlightPage.css
@@ -46,6 +46,26 @@
   white-space: pre-wrap;
 }
 
+.cultural-highlight-related {
+  margin: 1.25rem 0 0;
+}
+
+.cultural-highlight-related-link {
+  display: inline-block;
+  background: rgba(196, 82, 30, 0.08);
+  color: var(--color-primary, #C4521E);
+  padding: 0.45rem 0.9rem;
+  border-radius: var(--radius-sm, 6px);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.cultural-highlight-related-link:hover,
+.cultural-highlight-related-link:focus-visible {
+  background: rgba(196, 82, 30, 0.14);
+  text-decoration: underline;
+}
+
 .cultural-highlight-tags {
   list-style: none;
   margin: 1.5rem 0 0;

--- a/app/frontend/src/pages/CulturalHighlightPage.jsx
+++ b/app/frontend/src/pages/CulturalHighlightPage.jsx
@@ -53,6 +53,7 @@ export default function CulturalHighlightPage() {
   }
 
   const kindLabel = item.kind ? KIND_LABEL[item.kind] ?? null : null;
+  const linked = relatedLink(item.link);
 
   return (
     <main className="page-card cultural-highlight">
@@ -67,6 +68,14 @@ export default function CulturalHighlightPage() {
 
       {item.body && <p className="cultural-highlight-body">{item.body}</p>}
 
+      {linked && (
+        <p className="cultural-highlight-related">
+          <Link to={linked.href} className="cultural-highlight-related-link">
+            {linked.label} →
+          </Link>
+        </p>
+      )}
+
       {item.tags && item.tags.length > 0 && (
         <ul className="cultural-highlight-tags" aria-label="Tags">
           {item.tags.map((tag) => (
@@ -76,4 +85,14 @@ export default function CulturalHighlightPage() {
       )}
     </main>
   );
+}
+
+function relatedLink(link) {
+  if (!link || !link.kind || link.id == null) return null;
+  switch (String(link.kind).toLowerCase()) {
+    case 'recipe': return { href: `/recipes/${link.id}`, label: 'View the linked recipe' };
+    case 'story':  return { href: `/stories/${link.id}`, label: 'Read the linked story' };
+    case 'event':  return { href: '/calendar',           label: 'See on the cultural calendar' };
+    default:       return null;
+  }
 }


### PR DESCRIPTION
Two adjacent fixes on the Explore page.

## 1. Floating cultural prompt overflow

The "What would you like to taste this week? ✨" floating prompt grew past the viewport when the user clicked **+50 more** on the region chip list — the overlay clipped behind the screen edge and there was no way to reach the chips at the bottom.

\`.floating-prompt\` now has \`max-height: calc(100vh - 4rem)\` + \`overflow-y: auto\`, so it scrolls inside its own box instead of clipping.

## 2. Cultural Highlights "Read more" landing on broken recipes

PR #862 routed Read more straight to \`/recipes/:id\` / \`/stories/:id\` when the backend gave a \`link\`. In practice the linked recipe / story has sometimes been removed since the highlight was authored, so the user lands on **"Could not load recipe"** with no way back to the highlight body.

Now:
- **\`DailyCulturalSection\`**: Read more always opens \`/highlights/:id\`. The detail page body is the guaranteed available content.
- **\`CulturalHighlightPage\`**: when the item carries a \`link\`, the page surfaces a secondary "View the linked recipe →" / "Read the linked story →" / "See on the cultural calendar →" action below the body. If that target is stale, the primary read still works — only the secondary link errors, which is recoverable.

## Test plan
- [x] Full Jest suite: 740 passing (84 suites)
- [x] Production build clean
- [ ] Manual QA: open Explore, expand the +50 more chip list — overlay scrolls. Click any highlight Read more — opens \`/highlights/...\` with full body; if linked content exists, the related-link button works.