### PR TITLE
feat(frontend): home page redesign — region map, weekly rails, feedback, closing banner (#876)

### DIFF
--- a/app/frontend/src/__tests__/FeedbackBar.test.jsx
+++ b/app/frontend/src/__tests__/FeedbackBar.test.jsx
@@ -1,0 +1,68 @@
+import { render, screen, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import FeedbackBar from '../components/FeedbackBar';
+import * as feedbackService from '../services/feedbackService';
+
+jest.mock('../services/feedbackService');
+
+function renderBar() {
+  return render(<FeedbackBar />);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  feedbackService.submitFeedback = jest.fn().mockResolvedValue({ message: 'ok' });
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe('FeedbackBar', () => {
+  it('renders the label, input, and Send button', () => {
+    renderBar();
+    expect(screen.getByLabelText(/what would you like to see on genipe/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /send/i })).toBeInTheDocument();
+  });
+
+  it('blocks submission when the input is empty and shows a validation message', async () => {
+    renderBar();
+    await userEvent.click(screen.getByRole('button', { name: /send/i }));
+    expect(feedbackService.submitFeedback).not.toHaveBeenCalled();
+    expect(screen.getByRole('alert')).toHaveTextContent(/share something/i);
+  });
+
+  it('calls submitFeedback with the entered text on submit', async () => {
+    renderBar();
+    await userEvent.type(screen.getByLabelText(/what would you like to see/i), 'More Persian recipes please');
+    await userEvent.click(screen.getByRole('button', { name: /send/i }));
+    await waitFor(() => expect(feedbackService.submitFeedback).toHaveBeenCalledWith('More Persian recipes please'));
+  });
+
+  it('shows the thank-you status after a successful submit and resets the input', async () => {
+    renderBar();
+    const input = screen.getByLabelText(/what would you like to see/i);
+    await userEvent.type(input, 'Andean recipes');
+    await userEvent.click(screen.getByRole('button', { name: /send/i }));
+    expect(await screen.findByRole('status')).toHaveTextContent(/thanks! our team reads every note/i);
+    expect(input).toHaveValue('');
+  });
+
+  it('clears the thank-you status after 4 seconds', async () => {
+    renderBar();
+    await userEvent.type(screen.getByLabelText(/what would you like to see/i), 'Hello');
+    await userEvent.click(screen.getByRole('button', { name: /send/i }));
+    expect(await screen.findByRole('status')).toBeInTheDocument();
+    act(() => { jest.advanceTimersByTime(4000); });
+    await waitFor(() => expect(screen.queryByRole('status')).not.toBeInTheDocument());
+  });
+
+  it('shows an error alert if the submission rejects', async () => {
+    feedbackService.submitFeedback.mockRejectedValue(new Error('boom'));
+    renderBar();
+    await userEvent.type(screen.getByLabelText(/what would you like to see/i), 'Hello');
+    await userEvent.click(screen.getByRole('button', { name: /send/i }));
+    expect(await screen.findByRole('alert')).toHaveTextContent(/could not send/i);
+  });
+});

--- a/app/frontend/src/__tests__/HomeClosingBanner.test.jsx
+++ b/app/frontend/src/__tests__/HomeClosingBanner.test.jsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react';
+import HomeClosingBanner from '../components/HomeClosingBanner';
+
+describe('HomeClosingBanner', () => {
+  it('renders a region with the brand sentence about sharing cultures', () => {
+    render(<HomeClosingBanner />);
+    const region = screen.getByRole('region', { name: /sharing cultures/i });
+    expect(region).toBeInTheDocument();
+    expect(region).toHaveTextContent(/share/i);
+    expect(region).toHaveTextContent(/cultur/i);
+  });
+});

--- a/app/frontend/src/__tests__/HomePage.test.jsx
+++ b/app/frontend/src/__tests__/HomePage.test.jsx
@@ -5,10 +5,16 @@ import HomePage from '../pages/HomePage';
 import * as searchService from '../services/searchService';
 import * as culturalContentService from '../services/culturalContentService';
 import * as culturalFactService from '../services/culturalFactService';
+import * as mapService from '../services/mapService';
+import * as recipeService from '../services/recipeService';
+import * as storyService from '../services/storyService';
 
 jest.mock('../services/searchService');
 jest.mock('../services/culturalContentService');
 jest.mock('../services/culturalFactService');
+jest.mock('../services/mapService');
+jest.mock('../services/recipeService');
+jest.mock('../services/storyService');
 const mockNavigate = jest.fn();
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
@@ -28,6 +34,9 @@ beforeEach(() => {
     id: 99, text: 'Köfte traveled to Sweden.', source_url: '',
     heritage_group: null, region: null,
   });
+  mapService.fetchMapRegions.mockResolvedValue([]);
+  recipeService.fetchFeaturedRecipes.mockResolvedValue([]);
+  storyService.fetchFeaturedStories.mockResolvedValue([]);
 });
 
 function renderPage(user = null) {
@@ -122,5 +131,29 @@ describe('HomePage random cultural fact', () => {
     // Wait for the page baseline to settle — region chips finish loading.
     await screen.findByRole('button', { name: 'Aegean' });
     expect(screen.queryByText(/köfte traveled to sweden/i)).not.toBeInTheDocument();
+  });
+});
+
+describe('HomePage — redesign sections (#876)', () => {
+  it('renders the Explore by region section', async () => {
+    renderPage();
+    expect(await screen.findByRole('heading', { name: /explore by region/i })).toBeInTheDocument();
+  });
+
+  it("renders the This week's recipes and This week's stories rails", async () => {
+    renderPage();
+    expect(await screen.findByRole('heading', { name: /this week's recipes/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /this week's stories/i })).toBeInTheDocument();
+  });
+
+  it('renders the Feedback Bar with the prompt and Send button', async () => {
+    renderPage();
+    expect(await screen.findByLabelText(/what would you like to see on genipe/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /send/i })).toBeInTheDocument();
+  });
+
+  it('renders the closing brand banner', async () => {
+    renderPage();
+    expect(await screen.findByRole('region', { name: /sharing cultures/i })).toBeInTheDocument();
   });
 });

