### PR TITLE
feat(frontend): calendar UX polish — single-month layout, smooth scroll, legend, themed detail (#886)

### DIFF
--- a/app/frontend/src/__tests__/CalendarPage.test.jsx
+++ b/app/frontend/src/__tests__/CalendarPage.test.jsx
@@ -90,6 +90,15 @@ describe('CalendarPage', () => {
     expect(within(panel).getByRole('link', { name: /sumalak/i })).toHaveAttribute('href', '/recipes/10');
   });
 
+  it('scrolls the detail panel into view when an event card is clicked', async () => {
+    const scrollSpy = jest.fn();
+    window.HTMLElement.prototype.scrollIntoView = scrollSpy;
+    renderPage();
+    const card = await screen.findByRole('button', { name: /open nevruz details/i });
+    await userEvent.click(card);
+    expect(scrollSpy).toHaveBeenCalled();
+  });
+
   it('renders only the selected month panel when the month filter is set', async () => {
     culturalEventService.fetchCulturalEvents.mockResolvedValue([
       { id: 100, name: 'Spring Equinox', date_rule: 'fixed:03-21', region: { id: 1, name: 'Anatolia' }, description: '', recipes: [] },

--- a/app/frontend/src/__tests__/CalendarPage.test.jsx
+++ b/app/frontend/src/__tests__/CalendarPage.test.jsx
@@ -90,6 +90,24 @@ describe('CalendarPage', () => {
     expect(within(panel).getByRole('link', { name: /sumalak/i })).toHaveAttribute('href', '/recipes/10');
   });
 
+  it('renders a date-rule legend below the header explaining badge colors', async () => {
+    culturalEventService.fetchCulturalEvents.mockResolvedValue([]);
+    renderPage();
+    const legend = await screen.findByLabelText(/date legend/i);
+    const { within } = require('@testing-library/react');
+    expect(within(legend).getByText(/gregorian date/i)).toBeInTheDocument();
+    expect(within(legend).getByText(/lunar.+movable/i)).toBeInTheDocument();
+  });
+
+  it('does NOT render the per-card lunar subline (replaced by the legend)', async () => {
+    culturalEventService.fetchCulturalEvents.mockResolvedValue([
+      { id: 9, name: 'Eid al-Adha', date_rule: 'lunar:eid-adha', region: { id: 1, name: 'All Regions' }, description: '', recipes: [] },
+    ]);
+    renderPage();
+    await screen.findByText(/eid al-adha/i);
+    expect(screen.queryByText(/on the lunar calendar/i)).not.toBeInTheDocument();
+  });
+
   it('scrolls the detail panel into view when an event card is clicked', async () => {
     const scrollSpy = jest.fn();
     window.HTMLElement.prototype.scrollIntoView = scrollSpy;
@@ -134,14 +152,6 @@ describe('CalendarPage — lunar resolution + subline (#669)', () => {
     expect(within(monthPanel).getAllByText(/ramadan/i).length).toBeGreaterThan(0);
   });
 
-  it('shows a lunar subline on every lunar event card', async () => {
-    culturalEventService.fetchCulturalEvents.mockResolvedValue([
-      { id: 2, name: 'Eid al-Adha', date_rule: 'lunar:eid-adha', region: { id: 1, name: 'All Regions' }, description: '', recipes: [] },
-    ]);
-    renderPage();
-    expect(await screen.findByText(/on the lunar calendar/i)).toBeInTheDocument();
-  });
-
   it('keeps unresolved lunar events in a "Lunar / movable feasts" section with (movable)', async () => {
     culturalEventService.fetchCulturalEvents.mockResolvedValue([
       { id: 3, name: 'Made-up Lunar', date_rule: 'lunar:unknown-name', region: { id: 1, name: 'All Regions' }, description: '', recipes: [] },
@@ -167,7 +177,7 @@ describe('CalendarPage — lunar resolution + subline (#669)', () => {
       { id: 6, name: 'Eid al-Adha', date_rule: 'lunar:eid_al_adha', region: { id: 1, name: 'All Regions' }, description: '', recipes: [] },
     ]);
     renderPage();
-    expect(await screen.findByText(/on the lunar calendar/i)).toBeInTheDocument();
+    expect(await screen.findByText(/eid al-adha/i)).toBeInTheDocument();
     // (movable) only appears when unresolved; with the table entry it must NOT appear.
     expect(screen.queryByText(/\(movable\)/i)).not.toBeInTheDocument();
   });
@@ -177,15 +187,7 @@ describe('CalendarPage — lunar resolution + subline (#669)', () => {
       { id: 7, name: 'Diwali', date_rule: 'lunar:diwali', region: { id: 1, name: 'Indian' }, description: '', recipes: [] },
     ]);
     renderPage();
-    expect(await screen.findByText(/on the lunar calendar/i)).toBeInTheDocument();
+    expect(await screen.findByText(/diwali/i)).toBeInTheDocument();
     expect(screen.queryByText(/\(movable\)/i)).not.toBeInTheDocument();
-  });
-
-  it('shows the pretty event name in the subline rather than the raw slug', async () => {
-    culturalEventService.fetchCulturalEvents.mockResolvedValue([
-      { id: 8, name: 'Eid al-Adha', date_rule: 'lunar:eid_al_adha', region: { id: 1, name: 'All Regions' }, description: '', recipes: [] },
-    ]);
-    renderPage();
-    expect(await screen.findByText(/On the lunar calendar: Eid al-Adha this year/i)).toBeInTheDocument();
   });
 });

--- a/app/frontend/src/__tests__/CalendarPage.test.jsx
+++ b/app/frontend/src/__tests__/CalendarPage.test.jsx
@@ -90,6 +90,23 @@ describe('CalendarPage', () => {
     expect(within(panel).getByRole('link', { name: /sumalak/i })).toHaveAttribute('href', '/recipes/10');
   });
 
+  it('tints the detail panel by event kind', async () => {
+    culturalEventService.fetchCulturalEvents.mockResolvedValue([
+      { id: 1, name: 'Nevruz',      date_rule: 'fixed:03-21',    region: { id: 1, name: 'All Regions' }, description: '', recipes: [] },
+      { id: 2, name: 'Eid al-Adha', date_rule: 'lunar:eid-adha', region: { id: 1, name: 'All Regions' }, description: '', recipes: [] },
+      { id: 3, name: 'Made-up',     date_rule: 'lunar:unknown',  region: { id: 1, name: 'All Regions' }, description: '', recipes: [] },
+    ]);
+    renderPage();
+    await userEvent.click(await screen.findByRole('button', { name: /open nevruz details/i }));
+    expect(screen.getByTestId('event-detail')).toHaveClass('tint-gregorian');
+    await userEvent.click(screen.getByRole('button', { name: /close details/i }));
+    await userEvent.click(screen.getByRole('button', { name: /open eid al-adha details/i }));
+    expect(screen.getByTestId('event-detail')).toHaveClass('tint-lunar');
+    await userEvent.click(screen.getByRole('button', { name: /close details/i }));
+    await userEvent.click(screen.getByRole('button', { name: /open made-up details/i }));
+    expect(screen.getByTestId('event-detail')).toHaveClass('tint-movable');
+  });
+
   it('renders a date-rule legend below the header explaining badge colors', async () => {
     culturalEventService.fetchCulturalEvents.mockResolvedValue([]);
     renderPage();

--- a/app/frontend/src/__tests__/CalendarPage.test.jsx
+++ b/app/frontend/src/__tests__/CalendarPage.test.jsx
@@ -89,6 +89,19 @@ describe('CalendarPage', () => {
     expect(within(panel).getByRole('heading', { name: /nevruz/i })).toBeInTheDocument();
     expect(within(panel).getByRole('link', { name: /sumalak/i })).toHaveAttribute('href', '/recipes/10');
   });
+
+  it('renders only the selected month panel when the month filter is set', async () => {
+    culturalEventService.fetchCulturalEvents.mockResolvedValue([
+      { id: 100, name: 'Spring Equinox', date_rule: 'fixed:03-21', region: { id: 1, name: 'Anatolia' }, description: '', recipes: [] },
+    ]);
+    const { container } = renderPage();
+    await screen.findByText('Spring Equinox');
+    expect(container.querySelectorAll('[data-testid^="calendar-month-"]').length).toBe(12);
+    await userEvent.selectOptions(screen.getByLabelText(/month/i), '03');
+    await waitFor(() => expect(culturalEventService.fetchCulturalEvents).toHaveBeenLastCalledWith({ month: '03', region: '' }));
+    expect(container.querySelectorAll('[data-testid^="calendar-month-"]').length).toBe(1);
+    expect(container.querySelector('[data-testid="calendar-month-3"]')).toBeInTheDocument();
+  });
 });
 
 describe('CalendarPage — lunar resolution + subline (#669)', () => {

--- a/app/frontend/src/pages/CalendarPage.css
+++ b/app/frontend/src/pages/CalendarPage.css
@@ -232,3 +232,16 @@
   align-items: center;
   gap: 0.5rem;
 }
+
+.calendar-event-detail.tint-gregorian {
+  background: rgba(196, 82, 30, 0.06);
+  border-left: 4px solid #C4521E;
+}
+.calendar-event-detail.tint-lunar {
+  background: rgba(61, 21, 0, 0.06);
+  border-left: 4px solid #3D1500;
+}
+.calendar-event-detail.tint-movable {
+  background: rgba(212, 168, 48, 0.10);
+  border-left: 4px solid #D4A830;
+}

--- a/app/frontend/src/pages/CalendarPage.css
+++ b/app/frontend/src/pages/CalendarPage.css
@@ -216,8 +216,19 @@
   color: var(--color-surface, #FAF7EF);
 }
 
-.calendar-event-lunar-subline {
-  font-style: italic;
-  font-size: 0.8rem;
+.calendar-legend {
+  list-style: none;
+  margin: 0.75rem 0 1.5rem;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.25rem;
+  font-size: 0.85rem;
   color: var(--color-text-muted, #6b6b6b);
+}
+
+.calendar-legend li {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
 }

--- a/app/frontend/src/pages/CalendarPage.jsx
+++ b/app/frontend/src/pages/CalendarPage.jsx
@@ -10,32 +10,6 @@ const MONTHS = [
   'July', 'August', 'September', 'October', 'November', 'December',
 ];
 
-const LUNAR_PRETTY = {
-  'ramadan': 'Ramadan',
-  'eid-fitr': 'Eid al-Fitr',
-  'eid-al-fitr': 'Eid al-Fitr',
-  'eid-adha': 'Eid al-Adha',
-  'eid-al-adha': 'Eid al-Adha',
-  'kurban-bayrami': 'Eid al-Adha',
-  'mevlid': 'Mevlid',
-  'ashura': 'Ashura',
-  'diwali': 'Diwali',
-  'chuseok': 'Chuseok',
-  'carnaval': 'Carnaval',
-  'chinese-new-year': 'Chinese New Year',
-  'lunar-new-year': 'Lunar New Year',
-  'chunjie': 'Lunar New Year',
-  'homowo': 'Homowo',
-  'maslenitsa': 'Maslenitsa',
-};
-
-function prettyLunar(slug) {
-  if (!slug) return '';
-  const normalized = slug.toLowerCase().replace(/_/g, '-');
-  if (LUNAR_PRETTY[normalized]) return LUNAR_PRETTY[normalized];
-  return normalized.split('-').map((p) => p.charAt(0).toUpperCase() + p.slice(1)).join(' ');
-}
-
 function ruleFromEvent(event) {
   const r = event.date_rule;
   if (typeof r !== 'string') return null;
@@ -101,6 +75,17 @@ export default function CalendarPage() {
           Explore which foods belong to which seasons, rituals and celebrations.
         </p>
       </header>
+
+      <ul className="calendar-legend" aria-label="Date legend">
+        <li>
+          <span className="calendar-event-badge" aria-hidden="true">Mar 21</span>
+          Gregorian date
+        </li>
+        <li>
+          <span className="calendar-event-badge is-lunar" aria-hidden="true">Mar 19</span>
+          Lunar / movable feast
+        </li>
+      </ul>
 
       <div className="calendar-filters">
         <label className="calendar-filter">
@@ -217,7 +202,6 @@ export default function CalendarPage() {
 function CalendarEventCard({ event, parsed, onSelect }) {
   const isLunar = Boolean(parsed?.isLunar);
   const isMovable = isLunar && parsed?.lunarUnresolved;
-  const pretty = isLunar ? prettyLunar(parsed.lunarName) : '';
   const dateLabel = isMovable
     ? '(movable)'
     : `${MONTHS[parsed.monthIndex].slice(0, 3)} ${parsed.day}`;
@@ -236,12 +220,6 @@ function CalendarEventCard({ event, parsed, onSelect }) {
         <span className="calendar-event-name">{event.name}</span>
         {event.region?.name && (
           <span className="calendar-event-region">{event.region.name}</span>
-        )}
-        {isLunar && (
-          <span className="calendar-event-lunar-subline">
-            ☾ On the lunar calendar: {pretty} this year
-            {isMovable ? ' (movable)' : ''}
-          </span>
         )}
       </button>
     </li>

--- a/app/frontend/src/pages/CalendarPage.jsx
+++ b/app/frontend/src/pages/CalendarPage.jsx
@@ -119,7 +119,11 @@ export default function CalendarPage() {
       {loading && <p className="page-status">Loading…</p>}
 
       <div className="calendar-grid">
-        {MONTHS.map((label, idx) => {
+        {(month
+          ? [parseInt(month, 10) - 1].filter((i) => i >= 0 && i <= 11)
+          : MONTHS.map((_, i) => i)
+        ).map((idx) => {
+          const label = MONTHS[idx];
           const monthEvents = grouped.byMonth[idx];
           return (
             <section

--- a/app/frontend/src/pages/CalendarPage.jsx
+++ b/app/frontend/src/pages/CalendarPage.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { fetchCulturalEvents } from '../services/culturalEventService';
 import { parseEventDate } from '../services/calendarService';
@@ -50,12 +50,20 @@ export default function CalendarPage() {
   const [month, setMonth] = useState('');
   const [region, setRegion] = useState('');
   const [selected, setSelected] = useState(null);
+  const detailRef = useRef(null);
 
   useEffect(() => {
     let cancelled = false;
     fetchRegions().then((data) => { if (!cancelled) setRegions(data); }).catch(() => {});
     return () => { cancelled = true; };
   }, []);
+
+  useEffect(() => {
+    if (!selected) return;
+    if (typeof detailRef.current?.scrollIntoView === 'function') {
+      detailRef.current.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+  }, [selected]);
 
   useEffect(() => {
     let cancelled = false;
@@ -171,7 +179,7 @@ export default function CalendarPage() {
       )}
 
       {selected && (
-        <aside className="calendar-event-detail" data-testid="event-detail">
+        <aside ref={detailRef} className="calendar-event-detail" data-testid="event-detail">
           <button
             type="button"
             className="calendar-event-detail-close"

--- a/app/frontend/src/pages/CalendarPage.jsx
+++ b/app/frontend/src/pages/CalendarPage.jsx
@@ -17,6 +17,14 @@ function ruleFromEvent(event) {
   return r;
 }
 
+function tintForEvent(event) {
+  const parsed = parseEventDate(ruleFromEvent(event));
+  if (!parsed) return 'tint-gregorian';
+  if (parsed.isLunar && parsed.lunarUnresolved) return 'tint-movable';
+  if (parsed.isLunar) return 'tint-lunar';
+  return 'tint-gregorian';
+}
+
 export default function CalendarPage() {
   const [regions, setRegions] = useState([]);
   const [events, setEvents] = useState([]);
@@ -164,7 +172,11 @@ export default function CalendarPage() {
       )}
 
       {selected && (
-        <aside ref={detailRef} className="calendar-event-detail" data-testid="event-detail">
+        <aside
+          ref={detailRef}
+          className={`calendar-event-detail ${tintForEvent(selected)}`}
+          data-testid="event-detail"
+        >
           <button
             type="button"
             className="calendar-event-detail-close"


### PR DESCRIPTION
Closes #886. Four UX polish fixes on \`/calendar\`, one commit per concern.

## Changes

1. **Single-month layout when the month filter is engaged.** Picking a month from the dropdown now renders only that month's panel (the "Lunar / movable feasts" bucket still appears below if relevant). "All months" keeps the existing 12-panel grid.
2. **Smooth scroll to the detail panel on event click.** A \`useRef\` on the detail aside + a \`useEffect\` keyed on \`selected\` calls \`scrollIntoView({ behavior: 'smooth', block: 'center' })\` so the user doesn't have to scroll manually.
3. **Replaced the per-card lunar subline with a single legend.** The repetitive \`☾ On the lunar calendar: <Name> this year\` line that ran under every lunar card is gone. A two-swatch legend ("Mar 21 · Gregorian date", "Mar 19 · Lunar / movable feast") now sits below the calendar's intro paragraph.
4. **Detail panel tinted by event kind.** Selecting a Gregorian event gives the panel a light rust tint with a rust left border; resolved lunar events use a dark cream tint with a dark-brown border; unresolved/movable events use a mustard tint with a mustard border.

## Notes

- jsdom doesn't implement \`scrollIntoView\`. The component guards the call with \`typeof … === 'function'\` so the test environment is a no-op and real browsers scroll. The new "scrolls into view" test stubs the prototype method to assert it's called.
- Three of the \`#669\` companion tests asserted the per-card subline text; rewrote them to assert event presence + \`(movable)\` invariant instead, since the subline is intentionally removed by this PR.

## Test plan
- [x] Full Jest suite: **797 passing across 92 suites**
- [x] Production build clean (warnings only)
- [ ] Manual QA on \`/calendar\`:
  - Pick March from the month dropdown → only March + lunar bucket render.
  - Click any event card → page smooth-scrolls to the detail panel.
  - No \`On the lunar calendar\` line under any card; legend visible at the top.
  - Click a Gregorian event → rust-tinted panel. Click a lunar event → dark-cream panel. Pick a movable lunar slug → mustard panel.