### PR TITLE
feat(frontend): SiteHeader user menu rework + Avatar component (#879)

### DIFF
--- a/app/frontend/src/__tests__/Avatar.test.jsx
+++ b/app/frontend/src/__tests__/Avatar.test.jsx
@@ -1,0 +1,34 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import Avatar from '../components/Avatar';
+
+describe('Avatar', () => {
+  it('renders the username initial when no profile_picture is set', () => {
+    render(<Avatar user={{ username: 'ayse' }} size="sm" />);
+    expect(screen.getByText('A')).toBeInTheDocument();
+  });
+
+  it('renders ? when there is no user', () => {
+    render(<Avatar user={null} size="sm" />);
+    expect(screen.getByText('?')).toBeInTheDocument();
+  });
+
+  it('renders an <img> when profile_picture is present', () => {
+    render(<Avatar user={{ username: 'ayse', profile_picture: '/media/avatars/a.jpg' }} size="md" />);
+    const img = document.querySelector('img.avatar-image');
+    expect(img).not.toBeNull();
+    expect(img).toHaveAttribute('src', '/media/avatars/a.jpg');
+    expect(screen.queryByText('A')).not.toBeInTheDocument();
+  });
+
+  it('falls back to initials when the image fails to load', () => {
+    render(<Avatar user={{ username: 'ayse', profile_picture: '/broken.jpg' }} size="sm" />);
+    const img = document.querySelector('img.avatar-image');
+    fireEvent.error(img);
+    expect(screen.getByText('A')).toBeInTheDocument();
+  });
+
+  it('applies the size variant class', () => {
+    const { container } = render(<Avatar user={{ username: 'a' }} size="md" />);
+    expect(container.querySelector('.avatar-md')).not.toBeNull();
+  });
+});

--- a/app/frontend/src/__tests__/Navbar.test.jsx
+++ b/app/frontend/src/__tests__/Navbar.test.jsx
@@ -76,6 +76,21 @@ describe('Navbar', () => {
     expect(link).toHaveAttribute('href', '/profile');
   });
 
+  it('routes "My Account" to the user\'s public profile by username', () => {
+    renderNavbar({ id: 1, username: 'eren' });
+    fireEvent.click(screen.getByRole('button', { name: /@eren/i }));
+    const link = screen.getByRole('link', { name: /my account/i });
+    expect(link).toHaveAttribute('href', '/users/eren');
+  });
+
+  it('renders @username inside the toggle button (no separate profile link)', () => {
+    renderNavbar({ id: 1, username: 'eren' });
+    const toggle = screen.getByRole('button', { name: /@eren/i });
+    expect(toggle.textContent).toContain('@eren');
+    // The username text should not be a standalone link in the header anymore.
+    expect(screen.queryByRole('link', { name: '@eren' })).not.toBeInTheDocument();
+  });
+
   it('renders a Calendar link to /calendar', () => {
     renderNavbar();
     const link = screen.getByRole('link', { name: /calendar/i });

--- a/app/frontend/src/components/Avatar.css
+++ b/app/frontend/src/components/Avatar.css
@@ -1,0 +1,37 @@
+.avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-primary);
+  color: #fff;
+  font-weight: 700;
+  border-radius: 50%;
+  overflow: hidden;
+  flex-shrink: 0;
+  line-height: 1;
+}
+
+.avatar-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.avatar-sm {
+  width: 28px;
+  height: 28px;
+  font-size: 0.8125rem;
+}
+
+.avatar-md {
+  width: 64px;
+  height: 64px;
+  font-size: 1.5rem;
+}
+
+.avatar-lg {
+  width: 96px;
+  height: 96px;
+  font-size: 2.25rem;
+}

--- a/app/frontend/src/components/Avatar.jsx
+++ b/app/frontend/src/components/Avatar.jsx
@@ -1,0 +1,24 @@
+import { useState } from 'react';
+import './Avatar.css';
+
+export default function Avatar({ user, size = 'sm', className = '' }) {
+  const [imageBroken, setImageBroken] = useState(false);
+  const initial = user?.username?.[0]?.toUpperCase() ?? '?';
+  const photo = user?.profile_picture;
+  const showImage = photo && !imageBroken;
+  const classes = `avatar avatar-${size}${className ? ` ${className}` : ''}`;
+
+  if (showImage) {
+    return (
+      <span className={classes}>
+        <img
+          src={photo}
+          alt=""
+          className="avatar-image"
+          onError={() => setImageBroken(true)}
+        />
+      </span>
+    );
+  }
+  return <span className={classes} aria-hidden="true">{initial}</span>;
+}

--- a/app/frontend/src/components/Navbar.css
+++ b/app/frontend/src/components/Navbar.css
@@ -65,56 +65,34 @@
   position: relative;
 }
 