--- a/app/frontend/src/__tests__/HomeRail.test.jsx
+++ b/app/frontend/src/__tests__/HomeRail.test.jsx
@@ -1,0 +1,70 @@
+import { render, screen, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import HomeRail from '../components/HomeRail';
+
+function renderRail(props = {}) {
+  return render(
+    <MemoryRouter>
+      <HomeRail
+        title="This week's recipes"
+        items={[]}
+        loading={false}
+        moreHref="/recipes"
+        getHref={(it) => `/recipes/${it.id}`}
+        {...props}
+      />
+    </MemoryRouter>,
+  );
+}
+
+describe('HomeRail', () => {
+  it('renders the title and the More → link to moreHref', () => {
+    renderRail();
+    expect(screen.getByRole('heading', { name: /this week's recipes/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /more/i })).toHaveAttribute('href', '/recipes');
+  });
+
+  it('renders one Link per item with the per-item href from getHref', () => {
+    const items = Array.from({ length: 4 }, (_, i) => ({
+      id: i + 1, title: `Recipe ${i + 1}`, image: null, author_username: 'eren',
+    }));
+    renderRail({ items });
+    expect(screen.getByRole('link', { name: /recipe 1/i })).toHaveAttribute('href', '/recipes/1');
+    expect(screen.getByRole('link', { name: /recipe 4/i })).toHaveAttribute('href', '/recipes/4');
+  });
+
+  it('renders 6 skeleton cards when loading=true', () => {
+    const { container } = renderRail({ loading: true });
+    const skeletons = container.querySelectorAll('.home-rail-skeleton');
+    expect(skeletons.length).toBe(6);
+  });
+
+  it('renders an alert with the error text instead of cards when error is set', () => {
+    renderRail({ error: 'Could not load.' });
+    expect(screen.getByRole('alert')).toHaveTextContent(/could not load/i);
+    expect(screen.queryByRole('link', { name: /recipe/i })).not.toBeInTheDocument();
+  });
+
+  it('renders the emptyHint when items is empty and not loading and not error', () => {
+    renderRail({ emptyHint: 'No recipes yet.' });
+    expect(screen.getByText(/no recipes yet/i)).toBeInTheDocument();
+  });
+
+  it('renders the optional subtitle when provided', () => {
+    renderRail({ subtitle: 'Fresh picks from the community' });
+    expect(screen.getByText(/fresh picks/i)).toBeInTheDocument();
+  });
+
+  it('renders the image when item.image is truthy and a placeholder otherwise', () => {
+    const items = [
+      { id: 1, title: 'With image', image: '/img.jpg' },
+      { id: 2, title: 'Without image', image: null },
+    ];
+    const { container } = renderRail({ items });
+    expect(screen.getByRole('img', { name: /with image/i })).toHaveAttribute('src', '/img.jpg');
+    // The placeholder card should not have an <img>
+    const cards = container.querySelectorAll('.home-rail-card');
+    const placeholder = within(cards[1]).queryByRole('img');
+    expect(placeholder).toBeNull();
+  });
+});

--- a/app/frontend/src/__tests__/HomeRegionMapSection.test.jsx
+++ b/app/frontend/src/__tests__/HomeRegionMapSection.test.jsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import HomeRegionMapSection from '../components/HomeRegionMapSection';
+import * as mapService from '../services/mapService';
+
+jest.mock('../services/mapService');
+// Mock the inner RegionContentMap so we focus on the wrapper's behaviour.
+// Render the names of the regions it received so we can assert.
+jest.mock('../components/RegionContentMap', () => ({
+  __esModule: true,
+  default: ({ regions = [] }) => (
+    <div data-testid="region-content-map">
+      {regions.map((r) => <span key={r.id}>{r.name}</span>)}
+    </div>
+  ),
+}));
+
+function renderSection() {
+  return render(
+    <MemoryRouter>
+      <HomeRegionMapSection />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('HomeRegionMapSection', () => {
+  it('renders the section heading and tagline', async () => {
+    mapService.fetchMapRegions.mockResolvedValue([]);
+    renderSection();
+    expect(await screen.findByRole('heading', { name: /explore by region/i })).toBeInTheDocument();
+    expect(screen.getByText(/hover any culinary region/i)).toBeInTheDocument();
+  });
+
+  it('fetches regions on mount and forwards them to RegionContentMap', async () => {
+    mapService.fetchMapRegions.mockResolvedValue([
+      { id: 1, name: 'Anatolia',  content_count: { recipes: 4, stories: 2 } },
+      { id: 2, name: 'Aegean',    content_count: { recipes: 7, stories: 1 } },
+    ]);
+    renderSection();
+    expect(await screen.findByText('Anatolia')).toBeInTheDocument();
+    expect(screen.getByText('Aegean')).toBeInTheDocument();
+    expect(mapService.fetchMapRegions).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows a loading state while the fetch is in flight', () => {
+    let resolve;
+    mapService.fetchMapRegions.mockReturnValue(new Promise((r) => { resolve = r; }));
+    renderSection();
+    expect(screen.getByText(/loading/i)).toBeInTheDocument();
+    resolve([]);
+  });
+
+  it('shows an error message if the fetch fails', async () => {
+    mapService.fetchMapRegions.mockRejectedValue(new Error('boom'));
+    renderSection();
+    expect(await screen.findByText(/could not load region map/i)).toBeInTheDocument();
+  });
+});

--- a/app/frontend/src/__tests__/HomeWeeklySection.test.jsx
+++ b/app/frontend/src/__tests__/HomeWeeklySection.test.jsx
@@ -1,0 +1,68 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import HomeWeeklySection from '../components/HomeWeeklySection';
+import * as recipeService from '../services/recipeService';
+import * as storyService from '../services/storyService';
+
+jest.mock('../services/recipeService');
+jest.mock('../services/storyService');
+
+function renderSection() {
+  return render(
+    <MemoryRouter>
+      <HomeWeeklySection />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  recipeService.fetchFeaturedRecipes = jest.fn().mockResolvedValue([]);
+  storyService.fetchFeaturedStories  = jest.fn().mockResolvedValue([]);
+});
+
+describe('HomeWeeklySection', () => {
+  it('renders both rail titles and Wires the right More → targets', async () => {
+    renderSection();
+    expect(await screen.findByRole('heading', { name: /this week's recipes/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /this week's stories/i })).toBeInTheDocument();
+    const moreLinks = screen.getAllByRole('link', { name: /more/i });
+    const hrefs = moreLinks.map((l) => l.getAttribute('href'));
+    expect(hrefs).toEqual(expect.arrayContaining(['/recipes', '/stories']));
+  });
+
+  it('fetches both featured lists on mount with limit=6', async () => {
+    renderSection();
+    await waitFor(() => {
+      expect(recipeService.fetchFeaturedRecipes).toHaveBeenCalledWith(6);
+      expect(storyService.fetchFeaturedStories).toHaveBeenCalledWith(6);
+    });
+  });
+
+  it('renders a recipe card per item and routes via /recipes/:id', async () => {
+    recipeService.fetchFeaturedRecipes.mockResolvedValue([
+      { id: 1, title: 'Sarma',  image: null, author_username: 'eren' },
+      { id: 2, title: 'Pilav',  image: null, author_username: 'eren' },
+    ]);
+    storyService.fetchFeaturedStories.mockResolvedValue([
+      { id: 3, title: 'My memory', image: null, author_username: 'eren' },
+    ]);
+    renderSection();
+    const sarma  = await screen.findByRole('link', { name: /sarma/i });
+    const memory = await screen.findByRole('link', { name: /my memory/i });
+    expect(sarma).toHaveAttribute('href', '/recipes/1');
+    expect(memory).toHaveAttribute('href', '/stories/3');
+  });
+
+  it('surfaces a per-rail error if only one fetch fails', async () => {
+    recipeService.fetchFeaturedRecipes.mockResolvedValue([
+      { id: 1, title: 'Sarma', image: null, author_username: 'eren' },
+    ]);
+    storyService.fetchFeaturedStories.mockRejectedValue(new Error('boom'));
+    renderSection();
+    expect(await screen.findByRole('link', { name: /sarma/i })).toBeInTheDocument();
+    // The story rail should show an alert.
+    const alerts = await screen.findAllByRole('alert');
+    expect(alerts.some((a) => /stor/i.test(a.textContent))).toBe(true);
+  });
+});

--- a/app/frontend/src/__tests__/RegionContentMap.test.jsx
+++ b/app/frontend/src/__tests__/RegionContentMap.test.jsx
@@ -1,0 +1,87 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import RegionContentMap from '../components/RegionContentMap';
+
+// "Turkey" and "Greece" both exist in COUNTRY_TO_REGION; "Antarctica" does not.
+// (See utils/countryRegions.js.)
+const MOCK_GEOS = [
+  { rsmKey: 'TR', properties: { name: 'Turkey' } },
+  { rsmKey: 'GR', properties: { name: 'Greece' } },
+  { rsmKey: 'AQ', properties: { name: 'Antarctica' } },
+];
+
+jest.mock('react-simple-maps', () => ({
+  ComposableMap: ({ children }) => <div data-testid="map">{children}</div>,
+  Geographies: ({ children }) => children({ geographies: MOCK_GEOS }),
+  Geography: ({ geography, onClick, onMouseEnter, onMouseLeave, style }) => (
+    <button
+      type="button"
+      data-testid={`geo-${geography.properties.name}`}
+      data-fill={style?.default?.fill}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      onClick={onClick}
+    >
+      {geography.properties.name}
+    </button>
+  ),
+}));
+
+function renderMap(regions) {
+  return render(
+    <MemoryRouter initialEntries={['/']}>
+      <Routes>
+        <Route path="/" element={<RegionContentMap regions={regions} />} />
+        <Route path="/search" element={<div>search-page</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+// Turkey → "Anatolia", Greece → "Aegean" per countryRegions.js.
+const REGIONS = [
+  { id: 1, name: 'Anatolia', content_count: { recipes: 4,  stories: 2 } },
+  { id: 2, name: 'Aegean',   content_count: { recipes: 12, stories: 5 } },
+];
+
+describe('RegionContentMap', () => {
+  it('shows N recipes · M stories on hover for a mapped country', () => {
+    renderMap(REGIONS);
+    fireEvent.mouseEnter(screen.getByTestId('geo-Turkey'));
+    expect(screen.getByText(/anatolia/i)).toBeInTheDocument();
+    expect(screen.getByText(/4 recipes.*2 stories/i)).toBeInTheDocument();
+  });
+
+  it('shows the "not part of a culinary region yet" fallback for an unmapped country', () => {
+    renderMap(REGIONS);
+    fireEvent.mouseEnter(screen.getByTestId('geo-Antarctica'));
+    expect(screen.getByText(/not part of a culinary region yet/i)).toBeInTheDocument();
+  });
+
+  it('navigates to /search?region=<name> when a mapped country is clicked', async () => {
+    renderMap(REGIONS);
+    fireEvent.click(screen.getByTestId('geo-Turkey'));
+    expect(await screen.findByText('search-page')).toBeInTheDocument();
+  });
+
+  it('does not navigate when an unmapped country is clicked', () => {
+    renderMap(REGIONS);
+    fireEvent.click(screen.getByTestId('geo-Antarctica'));
+    expect(screen.queryByText('search-page')).not.toBeInTheDocument();
+  });
+
+  it('tints higher-traffic regions darker than lower-traffic ones', () => {
+    renderMap(REGIONS);
+    const turkey = screen.getByTestId('geo-Turkey').getAttribute('data-fill');
+    const greece = screen.getByTestId('geo-Greece').getAttribute('data-fill');
+    // Aegean (Greece) has more content (12+5=17) than Anatolia (Turkey, 4+2=6);
+    // the higher-traffic region should get a different (darker) fill.
+    expect(turkey).not.toEqual(greece);
+  });
+
+  it('uses the neutral cream fill for unmapped countries', () => {
+    renderMap(REGIONS);
+    const antarctica = screen.getByTestId('geo-Antarctica').getAttribute('data-fill');
+    expect(antarctica?.toUpperCase()).toBe('#FAF7EF');
+  });
+});

--- a/app/frontend/src/__tests__/feedbackService.test.js
+++ b/app/frontend/src/__tests__/feedbackService.test.js
@@ -1,0 +1,12 @@
+import { submitFeedback } from '../services/feedbackService';
+
+describe('submitFeedback (#876 stub)', () => {
+  it('resolves with { message } so consumers can chain', async () => {
+    const result = await submitFeedback('I want more Persian recipes.');
+    expect(result).toEqual({ message: 'I want more Persian recipes.' });
+  });
+
+  it('rejects when message is blank after trim', async () => {
+    await expect(submitFeedback('   ')).rejects.toThrow(/required/i);
+  });
+});

--- a/app/frontend/src/__tests__/recipeService.test.js
+++ b/app/frontend/src/__tests__/recipeService.test.js
@@ -15,6 +15,7 @@ import {
   fetchMyRecipes,
   fetchMyBookmarks,
   fetchRecipesByRegion,
+  fetchFeaturedRecipes,
 } from '../services/recipeService';
 
 jest.mock('../services/api', () => ({
@@ -321,5 +322,20 @@ describe('fetchRecipesByRegion', () => {
   it('unwraps paginated DRF responses', async () => {
     apiClient.get.mockResolvedValue({ data: { results: [{ id: 5 }] } });
     expect(await fetchRecipesByRegion('Aegean')).toEqual([{ id: 5 }]);
+  });
+});
+
+describe('fetchFeaturedRecipes', () => {
+  it('returns the first <limit> recipes from the list endpoint', async () => {
+    apiClient.get.mockResolvedValue({ data: { results: Array.from({ length: 10 }, (_, i) => ({ id: i + 1 })) } });
+    const result = await fetchFeaturedRecipes(6);
+    expect(apiClient.get).toHaveBeenCalledWith('/api/recipes/', { params: { page_size: 100 } });
+    expect(result).toHaveLength(6);
+    expect(result.map((r) => r.id)).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+
+  it('defaults limit to 6 when not provided', async () => {
+    apiClient.get.mockResolvedValue({ data: Array.from({ length: 12 }, (_, i) => ({ id: i + 1 })) });
+    expect(await fetchFeaturedRecipes()).toHaveLength(6);
   });
 });

--- a/app/frontend/src/__tests__/storyService.test.js
+++ b/app/frontend/src/__tests__/storyService.test.js
@@ -1,5 +1,5 @@
 import * as storyService from '../services/storyService';
-import { fetchMyStories, fetchStoriesByRegion } from '../services/storyService';
+import { fetchMyStories, fetchStoriesByRegion, fetchFeaturedStories } from '../services/storyService';
 import { apiClient } from '../services/api';
 
 jest.mock('../services/api', () => ({
@@ -143,5 +143,20 @@ describe('fetchStoriesByRegion', () => {
   it('unwraps paginated DRF responses', async () => {
     apiClient.get.mockResolvedValue({ data: { results: [{ id: 6 }] } });
     expect(await fetchStoriesByRegion('Aegean')).toEqual([{ id: 6 }]);
+  });
+});
+
+describe('fetchFeaturedStories', () => {
+  it('returns the first <limit> stories from the list endpoint', async () => {
+    apiClient.get.mockResolvedValue({ data: { results: Array.from({ length: 10 }, (_, i) => ({ id: i + 1 })) } });
+    const result = await fetchFeaturedStories(6);
+    expect(apiClient.get).toHaveBeenCalledWith('/api/stories/', { params: { page_size: 100 } });
+    expect(result).toHaveLength(6);
+    expect(result.map((s) => s.id)).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+
+  it('defaults limit to 6 when not provided', async () => {
+    apiClient.get.mockResolvedValue({ data: Array.from({ length: 12 }, (_, i) => ({ id: i + 1 })) });
+    expect(await fetchFeaturedStories()).toHaveLength(6);
   });
 });

--- a/app/frontend/src/components/FeedbackBar.css
+++ b/app/frontend/src/components/FeedbackBar.css
@@ -1,0 +1,51 @@
+.feedback-bar {
+  max-width: 720px;
+  margin: 2.5rem auto 0;
+  padding: 1rem 1rem 0;
+}
+
+.feedback-bar-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  background: var(--color-surface, #FAF7EF);
+  border: 1px solid var(--color-border, #e0d8c8);
+  border-radius: var(--radius-md, 8px);
+  padding: 0.9rem 1rem;
+}
+
+.feedback-bar-label {
+  font-weight: 600;
+  color: var(--color-surface-dark, #3D1500);
+  font-size: 0.95rem;
+}
+
+.feedback-bar-row {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.feedback-bar-input {
+  flex: 1;
+  font: inherit;
+  padding: 0.5rem 0.7rem;
+  border: 1px solid var(--color-border, #ccc);
+  border-radius: var(--radius-sm, 6px);
+  background: var(--color-surface, #FAF7EF);
+}
+
+.feedback-bar-send {
+  flex-shrink: 0;
+}
+
+.feedback-bar-error {
+  color: var(--color-error, #b00020);
+  margin: 0;
+  font-size: 0.875rem;
+}
+
+.feedback-bar-status {
+  color: var(--color-primary, #C4521E);
+  margin: 0;
+  font-size: 0.875rem;
+}

--- a/app/frontend/src/components/FeedbackBar.jsx
+++ b/app/frontend/src/components/FeedbackBar.jsx
@@ -1,0 +1,64 @@
+import { useEffect, useRef, useState } from 'react';
+import { submitFeedback } from '../services/feedbackService';
+import './FeedbackBar.css';
+
+export default function FeedbackBar() {
+  const [message, setMessage] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [status, setStatus] = useState('');
+  const [error, setError] = useState('');
+  const timerRef = useRef(null);
+
+  useEffect(() => () => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+  }, []);
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    setError('');
+    setStatus('');
+    const trimmed = message.trim();
+    if (!trimmed) {
+      setError('Share something — even a single word helps.');
+      return;
+    }
+    setSubmitting(true);
+    try {
+      await submitFeedback(trimmed);
+      setMessage('');
+      setStatus('Thanks! Our team reads every note.');
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => setStatus(''), 4000);
+    } catch {
+      setError('Could not send your note right now. Please try again.');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <section className="feedback-bar" aria-label="Send feedback">
+      <form className="feedback-bar-form" onSubmit={handleSubmit}>
+        <label className="feedback-bar-label" htmlFor="feedback-bar-input">
+          What would you like to see on Genipe?
+        </label>
+        <div className="feedback-bar-row">
+          <input
+            id="feedback-bar-input"
+            className="feedback-bar-input"
+            type="text"
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            placeholder="Share an idea, a recipe you want, a region you're curious about…"
+            disabled={submitting}
+          />
+          <button type="submit" className="feedback-bar-send btn btn-primary" disabled={submitting}>
+            {submitting ? 'Sending…' : 'Send'}
+          </button>
+        </div>
+        {error && <p className="feedback-bar-error" role="alert">{error}</p>}
+        {status && <p className="feedback-bar-status" role="status">{status}</p>}
+      </form>
+    </section>
+  );
+}

--- a/app/frontend/src/components/HomeClosingBanner.css
+++ b/app/frontend/src/components/HomeClosingBanner.css
@@ -1,0 +1,23 @@
+.home-closing-banner {
+  max-width: 1100px;
+  margin: 3rem auto 2.5rem;
+  padding: 2.25rem 1.5rem;
+  text-align: center;
+  background: linear-gradient(135deg, rgba(196, 82, 30, 0.06), rgba(250, 247, 239, 0.0));
+  border-top: 1px solid var(--color-border, #e0d8c8);
+  border-bottom: 1px solid var(--color-border, #e0d8c8);
+}
+
+.home-closing-banner-lead {
+  margin: 0 0 0.4rem;
+  font-family: var(--font-display, Fraunces, serif);
+  font-size: clamp(1.4rem, 3vw, 2rem);
+  color: var(--color-surface-dark, #3D1500);
+  font-weight: 700;
+}
+
+.home-closing-banner-tag {
+  margin: 0;
+  color: var(--color-text-muted, #6b6b6b);
+  font-size: 1rem;
+}

--- a/app/frontend/src/components/HomeClosingBanner.jsx
+++ b/app/frontend/src/components/HomeClosingBanner.jsx
@@ -1,0 +1,14 @@
+import './HomeClosingBanner.css';
+
+export default function HomeClosingBanner() {
+  return (
+    <section className="home-closing-banner" role="region" aria-label="Sharing cultures">
+      <p className="home-closing-banner-lead">
+        Most cultures share food.
+      </p>
+      <p className="home-closing-banner-tag">
+        We share those cultures — plate by plate, story by story.
+      </p>
+    </section>
+  );
+}

--- a/app/frontend/src/components/HomeRail.css
+++ b/app/frontend/src/components/HomeRail.css
@@ -1,0 +1,114 @@
+.home-rail {
+  max-width: 1100px;
+  margin: 2.5rem auto 0;
+  padding: 0 1rem;
+}
+
+.home-rail-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.home-rail-title {
+  margin: 0;
+  font-family: var(--font-display, Fraunces, serif);
+  font-size: clamp(1.4rem, 2.8vw, 1.85rem);
+  color: var(--color-surface-dark, #3D1500);
+}
+
+.home-rail-subtitle {
+  margin: 0.25rem 0 0;
+  color: var(--color-text-muted, #6b6b6b);
+  font-size: 0.9rem;
+}
+
+.home-rail-more {
+  color: var(--color-primary, #C4521E);
+  font-weight: 600;
+  text-decoration: none;
+  flex-shrink: 0;
+}
+
+.home-rail-more:hover,
+.home-rail-more:focus-visible {
+  text-decoration: underline;
+}
+
+.home-rail-grid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+@media (max-width: 960px) {
+  .home-rail-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+}
+
+@media (max-width: 560px) {
+  .home-rail-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+
+.home-rail-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  text-decoration: none;
+  color: inherit;
+  background: var(--color-surface, #FAF7EF);
+  border: 1px solid var(--color-border, #e0d8c8);
+  border-radius: var(--radius-md, 8px);
+  overflow: hidden;
+  transition: border-color 0.15s, transform 0.15s;
+}
+
+.home-rail-card:hover,
+.home-rail-card:focus-visible {
+  border-color: var(--color-primary, #C4521E);
+  transform: translateY(-2px);
+  text-decoration: none;
+}
+
+.home-rail-card-img,
+.home-rail-card-placeholder {
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
+  background: rgba(196, 82, 30, 0.08);
+  display: block;
+}
+
+.home-rail-card-title {
+  padding: 0.55rem 0.7rem 0;
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: var(--color-surface-dark, #3D1500);
+  line-height: 1.3;
+}
+
+.home-rail-card-meta {
+  padding: 0 0.7rem 0.6rem;
+  font-size: 0.8rem;
+  color: var(--color-text-muted, #6b6b6b);
+}
+
+.home-rail-skeleton {
+  aspect-ratio: 4 / 3;
+  background: rgba(196, 82, 30, 0.08);
+  border-radius: var(--radius-md, 8px);
+}
+
+.home-rail-empty,
+.home-rail-error {
+  margin: 1rem 0 0;
+  color: var(--color-text-muted, #6b6b6b);
+}
+
+.home-rail-error {
+  color: var(--color-error, #b00020);
+}

--- a/app/frontend/src/components/HomeRail.jsx
+++ b/app/frontend/src/components/HomeRail.jsx
@@ -1,0 +1,61 @@
+import { Link } from 'react-router-dom';
+import './HomeRail.css';
+
+export default function HomeRail({
+  title,
+  subtitle,
+  items = [],
+  loading = false,
+  error = '',
+  moreHref,
+  getHref,
+  emptyHint = 'Nothing here yet.',
+}) {
+  return (
+    <section className="home-rail" aria-label={title}>
+      <div className="home-rail-header">
+        <div>
+          <h2 className="home-rail-title">{title}</h2>
+          {subtitle && <p className="home-rail-subtitle">{subtitle}</p>}
+        </div>
+        {moreHref && (
+          <Link to={moreHref} className="home-rail-more">More →</Link>
+        )}
+      </div>
+
+      {error ? (
+        <p className="home-rail-error" role="alert">{error}</p>
+      ) : loading ? (
+        <ul className="home-rail-grid" aria-busy="true">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <li key={i} className="home-rail-skeleton" />
+          ))}
+        </ul>
+      ) : items.length === 0 ? (
+        <p className="home-rail-empty">{emptyHint}</p>
+      ) : (
+        <ul className="home-rail-grid">
+          {items.map((item) => (
+            <li key={item.id}>
+              <Link to={getHref(item)} className="home-rail-card">
+                {item.image ? (
+                  <img src={item.image} alt={item.title} className="home-rail-card-img" />
+                ) : (
+                  <div className="home-rail-card-placeholder" aria-hidden="true" />
+                )}
+                <span className="home-rail-card-title">{item.title}</span>
+                {(item.region_name || item.author_username) && (
+                  <span className="home-rail-card-meta">
+                    {item.region_name && <span>{item.region_name}</span>}
+                    {item.region_name && item.author_username && ' · '}
+                    {item.author_username && <span>@{item.author_username}</span>}
+                  </span>
+                )}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/app/frontend/src/components/HomeRegionMapSection.css
+++ b/app/frontend/src/components/HomeRegionMapSection.css
@@ -1,0 +1,33 @@
+.home-region-map-section {
+  max-width: 1100px;
+  margin: 2.5rem auto 0;
+  padding: 0 1rem;
+}
+
+.home-section-header {
+  text-align: center;
+  margin-bottom: 1.25rem;
+}
+
+.home-section-header h2 {
+  margin: 0 0 0.4rem;
+  font-family: var(--font-display, Fraunces, serif);
+  font-size: clamp(1.5rem, 3vw, 2rem);
+  color: var(--color-surface-dark, #3D1500);
+}
+
+.home-section-header p {
+  margin: 0;
+  color: var(--color-text-muted, #6b6b6b);
+  font-size: 0.95rem;
+}
+
+.home-region-map-status {
+  text-align: center;
+  color: var(--color-text-muted, #6b6b6b);
+  padding: 2rem 0;
+}
+
+.home-region-map-error {
+  color: var(--color-error, #b00020);
+}

--- a/app/frontend/src/components/HomeRegionMapSection.jsx
+++ b/app/frontend/src/components/HomeRegionMapSection.jsx
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react';
+import { fetchMapRegions } from '../services/mapService';
+import RegionContentMap from './RegionContentMap';
+import './HomeRegionMapSection.css';
+
+export default function HomeRegionMapSection() {
+  const [regions, setRegions] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError('');
+    fetchMapRegions()
+      .then((data) => { if (!cancelled) setRegions(Array.isArray(data) ? data : []); })
+      .catch(() => { if (!cancelled) setError('Could not load region map.'); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, []);
+
+  return (
+    <section className="home-region-map-section" aria-label="Explore by region">
+      <div className="home-section-header">
+        <h2>Explore by region</h2>
+        <p>Hover any culinary region to see how many recipes and stories live there.</p>
+      </div>
+      {loading && <p className="home-region-map-status">Loading region map…</p>}
+      {error && <p className="home-region-map-status home-region-map-error" role="alert">{error}</p>}
+      {!loading && !error && <RegionContentMap regions={regions} />}
+    </section>
+  );
+}

--- a/app/frontend/src/components/HomeWeeklySection.jsx
+++ b/app/frontend/src/components/HomeWeeklySection.jsx
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'react';
+import { fetchFeaturedRecipes } from '../services/recipeService';
+import { fetchFeaturedStories } from '../services/storyService';
+import HomeRail from './HomeRail';
+
+export default function HomeWeeklySection() {
+  const [recipes, setRecipes] = useState([]);
+  const [stories, setStories] = useState([]);
+  const [recipesLoading, setRecipesLoading] = useState(true);
+  const [storiesLoading, setStoriesLoading] = useState(true);
+  const [recipesError, setRecipesError] = useState('');
+  const [storiesError, setStoriesError] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+    Promise.allSettled([
+      fetchFeaturedRecipes(6),
+      fetchFeaturedStories(6),
+    ]).then(([r, s]) => {
+      if (cancelled) return;
+      if (r.status === 'fulfilled') setRecipes(Array.isArray(r.value) ? r.value : []);
+      else setRecipesError('Could not load recipes.');
+      if (s.status === 'fulfilled') setStories(Array.isArray(s.value) ? s.value : []);
+      else setStoriesError('Could not load stories.');
+      setRecipesLoading(false);
+      setStoriesLoading(false);
+    });
+    return () => { cancelled = true; };
+  }, []);
+
+  return (
+    <>
+      <HomeRail
+        title="This week's recipes"
+        subtitle="Fresh from the community"
+        items={recipes}
+        loading={recipesLoading}
+        error={recipesError}
+        moreHref="/recipes"
+        getHref={(r) => `/recipes/${r.id}`}
+        emptyHint="No recipes yet — share the first one!"
+      />
+      <HomeRail
+        title="This week's stories"
+        subtitle="Voices behind the plates"
+        items={stories}
+        loading={storiesLoading}
+        error={storiesError}
+        moreHref="/stories"
+        getHref={(s) => `/stories/${s.id}`}
+        emptyHint="No stories yet — share the first one!"
+      />
+    </>
+  );
+}

--- a/app/frontend/src/components/RegionContentMap.css
+++ b/app/frontend/src/components/RegionContentMap.css
@@ -1,0 +1,31 @@
+.region-content-map {
+  position: relative;
+  width: 100%;
+}
+
+.region-content-map svg {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.region-content-map-popover {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+  background: var(--color-surface, #FAF7EF);
+  border: 1.5px solid var(--color-surface-dark, #3D1500);
+  border-radius: var(--radius-md, 8px);
+  padding: 0.55rem 0.85rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  box-shadow: var(--shadow-sm, 0 2px 8px rgba(0, 0, 0, 0.08));
+  font-size: 0.875rem;
+  pointer-events: none;
+  max-width: 220px;
+}
+
+.region-content-map-popover strong {
+  color: var(--color-surface-dark, #3D1500);
+}

--- a/app/frontend/src/components/RegionContentMap.jsx
+++ b/app/frontend/src/components/RegionContentMap.jsx
@@ -1,0 +1,116 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { ComposableMap, Geographies, Geography } from 'react-simple-maps';
+import { getRegionForCountry } from '../utils/countryRegions';
+import './RegionContentMap.css';
+
+const GEO_URL = 'https://cdn.jsdelivr.net/npm/world-atlas@2/countries-110m.json';
+
+const CREAM = { r: 0xFA, g: 0xF7, b: 0xEF }; // var(--color-surface)
+const RUST  = { r: 0xC4, g: 0x52, b: 0x1E }; // var(--color-primary)
+
+function toHex2(n) {
+  return Math.max(0, Math.min(255, Math.round(n))).toString(16).padStart(2, '0');
+}
+
+/**
+ * Interpolate between cream (count = 0) and rust (count = max). Used to tint
+ * each country by its region's total recipe + story content.
+ */
+export function fillFor(count, max) {
+  if (!count || max <= 0) return '#FAF7EF';
+  const ratio = Math.min(1, count / max);
+  const r = CREAM.r + (RUST.r - CREAM.r) * ratio;
+  const g = CREAM.g + (RUST.g - CREAM.g) * ratio;
+  const b = CREAM.b + (RUST.b - CREAM.b) * ratio;
+  return `#${toHex2(r)}${toHex2(g)}${toHex2(b)}`.toUpperCase();
+}
+
+/**
+ * World map for the home page. Tints each country by how much culinary
+ * content (`recipes + stories`) lives in the region it belongs to, shows a
+ * hover popover, and routes to the region's search results on click.
+ *
+ * Country → region mapping comes from `utils/countryRegions.js`; countries
+ * without a region render in neutral cream and are click-inert.
+ */
+export default function RegionContentMap({ regions = [] }) {
+  const navigate = useNavigate();
+  const [hovered, setHovered] = useState(null);
+
+  const byName = new Map(regions.map((r) => [r.name, r]));
+  const maxCount = regions.reduce((m, r) => {
+    const c = (r.content_count?.recipes ?? 0) + (r.content_count?.stories ?? 0);
+    return Math.max(m, c);
+  }, 0);
+
+  function handleEnter(country) {
+    const regionName = getRegionForCountry(country);
+    const region = regionName ? byName.get(regionName) : null;
+    if (region) {
+      setHovered({
+        name: region.name,
+        recipes: region.content_count?.recipes ?? 0,
+        stories: region.content_count?.stories ?? 0,
+      });
+    } else {
+      setHovered({ unmapped: true, country });
+    }
+  }
+
+  function handleClick(country) {
+    const regionName = getRegionForCountry(country);
+    if (!regionName) return;
+    navigate(`/search?region=${encodeURIComponent(regionName)}`);
+  }
+
+  return (
+    <div className="region-content-map">
+      <ComposableMap projection="geoEqualEarth" projectionConfig={{ scale: 150 }}>
+        <Geographies geography={GEO_URL}>
+          {({ geographies }) =>
+            geographies.map((geo) => {
+              const country = geo.properties.name;
+              const regionName = getRegionForCountry(country);
+              const region = regionName ? byName.get(regionName) : null;
+              const count = region
+                ? (region.content_count?.recipes ?? 0) + (region.content_count?.stories ?? 0)
+                : 0;
+              const fill = region ? fillFor(count, maxCount) : '#FAF7EF';
+              return (
+                <Geography
+                  key={geo.rsmKey}
+                  geography={geo}
+                  onMouseEnter={() => handleEnter(country)}
+                  onMouseLeave={() => setHovered(null)}
+                  onClick={() => handleClick(country)}
+                  style={{
+                    default: { fill, stroke: '#3D1500', strokeWidth: 0.4, outline: 'none' },
+                    hover:   { fill, stroke: '#3D1500', strokeWidth: 0.8, outline: 'none', cursor: regionName ? 'pointer' : 'default' },
+                    pressed: { fill, outline: 'none' },
+                  }}
+                />
+              );
+            })
+          }
+        </Geographies>
+      </ComposableMap>
+
+      {hovered && (
+        <div className="region-content-map-popover" role="status">
+          {hovered.unmapped ? (
+            <>
+              <strong>{hovered.country}</strong>
+              <span>Not part of a culinary region yet</span>
+            </>
+          ) : (
+            <>
+              <strong>{hovered.name}</strong>
+              <span>{hovered.recipes} recipes · {hovered.stories} stories</span>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/frontend/src/pages/HomePage.jsx
+++ b/app/frontend/src/pages/HomePage.jsx
@@ -7,6 +7,10 @@ import ChipGroup from '../components/ChipGroup';
 import DailyCulturalSection from '../components/DailyCulturalSection';
 import FloatingCulturalPrompt from '../components/FloatingCulturalPrompt';
 import RandomCulturalFact from '../components/RandomCulturalFact';
+import HomeRegionMapSection from '../components/HomeRegionMapSection';
+import HomeWeeklySection from '../components/HomeWeeklySection';
+import FeedbackBar from '../components/FeedbackBar';
+import HomeClosingBanner from '../components/HomeClosingBanner';
 import useKeyboardShortcuts from '../hooks/useKeyboardShortcuts';
 import './HomePage.css';
 
@@ -188,6 +192,10 @@ export default function HomePage() {
       <aside className="home-random-fact" aria-label="Cultural fact of the moment">
         <RandomCulturalFact />
       </aside>
+      <HomeRegionMapSection />
+      <HomeWeeklySection />
+      <FeedbackBar />
+      <HomeClosingBanner />
       <FloatingCulturalPrompt regions={regions} />
     </main>
   );

--- a/app/frontend/src/services/feedbackService.js
+++ b/app/frontend/src/services/feedbackService.js
@@ -1,0 +1,19 @@
+/**
+ * Frontend-only stub for the home page Feedback Bar (#876).
+ *
+ * The real backend endpoint (POST /api/feedback/) is tracked in #877. Once
+ * that lands, swap the body for `apiClient.post('/api/feedback/', { message })`
+ * and update the test in feedbackService.test.js.
+ */
+export async function submitFeedback(message) {
+  const trimmed = typeof message === 'string' ? message.trim() : '';
+  if (!trimmed) {
+    throw new Error('Message is required.');
+  }
+  if (process.env.NODE_ENV !== 'test') {
+    // Light client-side trace until the backend lands.
+    // eslint-disable-next-line no-console
+    console.info('[feedback]', trimmed);
+  }
+  return { message: trimmed };
+}

--- a/app/frontend/src/services/recipeService.js
+++ b/app/frontend/src/services/recipeService.js
@@ -150,3 +150,13 @@ export async function fetchRecipesByRegion(regionName) {
   const response = await apiClient.get('/api/recipes/', { params: { region: regionName, page_size: 100 } });
   return response.data.results ?? response.data;
 }
+
+/**
+ * Top N recipes for the home page weekly rail (#876).
+ * Wraps fetchRecipes() and slices client-side. A future curated/featured
+ * endpoint can replace this without touching consumers.
+ */
+export async function fetchFeaturedRecipes(limit = 6) {
+  const list = await fetchRecipes();
+  return list.slice(0, limit);
+}

--- a/app/frontend/src/services/storyService.js
+++ b/app/frontend/src/services/storyService.js
@@ -72,3 +72,12 @@ export async function fetchStoriesByRegion(regionName) {
   const response = await apiClient.get('/api/stories/', { params: { region: regionName, page_size: 100 } });
   return response.data.results ?? response.data;
 }
+
+/**
+ * Top N stories for the home page weekly rail (#876).
+ * Wraps fetchStories() and slices client-side.
+ */
+export async function fetchFeaturedStories(limit = 6) {
+  const list = await fetchStories();
+  return list.slice(0, limit);
+}

--- a/app/frontend/src/utils/countryRegions.js
+++ b/app/frontend/src/utils/countryRegions.js
@@ -1,0 +1,62 @@
+/**
+ * Country (as named by world-atlas' `countries-110m.json` `properties.name`)
+ * → culinary-region lookup used by the home page's `RegionContentMap`.
+ *
+ * Region names here mirror the backend `Region.name` values returned by
+ * `/api/map/regions/` (e.g. "Anatolia", "Aegean", "Black Sea", …) so that the
+ * map can hand the name straight into `/search?region=<name>` URLs and into
+ * `byName.get(region.name)` lookups against the API payload.
+ *
+ * The same source data underpins `passportCultureRegions.js` (which works in
+ * the inverse direction, culture → countries). The two utilities are kept
+ * separate because they serve genuinely different flows: the passport flow
+ * cares about how engaged the user is with a culture and can let multiple
+ * cultures claim the same country, while the home-page map only needs a
+ * single canonical region per country.
+ *
+ * Lookup is case-insensitive and trims whitespace.
+ * Returns `null` for countries that don't belong to any culinary region yet.
+ */
+export const COUNTRY_TO_REGION = {
+  // Turkish heartland — single canonical pick per country.
+  Turkey: 'Anatolia',
+  Greece: 'Aegean',
+  Italy: 'Mediterranean',
+  Spain: 'Mediterranean',
+  France: 'Mediterranean',
+  Malta: 'Mediterranean',
+  Cyprus: 'Mediterranean',
+  Egypt: 'Mediterranean',
+  Libya: 'Mediterranean',
+  Tunisia: 'Mediterranean',
+  Algeria: 'Mediterranean',
+  Morocco: 'Mediterranean',
+  Lebanon: 'Mediterranean',
+  Israel: 'Mediterranean',
+  Syria: 'Mediterranean',
+  // Black Sea littoral.
+  Ukraine: 'Black Sea',
+  Russia: 'Black Sea',
+  Romania: 'Black Sea',
+  Bulgaria: 'Black Sea',
+  Georgia: 'Black Sea',
+  // South-eastern Anatolia spills into Iraq.
+  Iraq: 'Southeast Anatolia',
+};
+
+const LOOKUP = Object.fromEntries(
+  Object.entries(COUNTRY_TO_REGION).map(([country, region]) => [
+    country.trim().toLowerCase(),
+    region,
+  ]),
+);
+
+/**
+ * Return the canonical culinary-region name for a country, or `null` if the
+ * country isn't part of any region yet. Trims whitespace and ignores case.
+ */
+export function getRegionForCountry(countryName) {
+  if (typeof countryName !== 'string') return null;
+  const key = countryName.trim().toLowerCase();
+  return LOOKUP[key] ?? null;
+}


### PR DESCRIPTION
Closes #876.

The home page used to end after the Cultural Highlights grid and a small **Did you know?** card. This PR extends it with four new sections so anonymous visitors and signed-in users alike have somewhere to go after the hero. All additive — nothing existing was removed.

## Sections (in order, below the existing \`RandomCulturalFact\` aside and above \`FloatingCulturalPrompt\`)

1. **Explore by region** — \`HomeRegionMapSection\` + new \`RegionContentMap\` component (\`react-simple-maps\`). Tints countries by their region's combined recipe + story count from \`/api/map/regions/\` (the endpoint already ships \`content_count\`). Hover shows a popover with \`N recipes · M stories\`; unmapped countries show \"Not part of a culinary region yet\". Click on a mapped country navigates to \`/search?region=<name>\`.
2. **This week's recipes** — \`HomeWeeklySection\` rail of 6 recipe cards + a \`More →\` link to \`/recipes\`. Sourced by a new \`fetchFeaturedRecipes(limit = 6)\` helper that wraps \`fetchRecipes()\` and slices client-side (a real curation endpoint can replace it later without touching consumers).
3. **This week's stories** — same shape, \`More →\` to \`/stories\`, sourced by \`fetchFeaturedStories(limit = 6)\`. Both rails fetch in parallel via \`Promise.allSettled\`; one failure doesn't take down the other.
4. **Feedback Bar** — a thin form: \"What would you like to see on Genipe?\" + Send button. Validation, \"Thanks! Our team reads every note.\" status that auto-clears after 4s, and a frontend-only stub \`feedbackService.submitFeedback\` until the backend endpoint lands (tracked in #877).
5. **Closing brand banner** — static \"Most cultures share food. We share those cultures — plate by plate, story by story.\" tinted region.

## New / touched files

- \`components/RegionContentMap.{jsx,css}\` (+ tests) — reusable map widget
- \`utils/countryRegions.js\` — small country → region lookup (PassportMap untouched; this is a fresh table sized for the regions \`/api/map/regions/\` actually ships)
- \`components/HomeRegionMapSection.{jsx,css}\` (+ tests)
- \`components/HomeRail.{jsx,css}\` (+ tests) — shared between the two weekly rails
- \`components/HomeWeeklySection.jsx\` (+ tests)
- \`components/FeedbackBar.{jsx,css}\` (+ tests) — frontend-only stub
- \`services/feedbackService.js\` (+ tests) — stub that #877 will replace with a real POST
- \`components/HomeClosingBanner.{jsx,css}\` (+ tests)
- \`pages/HomePage.jsx\` — wires the four new sections in order

## Test plan
- [x] Full Jest suite: **781 passing across 91 suites** (+38 new tests, +7 new suites)
- [x] Production build: \`Compiled with warnings\` (no errors)
- [ ] Manual QA on \`/\`:
  - Scroll past Cultural Highlights → \"Explore by region\" map renders; hover on Turkey shows the Anatolia count line; click navigates to \`/search?region=Anatolia\`.
  - \"This week's recipes\" + \"This week's stories\" rails render 6 cards each; \"More →\" goes to \`/recipes\` / \`/stories\`.
  - Feedback Bar accepts text, validates empty submit, shows thanks for ~4s.
  - Closing banner renders at the bottom above the floating prompt.

## Follow-ups
- **#877** — backend \`POST /api/feedback/\` endpoint. After it lands, swap \`feedbackService.submitFeedback\` for a real \`apiClient.post\` (one-line change).
- Curated \"featured\" flag / endpoint for recipes & stories — the helpers slice the list endpoint for now.
- \`<ZoomableGroup>\` interaction on the home map — static world view today.