### PR TITLE
feat(backend): expose recipe_title and story_title on PassportEventSerializer (#870)

### DIFF
--- a/app/backend/apps/passport/serializers.py
+++ b/app/backend/apps/passport/serializers.py
@@ -23,13 +23,22 @@ class StampSerializer(serializers.ModelSerializer):
 class PassportEventSerializer(serializers.ModelSerializer):
     related_recipe = serializers.PrimaryKeyRelatedField(read_only=True)
     related_story = serializers.PrimaryKeyRelatedField(read_only=True)
+    recipe_title = serializers.SerializerMethodField()
+    story_title = serializers.SerializerMethodField()
 
     class Meta:
         model = PassportEvent
         fields = [
             'id', 'event_type', 'description', 'timestamp',
-            'related_recipe', 'related_story', 'stamp_rarity',
+            'related_recipe', 'related_story', 'recipe_title', 'story_title',
+            'stamp_rarity',
         ]
+
+    def get_recipe_title(self, obj):
+        return obj.related_recipe.title if obj.related_recipe_id else None
+
+    def get_story_title(self, obj):
+        return obj.related_story.title if obj.related_story_id else None
 
 
 class QuestProgressSerializer(serializers.Serializer):

--- a/app/backend/apps/passport/tests.py
+++ b/app/backend/apps/passport/tests.py
@@ -566,6 +566,37 @@ class TimelineTest(APITestCase):
         self.assertEqual(timeline[0]['description'], 'event-54')
         self.assertEqual(timeline[-1]['description'], 'event-5')
 
+    def test_timeline_event_includes_recipe_and_story_titles(self):
+        PassportEvent.objects.create(
+            user=self.bob, event_type=PassportEvent.TYPE_RECIPE_TRIED,
+            description='tried a recipe', timestamp=timezone.now(),
+            related_recipe=self.recipe,
+        )
+        PassportEvent.objects.create(
+            user=self.bob, event_type=PassportEvent.TYPE_STORY_SAVED,
+            description='saved a story', timestamp=timezone.now() - timedelta(seconds=1),
+            related_story=self.story,
+        )
+        timeline = self.client.get('/api/users/bob/passport/').data['timeline']
+        by_type = {e['event_type']: e for e in timeline}
+
+        recipe_event = by_type[PassportEvent.TYPE_RECIPE_TRIED]
+        self.assertEqual(recipe_event['recipe_title'], 'R')
+        self.assertIsNone(recipe_event['story_title'])
+
+        story_event = by_type[PassportEvent.TYPE_STORY_SAVED]
+        self.assertEqual(story_event['story_title'], 'S')
+        self.assertIsNone(story_event['recipe_title'])
+
+    def test_timeline_event_titles_are_none_without_related_objects(self):
+        PassportEvent.objects.create(
+            user=self.bob, event_type=PassportEvent.TYPE_LEVEL_UP,
+            description='reached level 2', timestamp=timezone.now(),
+        )
+        event = self.client.get('/api/users/bob/passport/').data['timeline'][0]
+        self.assertIsNone(event['recipe_title'])
+        self.assertIsNone(event['story_title'])
+
 
 class PopulatedPassportEndpointTest(APITestCase):
     """GET /api/users/<username>/passport/ once stamps/quests/timeline exist."""


### PR DESCRIPTION
Summary
PassportEventSerializer: timeline events only sent the integer IDs of `related_recipe` / `related_story`, so mobile and web clients had to do an extra fetch per event to render a human-readable title for timeline pills. Added `recipe_title` and `story_title` as `SerializerMethodField`s that return the related object's `title` (or `null` when the FK is unset) — no extra API calls needed.

Closes #870.

Test plan
 [ ] `python manage.py test apps.passport` — all green
 [ ] GET `/api/users/<username>/passport/` — each `timeline` entry now has `recipe_title` and `story_title` keys
 [ ] A `recipe_tried` event shows `recipe_title` set and `story_title` null; a `story_saved` event shows the reverse
 [ ] An event with no related recipe/story (e.g. `level_up`) has both titles null