-.navbar-user-btn-area {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  border: 1.5px solid var(--color-border);
-  border-radius: 999px;
-  padding: 0.3rem 0.75rem 0.3rem 0.3rem;
-  transition: background 0.15s ease, border-color 0.15s ease;
-  cursor: pointer;
-}
-
-.navbar-user-btn-area:hover {
-  background: var(--color-surface-dark);
-  border-color: var(--color-primary);
-}
-
-.navbar-user-btn-area:hover .navbar-username {
-  color: var(--color-surface);
-}
-
-.navbar-user-btn-area:hover .navbar-chevron {
-  border-color: var(--color-surface);
-}
-
 .navbar-user-btn {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  background: none;
-  border: none;
-  padding: 0;
+  border: 1.5px solid var(--color-border);
+  background: transparent;
+  border-radius: 999px;
+  padding: 0.3rem 0.75rem 0.3rem 0.3rem;
+  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
   cursor: pointer;
+  font: inherit;
+  color: inherit;
 }
 
-.navbar-user-btn:hover {
-  background: none;
+.navbar-user-btn:hover,
+.navbar-user-btn:focus-visible {
+  background: var(--color-surface-dark);
+  border-color: var(--color-primary);
 }
 
-.navbar-avatar {
-  width: 28px;
-  height: 28px;
-  border-radius: 50%;
-  background: var(--color-primary);
-  color: #fff;
-  font-size: 0.8125rem;
-  font-weight: 700;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
+.navbar-user-btn:hover .navbar-username,
+.navbar-user-btn:focus-visible .navbar-username {
+  color: var(--color-surface);
+}
+
+.navbar-user-btn:hover .navbar-chevron,
+.navbar-user-btn:focus-visible .navbar-chevron {
+  border-color: var(--color-surface);
 }
 
 .navbar-chevron {

--- a/app/frontend/src/components/Navbar.jsx
+++ b/app/frontend/src/components/Navbar.jsx
@@ -2,6 +2,7 @@ import { useContext, useState, useEffect, useRef } from 'react';
 import { Link, NavLink } from 'react-router-dom';
 import { AuthContext } from '../context/AuthContext';
 import NotificationTray from './NotificationTray';
+import Avatar from './Avatar';
 import './Navbar.css';
 
 export default function Navbar() {
@@ -70,24 +71,18 @@ export default function Navbar() {
             <>
               <NotificationTray />
               <div className="navbar-user-menu" ref={menuRef}>
-                <div className="navbar-user-btn-area">
-                  <button
-                    className="navbar-user-btn"
-                    onClick={() => setMenuOpen(o => !o)}
-                    aria-expanded={menuOpen}
-                    aria-haspopup="true"
-                    aria-label={`User menu for @${user.username}`}
-                  >
-                    <span className="navbar-avatar">
-                      {user.username?.[0]?.toUpperCase() ?? '?'}
-                    </span>
-                    <span className={`navbar-chevron${menuOpen ? ' open' : ''}`} aria-hidden="true" />
-                  </button>
-                  <Link
-                    to={`/users/${user.username}`}
-                    className="navbar-username"
-                  >@{user.username}</Link>
-                </div>
+                <button
+                  type="button"
+                  className="navbar-user-btn"
+                  onClick={() => setMenuOpen(o => !o)}
+                  aria-expanded={menuOpen}
+                  aria-haspopup="true"
+                  aria-label={`User menu for @${user.username}`}
+                >
+                  <Avatar user={user} size="sm" />
+                  <span className="navbar-username">@{user.username}</span>
+                  <span className={`navbar-chevron${menuOpen ? ' open' : ''}`} aria-hidden="true" />
+                </button>
                 {menuOpen && (
                   <div className="navbar-dropdown" role="menu">
                     <Link
@@ -98,7 +93,7 @@ export default function Navbar() {
                       Profile
                     </Link>
                     <Link
-                      to="/account"
+                      to={`/users/${user.username}`}
                       className="navbar-dropdown-item"
                       onClick={() => setMenuOpen(false)}
                     >

--- a/app/frontend/src/pages/AccountPage.css
+++ b/app/frontend/src/pages/AccountPage.css
@@ -2,6 +2,19 @@
   max-width: 640px;
 }
 
+.account-page-back {
+  display: inline-block;
+  margin-bottom: 1rem;
+  color: var(--color-text-muted);
+  font-size: 0.875rem;
+  text-decoration: none;
+  font-weight: 600;
+}
+.account-page-back:hover {
+  color: var(--color-primary);
+  text-decoration: underline;
+}
+
 .account-page-header {
   margin-bottom: 2rem;
 }

--- a/app/frontend/src/pages/AccountPage.jsx
+++ b/app/frontend/src/pages/AccountPage.jsx
@@ -1,4 +1,5 @@
 import { useContext, useEffect, useRef, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { AuthContext } from '../context/AuthContext';
 import { extractApiError } from '../services/api';
 import { updateMe } from '../services/authService';
@@ -97,6 +98,11 @@ export default function AccountPage() {
 
   return (
     <main className="page-card account-page">
+      {user?.username && (
+        <Link to={`/users/${user.username}`} className="account-page-back">
+          ← Back to my profile
+        </Link>
+      )}
       <div className="account-page-header">
         <h1>My Account</h1>
         <p className="account-page-sub">Manage your cultural preferences.</p>

--- a/app/frontend/src/pages/UserProfilePage.css
+++ b/app/frontend/src/pages/UserProfilePage.css
@@ -11,20 +11,6 @@
   flex-wrap: wrap;
 }
 
-.user-profile-avatar {
-  width: 64px;
-  height: 64px;
-  border-radius: 50%;
-  background: var(--color-primary);
-  color: #fff;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 1.6rem;
-  font-weight: 700;
-  flex-shrink: 0;
-}
-
 .user-profile-identity {
   flex: 1;
   display: flex;

--- a/app/frontend/src/pages/UserProfilePage.jsx
+++ b/app/frontend/src/pages/UserProfilePage.jsx
@@ -3,6 +3,7 @@ import { useParams, Link, useNavigate } from 'react-router-dom';
 import { AuthContext } from '../context/AuthContext';
 import { getPublicProfile, getPassport } from '../services/passportService';
 import { extractApiError } from '../services/api';
+import Avatar from '../components/Avatar';
 import PassportCover from '../components/passport/PassportCover';
 import PassportStatsBar from '../components/passport/PassportStatsBar';
 import StampGrid from '../components/passport/StampGrid';
@@ -69,7 +70,7 @@ export default function UserProfilePage() {
 
       {/* Header */}
       <div className="user-profile-header">
-        <div className="user-profile-avatar">{profile.username?.[0]?.toUpperCase() ?? '?'}</div>
+        <Avatar user={profile} size="md" className="user-profile-avatar" />
         <div className="user-profile-identity">
           <h1 className="user-profile-username">@{profile.username}</h1>
           {profile.region && <span className="user-profile-region">📍 {profile.region}</span>}
@@ -77,7 +78,7 @@ export default function UserProfilePage() {
         </div>
         {isOwn && (
           <Link to="/account" className="btn btn-outline btn-sm user-profile-edit-btn">
-            Edit preferences
+            Edit Preferences
           </Link>
         )}
       </div>


### PR DESCRIPTION
Summary
SiteHeader: The user control was awkward — `A ▾` toggled the dropdown while `@ayse` was a separate link to the profile. Reordered to `A @ayse ▾` as a single toggle button. Removed the standalone username link.

Dropdown: "My Account" now navigates to `/users/<username>` (the user's own public profile) instead of `/account`. "Profile" still points at `/profile`.

New `Avatar` component (`app/frontend/src/components/Avatar.jsx`): renders `<img src={user.profile_picture}>` when the field is present, falls back to initials on missing or broken image. Used in the Navbar and on `UserProfilePage`. Backend support for `profile_picture` is tracked in #878 — once that lands, photos appear automatically with no frontend follow-up.

UserProfilePage: Swapped the initials div for `<Avatar size="md">`. Capitalized the existing own-profile button label to "Edit Preferences".

AccountPage: Added a `← Back to my profile` link at the top to close the round-trip from `/users/:username`.

Tests: New `Avatar.test.jsx` (initials, ?, img, onError fallback, size class). Navbar test now also asserts "My Account → /users/:username" and that `@username` is inside the toggle button, not a separate link.

Test plan
 [ ] Logged-in header reads `A @ayse ▾`; clicking anywhere on it toggles the dropdown
 [ ] Dropdown → **My Account** navigates to `/users/<my-username>`
 [ ] Dropdown → **Profile** still navigates to `/profile`
 [ ] On `/users/<my-username>`, the "Edit Preferences" button is visible and links to `/account`
 [ ] On `/users/<someone-else>`, the "Edit Preferences" button is absent
 [ ] `/account` shows "← Back to my profile" linking back to `/users/<my-username>`; saving preferences still persists (PATCH /api/users/me/)
 [ ] Avatar shows initials everywhere (until #878 ships); when a user has `profile_picture`, the avatar renders the image; if the image URL is broken, it falls back to initials with no console error
 [ ] `CI=true npm test -- --testPathPattern="(Navbar|Avatar|AccountPage)"` — passes
 [ ] Logged-out header still shows Log In / Sign Up