### PR TITLE
feat(mobile): clean profile tab and add rich user info header (#873, #874)

### DIFF
--- a/app/mobile/src/screens/UserProfileScreen.tsx
+++ b/app/mobile/src/screens/UserProfileScreen.tsx
@@ -18,6 +18,10 @@ import {
   type BookmarkedRecipeListItem,
 } from '../services/bookmarkService';
 import { fetchPassport, type Passport } from '../services/passportService';
+import {
+  fetchPublicProfile,
+  type PublicUserProfile,
+} from '../services/profileService';
 import { fetchRecipesList } from '../services/recipeService';
 import { fetchStoriesList } from '../services/storyService';
 import { resolveTheme } from '../utils/passportTheme';
@@ -97,6 +101,11 @@ export default function UserProfileScreen({ route, navigation }: Props) {
   const [passportLoading, setPassportLoading] = useState(true);
   const [passportError, setPassportError] = useState<string | null>(null);
   const [activePassportTab, setActivePassportTab] = useState<PassportTabKey>('stamps');
+
+  // Public profile (#874): bio, region, join date, stats, preference tags.
+  // Failures here must not break the rest of the screen — we simply skip the
+  // rich header section. The legacy fetches above stay independent.
+  const [publicProfile, setPublicProfile] = useState<PublicUserProfile | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -182,6 +191,29 @@ export default function UserProfileScreen({ route, navigation }: Props) {
     }, [loadPassport]),
   );
 
+  // Fetch the public profile by username. Don't block the screen on failure —
+  // we just skip the rich header if it errors.
+  useEffect(() => {
+    let cancelled = false;
+    if (!username) {
+      setPublicProfile(null);
+      return () => {
+        cancelled = true;
+      };
+    }
+    void (async () => {
+      try {
+        const data = await fetchPublicProfile(username);
+        if (!cancelled) setPublicProfile(data);
+      } catch {
+        if (!cancelled) setPublicProfile(null);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [username, reloadToken]);
+
   // Initial fetch when the user first opens the Saved tab.
   useEffect(() => {
     if (isOwnProfile && activeTab === 'saved' && savedRecipes.length === 0 && !savedLoading && !savedError) {
@@ -226,10 +258,57 @@ export default function UserProfileScreen({ route, navigation }: Props) {
           <View style={styles.avatar} accessibilityLabel="User avatar">
             <Text style={styles.avatarText}>{initial}</Text>
           </View>
-          <Text style={styles.username} accessibilityRole="header">
-            {username ?? `User #${userIdStr}`}
-          </Text>
+          <View style={styles.headerIdentity}>
+            <Text style={styles.username} accessibilityRole="header">
+              {username ?? `User #${userIdStr}`}
+            </Text>
+            {publicProfile?.region ? (
+              <View style={styles.regionPill} accessibilityLabel={`Region ${publicProfile.region}`}>
+                <Text style={styles.regionPillText} numberOfLines={1}>
+                  {`\u{1F4CD} ${publicProfile.region}`}
+                </Text>
+              </View>
+            ) : null}
+            {publicProfile?.created_at ? (
+              <Text style={styles.joinedText}>
+                {`Joined ${new Date(publicProfile.created_at).getFullYear()}`}
+              </Text>
+            ) : null}
+          </View>
         </View>
+
+        {publicProfile ? (
+          <View style={styles.infoCard}>
+            {publicProfile.bio ? (
+              <Text style={styles.bioText}>{publicProfile.bio}</Text>
+            ) : null}
+            <Text style={styles.statsText} accessibilityLabel="Profile stats">
+              {`${publicProfile.recipe_count ?? 0} recipes · ${publicProfile.story_count ?? 0} stories`}
+            </Text>
+            <TagSection label="Cultural Interests" values={publicProfile.cultural_interests} />
+            <TagSection label="Dietary Preferences" values={publicProfile.religious_preferences} />
+            <TagSection label="Event Interests" values={publicProfile.event_interests} />
+            {isOwnProfile ? (
+              <Pressable
+                onPress={() => navigation.navigate('EditProfile')}
+                style={({ pressed }) => [styles.editBtn, pressed && styles.pressed]}
+                accessibilityRole="button"
+                accessibilityLabel="Edit profile"
+              >
+                <Text style={styles.editBtnText}>{'✏️  Edit profile'}</Text>
+              </Pressable>
+            ) : null}
+          </View>
+        ) : isOwnProfile ? (
+          <Pressable
+            onPress={() => navigation.navigate('EditProfile')}
+            style={({ pressed }) => [styles.editBtnStandalone, pressed && styles.pressed]}
+            accessibilityRole="button"
+            accessibilityLabel="Edit profile"
+          >
+            <Text style={styles.editBtnText}>{'✏️  Edit profile'}</Text>
+          </Pressable>
+        ) : null}
 
         {canMessage ? (
           <Pressable
@@ -434,6 +513,30 @@ export default function UserProfileScreen({ route, navigation }: Props) {
   );
 }
 
+function TagSection({
+  label,
+  values,
+}: {
+  label: string;
+  values?: string[] | null;
+}) {
+  if (!values || values.length === 0) return null;
+  return (
+    <View style={styles.tagSection} accessibilityLabel={label}>
+      <Text style={styles.tagSectionTitle}>{label}</Text>
+      <View style={styles.tagRow}>
+        {values.map((v) => (
+          <View key={`${label}-${v}`} style={styles.tagPill}>
+            <Text style={styles.tagPillText} numberOfLines={1}>
+              {v}
+            </Text>
+          </View>
+        ))}
+      </View>
+    </View>
+  );
+}
+
 function TabButton({
   label,
   active,
@@ -498,6 +601,69 @@ const styles = StyleSheet.create({
     color: tokens.colors.text,
     fontFamily: tokens.typography.display.fontFamily,
     flexShrink: 1,
+  },
+  headerIdentity: { flex: 1, minWidth: 0, gap: 6 },
+  regionPill: {
+    alignSelf: 'flex-start',
+    backgroundColor: tokens.colors.accentGreenTint,
+    borderWidth: 1,
+    borderColor: tokens.colors.surfaceDark,
+    borderRadius: tokens.radius.pill,
+    paddingHorizontal: 10,
+    paddingVertical: 3,
+  },
+  regionPillText: { fontSize: 12, fontWeight: '700', color: tokens.colors.text },
+  joinedText: { fontSize: 12, color: tokens.colors.textMuted, fontWeight: '600' },
+  infoCard: {
+    borderWidth: 1,
+    borderColor: tokens.colors.border,
+    borderRadius: tokens.radius.xl,
+    backgroundColor: tokens.colors.surface,
+    padding: 16,
+    marginBottom: 22,
+    gap: 12,
+    ...shadows.md,
+  },
+  bioText: { fontSize: 15, color: tokens.colors.text, lineHeight: 21 },
+  statsText: { fontSize: 13, fontWeight: '700', color: tokens.colors.textMuted },
+  tagSection: { gap: 6 },
+  tagSectionTitle: { fontSize: 13, fontWeight: '800', color: tokens.colors.text, letterSpacing: 0.3 },
+  tagRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 6 },
+  tagPill: {
+    backgroundColor: tokens.colors.bg,
+    borderWidth: 1,
+    borderColor: tokens.colors.surfaceDark,
+    borderRadius: tokens.radius.pill,
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+  },
+  tagPillText: { fontSize: 12, fontWeight: '700', color: tokens.colors.text },
+  editBtn: {
+    alignSelf: 'flex-start',
+    paddingVertical: 10,
+    paddingHorizontal: 16,
+    borderRadius: tokens.radius.pill,
+    backgroundColor: tokens.colors.accentGreen,
+    borderWidth: 2,
+    borderColor: tokens.colors.surfaceDark,
+    ...shadows.sm,
+  },
+  editBtnStandalone: {
+    alignSelf: 'flex-start',
+    marginBottom: 22,
+    paddingVertical: 10,
+    paddingHorizontal: 16,
+    borderRadius: tokens.radius.pill,
+    backgroundColor: tokens.colors.accentGreen,
+    borderWidth: 2,
+    borderColor: tokens.colors.surfaceDark,
+    ...shadows.sm,
+  },
+  editBtnText: {
+    color: tokens.colors.textOnDark,
+    fontSize: 14,
+    fontWeight: '800',
+    letterSpacing: 0.3,
   },
   messageBtn: {
     marginBottom: 22,

--- a/app/mobile/src/screens/tabs/ProfileTabScreen.tsx
+++ b/app/mobile/src/screens/tabs/ProfileTabScreen.tsx
@@ -88,40 +88,10 @@ export default function ProfileTabScreen() {
 
               <View style={styles.list}>
                 <ActionRow
-                  icon="\u{1F373}"
-                  label="My recipes"
-                  onPress={openUserProfile}
-                  accessibilityLabel="View my recipes"
-                />
-                <ActionRow
-                  icon="\u{1F4DC}"
-                  label="My stories"
-                  onPress={openUserProfile}
-                  accessibilityLabel="View my stories"
-                />
-                <ActionRow
-                  icon="\u{1F516}"
-                  label="Saved recipes"
-                  onPress={openUserProfile}
-                  accessibilityLabel="View saved recipes"
-                />
-                <ActionRow
                   icon="✉️"
                   label="Messages"
                   onPress={() => navigation.navigate('Feed', { screen: 'Inbox' })}
                   accessibilityLabel="Open messages"
-                />
-                <ActionRow
-                  icon="\u{1F30D}"
-                  label="Cultural preferences"
-                  onPress={() => navigation.navigate('Feed', { screen: 'Onboarding' })}
-                  accessibilityLabel="Update cultural preferences"
-                />
-                <ActionRow
-                  icon="✏️"
-                  label="Edit profile"
-                  onPress={() => navigation.navigate('Feed', { screen: 'EditProfile' })}
-                  accessibilityLabel="Edit profile"
                 />
                 <ActionRow
                   icon="\u{1F6AA}"

--- a/app/mobile/src/screens/tabs/ProfileTabScreen.tsx
+++ b/app/mobile/src/screens/tabs/ProfileTabScreen.tsx
@@ -94,7 +94,7 @@ export default function ProfileTabScreen() {
                   accessibilityLabel="Open messages"
                 />
                 <ActionRow
-                  icon="\u{1F6AA}"
+                  icon="🚪"
                   label="Log out"
                   onPress={() => void logout()}
                   accessibilityLabel="Log out"

--- a/app/mobile/src/services/profileService.ts
+++ b/app/mobile/src/services/profileService.ts
@@ -54,3 +54,33 @@ export async function updateOwnProfile(
 ): Promise<UserProfile> {
   return apiPatchJson<UserProfile>(ENDPOINT, patch);
 }
+
+/**
+ * Public-facing user profile shape returned by `GET /api/users/<username>/`.
+ *
+ * Backed by `PublicUserSerializer` in
+ * `app/backend/apps/users/serializers.py`. Note this endpoint lives at
+ * `/api/users/<username>/` (no `/profile/` suffix). The "dietary preferences"
+ * surfaced on web is actually the `religious_preferences` field on the
+ * backend — there is no separate `dietary_preferences` field today.
+ */
+export type PublicUserProfile = {
+  username: string;
+  bio?: string | null;
+  region?: string | null;
+  cultural_interests?: string[];
+  religious_preferences?: string[];
+  event_interests?: string[];
+  created_at?: string | null;
+  recipe_count?: number;
+  story_count?: number;
+};
+
+/** Fetch a user's public profile by username. */
+export async function fetchPublicProfile(
+  username: string,
+): Promise<PublicUserProfile> {
+  return apiGetJson<PublicUserProfile>(
+    `/api/users/${encodeURIComponent(username)}/`,
+  );
+}


### PR DESCRIPTION
Summary
ProfileTabScreen: Removed redundant first-layer rows (My recipes, My stories, Saved recipes, Cultural preferences, Edit profile) since UserProfile already exposes Recipes/Stories/Saved as tabs and Edit profile is accessible from there. Kept avatar/username card + Messages + Log out. Also fixed the Log out icon which was rendering as the literal string \u{1F6AA} because JSX attribute strings don't process escape sequences — switched to a raw 🚪 character. (#873)

UserProfileScreen: Added a rich header card matching the web UserProfilePage — region pill, join year, bio, "X recipes · Y stories" stats line, and chip rows for Cultural Interests / Dietary Preferences / Event Interests. Added an "Edit profile" button on own-profile that navigates to EditProfile, replacing the removed row in ProfileTabScreen. Non-own profiles continue to show the existing "Message" button. (#874)

profileService: Added fetchPublicProfile(username) hitting GET /api/users/<username>/ (note: not /profile/ — that path 404s). Comments document two other backend surprises: religious_preferences is the field name behind the UI's "Dietary Preferences" label, and created_at is what we use for the join date.

Test plan
 [ ] Profile tab shows only the avatar card, Messages, and Log out — no My recipes / My stories / Saved recipes / Cultural preferences rows
 [ ] Log out row icon renders as a door emoji, not the literal text \u{1F6AA}
 [ ] Open own profile from the avatar card — rich header (region, joined year, bio, stats, chip rows) renders
 [ ] Tap "Edit profile" on own profile — navigates to EditProfile screen
 [ ] Open another user's profile (e.g. via "By mehmet" chip on a story) — rich header renders, "Message" button shown, "Edit profile" button NOT shown
 [ ] Recipes / Stories / Saved tabs still work on both own and other-user profiles