### PR TITLE
fix(frontend): cover all seeded regions in home map country lookup

### DIFF
--- a/app/frontend/src/__tests__/RegionContentMap.test.jsx
+++ b/app/frontend/src/__tests__/RegionContentMap.test.jsx
@@ -38,17 +38,18 @@ function renderMap(regions) {
   );
 }
 
-// Turkey → "Anatolia", Greece → "Aegean" per countryRegions.js.
+// Turkey → "Anatolian", Greece → "Greece" per countryRegions.js (names match
+// the backend seed in app/backend/apps/recipes/migrations/0004_seed_regions.py).
 const REGIONS = [
-  { id: 1, name: 'Anatolia', content_count: { recipes: 4,  stories: 2 } },
-  { id: 2, name: 'Aegean',   content_count: { recipes: 12, stories: 5 } },
+  { id: 1, name: 'Anatolian', content_count: { recipes: 4,  stories: 2 } },
+  { id: 2, name: 'Greece',    content_count: { recipes: 12, stories: 5 } },
 ];
 
 describe('RegionContentMap', () => {
   it('shows N recipes · M stories on hover for a mapped country', () => {
     renderMap(REGIONS);
     fireEvent.mouseEnter(screen.getByTestId('geo-Turkey'));
-    expect(screen.getByText(/anatolia/i)).toBeInTheDocument();
+    expect(screen.getByText(/anatolian/i)).toBeInTheDocument();
     expect(screen.getByText(/4 recipes.*2 stories/i)).toBeInTheDocument();
   });
 

--- a/app/frontend/src/__tests__/countryRegions.test.js
+++ b/app/frontend/src/__tests__/countryRegions.test.js
@@ -1,0 +1,100 @@
+import { COUNTRY_TO_REGION, getRegionForCountry } from '../utils/countryRegions';
+
+/**
+ * Mirror of `REGIONS` in
+ * `app/backend/apps/recipes/migrations/0004_seed_regions.py` (the source of
+ * truth for which `Region.name` values exist on the backend). If the backend
+ * grows or renames a region, update this list — the contract test below
+ * fails loudly so the home map can't silently drop a region.
+ */
+const BACKEND_SEED_REGIONS = new Set([
+  'Aegean', 'Anatolian', 'Black Sea', 'Marmara', 'Mediterranean',
+  'Southeastern Anatolia', 'Levantine', 'Persian', 'Arabian', 'Saudi Arabia',
+  'Balkan', 'Central European', 'Eastern European', 'French', 'Iberian',
+  'Italian', 'Nordic', 'British Isles', 'France', 'Germany', 'Greece',
+  'Hungary', 'Poland', 'Portugal', 'Russia', 'Spain', 'United Kingdom',
+  'Central Asian', 'Chinese', 'Indian', 'Japanese', 'Korean',
+  'Southeast Asian', 'China', 'South Korea', 'Thailand', 'Vietnam',
+  'Kyrgyzstan', 'Uzbekistan', 'East African', 'North African', 'West African',
+  'Ethiopia', 'Ghana', 'Morocco', 'Nigeria', 'Caribbean', 'Central American',
+  'North American', 'South American', 'Argentina', 'Brazil', 'El Salvador',
+  'Jamaica', 'Peru', 'Trinidad and Tobago', 'Oceanian', 'Australia',
+]);
+
+describe('getRegionForCountry', () => {
+  it('returns null for an unmapped country', () => {
+    expect(getRegionForCountry('Atlantis')).toBeNull();
+  });
+
+  it('returns null for non-string input', () => {
+    expect(getRegionForCountry(undefined)).toBeNull();
+    expect(getRegionForCountry(null)).toBeNull();
+    expect(getRegionForCountry(42)).toBeNull();
+  });
+
+  it('is case-insensitive and trims whitespace', () => {
+    expect(getRegionForCountry('  france  ')).toBe('France');
+    expect(getRegionForCountry('TURKEY')).toBe('Anatolian');
+  });
+
+  it('prefers country-level regions over macro-regions when both exist', () => {
+    // Russia is its own seeded region; macro-Black-Sea is not the right answer
+    // for someone clicking the country Russia.
+    expect(getRegionForCountry('Russia')).toBe('Russia');
+    // Same for Spain (Iberian exists too, but Spain is the specific country
+    // region the user expects to land on).
+    expect(getRegionForCountry('Spain')).toBe('Spain');
+    expect(getRegionForCountry('Brazil')).toBe('Brazil');
+  });
+
+  it('falls back to the macro-region when no country-level region exists', () => {
+    expect(getRegionForCountry('Sweden')).toBe('Nordic');
+    expect(getRegionForCountry('Croatia')).toBe('Balkan');
+    expect(getRegionForCountry('Belgium')).toBe('Central European');
+    expect(getRegionForCountry('Bangladesh')).toBe('Indian');
+    expect(getRegionForCountry('Vietnam')).toBe('Vietnam'); // country-level
+  });
+
+  it('uses Southeastern Anatolia (not Southeast Anatolia) for Iraq', () => {
+    // Regression: the previous mapping used "Southeast Anatolia", which the
+    // backend doesn't seed — Iraq stayed cream-coloured on the home map.
+    expect(getRegionForCountry('Iraq')).toBe('Southeastern Anatolia');
+  });
+
+  it('covers world-atlas truncated names alongside full names', () => {
+    expect(getRegionForCountry('Bosnia and Herz.')).toBe('Balkan');
+    expect(getRegionForCountry('Bosnia and Herzegovina')).toBe('Balkan');
+    expect(getRegionForCountry('Czech Rep.')).toBe('Central European');
+    expect(getRegionForCountry('Czechia')).toBe('Central European');
+    expect(getRegionForCountry('Dem. Rep. Congo')).toBe('West African');
+    expect(getRegionForCountry('S. Sudan')).toBe('East African');
+  });
+
+  it('covers a sample of countries across every continent', () => {
+    expect(getRegionForCountry('Greece')).toBe('Greece');
+    expect(getRegionForCountry('Japan')).toBe('Japanese');
+    expect(getRegionForCountry('China')).toBe('China');
+    expect(getRegionForCountry('India')).toBe('Indian');
+    expect(getRegionForCountry('Australia')).toBe('Australia');
+    expect(getRegionForCountry('New Zealand')).toBe('Oceanian');
+    expect(getRegionForCountry('United States of America')).toBe('North American');
+    expect(getRegionForCountry('Canada')).toBe('North American');
+    expect(getRegionForCountry('Mexico')).toBe('Central American');
+    expect(getRegionForCountry('Cuba')).toBe('Caribbean');
+    expect(getRegionForCountry('Argentina')).toBe('Argentina');
+    expect(getRegionForCountry('Egypt')).toBe('North African');
+    expect(getRegionForCountry('Kenya')).toBe('East African');
+    expect(getRegionForCountry('Nigeria')).toBe('Nigeria');
+    expect(getRegionForCountry('Saudi Arabia')).toBe('Saudi Arabia');
+    expect(getRegionForCountry('Iran')).toBe('Persian');
+  });
+
+  it('every mapped region value matches a backend seed Region.name', () => {
+    // Contract: if this fails, either the backend seeds were renamed or a
+    // typo slipped into the mapping (e.g. the old "Southeast Anatolia" bug).
+    const orphans = Object.entries(COUNTRY_TO_REGION).filter(
+      ([, region]) => !BACKEND_SEED_REGIONS.has(region),
+    );
+    expect(orphans).toEqual([]);
+  });
+});

--- a/app/frontend/src/utils/countryRegions.js
+++ b/app/frontend/src/utils/countryRegions.js
@@ -2,46 +2,275 @@
  * Country (as named by world-atlas' `countries-110m.json` `properties.name`)
  * → culinary-region lookup used by the home page's `RegionContentMap`.
  *
- * Region names here mirror the backend `Region.name` values returned by
- * `/api/map/regions/` (e.g. "Anatolia", "Aegean", "Black Sea", …) so that the
- * map can hand the name straight into `/search?region=<name>` URLs and into
- * `byName.get(region.name)` lookups against the API payload.
+ * Region names here mirror the backend `Region.name` values seeded in
+ * `app/backend/apps/recipes/migrations/0004_seed_regions.py` (which is the
+ * single source of truth — every value below MUST exist there or the map will
+ * never light up that country, because `RegionContentMap` joins this lookup
+ * against the `/api/map/regions/` payload by exact name).
  *
- * The same source data underpins `passportCultureRegions.js` (which works in
- * the inverse direction, culture → countries). The two utilities are kept
- * separate because they serve genuinely different flows: the passport flow
- * cares about how engaged the user is with a culture and can let multiple
- * cultures claim the same country, while the home-page map only needs a
- * single canonical region per country.
+ * Strategy: prefer the most specific region available — a country-level
+ * region wins over a macro-region. e.g. `Japan` → `Japanese` (no country-level
+ * "Japan" region exists), `Russia` → `Russia` (a country-level region exists),
+ * `Sweden` → `Nordic` (no Swedish country-level region).
+ *
+ * Aliases: world-atlas / Natural Earth truncates a few long names with `.`
+ * ("Bosnia and Herz.", "Czech Rep.") — we add both forms so existing tests
+ * keep passing and so the map doesn't go cream-empty if the topojson swaps
+ * between long and short forms in a future version.
  *
  * Lookup is case-insensitive and trims whitespace.
  * Returns `null` for countries that don't belong to any culinary region yet.
  */
 export const COUNTRY_TO_REGION = {
-  // Turkish heartland — single canonical pick per country.
-  Turkey: 'Anatolia',
-  Greece: 'Aegean',
-  Italy: 'Mediterranean',
-  Spain: 'Mediterranean',
-  France: 'Mediterranean',
+  // ── Anatolia / surrounding ──
+  Turkey: 'Anatolian',
+  Iraq: 'Southeastern Anatolia',
+  Syria: 'Levantine',
+  Lebanon: 'Levantine',
+  Israel: 'Levantine',
+  Jordan: 'Levantine',
+  Palestine: 'Levantine',
+  'West Bank': 'Levantine',
+
+  // ── Mediterranean basin ──
+  Greece: 'Greece',
+  Italy: 'Italian',
+  'San Marino': 'Italian',
+  Vatican: 'Italian',
   Malta: 'Mediterranean',
   Cyprus: 'Mediterranean',
-  Egypt: 'Mediterranean',
-  Libya: 'Mediterranean',
-  Tunisia: 'Mediterranean',
-  Algeria: 'Mediterranean',
-  Morocco: 'Mediterranean',
-  Lebanon: 'Mediterranean',
-  Israel: 'Mediterranean',
-  Syria: 'Mediterranean',
-  // Black Sea littoral.
+  'N. Cyprus': 'Mediterranean',
+
+  // ── Iberia ──
+  Spain: 'Spain',
+  Portugal: 'Portugal',
+  Andorra: 'Iberian',
+
+  // ── France & adjacent ──
+  France: 'France',
+  Monaco: 'French',
+
+  // ── British Isles ──
+  'United Kingdom': 'United Kingdom',
+  Ireland: 'British Isles',
+
+  // ── Central Europe ──
+  Germany: 'Germany',
+  Austria: 'Central European',
+  Switzerland: 'Central European',
+  Liechtenstein: 'Central European',
+  Luxembourg: 'Central European',
+  Belgium: 'Central European',
+  Netherlands: 'Central European',
+  Czechia: 'Central European',
+  'Czech Rep.': 'Central European',
+  Slovakia: 'Central European',
+  Hungary: 'Hungary',
+  Poland: 'Poland',
+
+  // ── Eastern Europe ──
+  Belarus: 'Eastern European',
+  Latvia: 'Eastern European',
+  Lithuania: 'Eastern European',
+  Estonia: 'Eastern European',
+  Moldova: 'Eastern European',
+
+  // ── Nordics ──
+  Sweden: 'Nordic',
+  Norway: 'Nordic',
+  Denmark: 'Nordic',
+  Finland: 'Nordic',
+  Iceland: 'Nordic',
+
+  // ── Balkans ──
+  Albania: 'Balkan',
+  Bosnia: 'Balkan',
+  'Bosnia and Herz.': 'Balkan',
+  'Bosnia and Herzegovina': 'Balkan',
+  Croatia: 'Balkan',
+  Kosovo: 'Balkan',
+  Macedonia: 'Balkan',
+  'North Macedonia': 'Balkan',
+  Montenegro: 'Balkan',
+  Serbia: 'Balkan',
+  Slovenia: 'Balkan',
+
+  // ── Black Sea littoral ──
+  Russia: 'Russia',
   Ukraine: 'Black Sea',
-  Russia: 'Black Sea',
   Romania: 'Black Sea',
   Bulgaria: 'Black Sea',
   Georgia: 'Black Sea',
-  // South-eastern Anatolia spills into Iraq.
-  Iraq: 'Southeast Anatolia',
+  Armenia: 'Black Sea',
+  Azerbaijan: 'Black Sea',
+
+  // ── Persian / Arabian ──
+  Iran: 'Persian',
+  'Saudi Arabia': 'Saudi Arabia',
+  Yemen: 'Arabian',
+  Oman: 'Arabian',
+  'United Arab Emirates': 'Arabian',
+  Qatar: 'Arabian',
+  Bahrain: 'Arabian',
+  Kuwait: 'Arabian',
+
+  // ── Central Asia ──
+  Afghanistan: 'Central Asian',
+  Kazakhstan: 'Central Asian',
+  Turkmenistan: 'Central Asian',
+  Tajikistan: 'Central Asian',
+  Mongolia: 'Central Asian',
+  Kyrgyzstan: 'Kyrgyzstan',
+  Uzbekistan: 'Uzbekistan',
+
+  // ── South Asia ──
+  India: 'Indian',
+  Pakistan: 'Indian',
+  Bangladesh: 'Indian',
+  Nepal: 'Indian',
+  Bhutan: 'Indian',
+  'Sri Lanka': 'Indian',
+  Maldives: 'Indian',
+
+  // ── East Asia ──
+  China: 'China',
+  Taiwan: 'Chinese',
+  Japan: 'Japanese',
+  'North Korea': 'Korean',
+  'Dem. Rep. Korea': 'Korean',
+  'South Korea': 'South Korea',
+  'Republic of Korea': 'South Korea',
+
+  // ── Southeast Asia ──
+  Thailand: 'Thailand',
+  Vietnam: 'Vietnam',
+  Laos: 'Southeast Asian',
+  Cambodia: 'Southeast Asian',
+  Myanmar: 'Southeast Asian',
+  Burma: 'Southeast Asian',
+  Malaysia: 'Southeast Asian',
+  Singapore: 'Southeast Asian',
+  Brunei: 'Southeast Asian',
+  Indonesia: 'Southeast Asian',
+  Philippines: 'Southeast Asian',
+  'Timor-Leste': 'Southeast Asian',
+  'East Timor': 'Southeast Asian',
+
+  // ── North Africa ──
+  Morocco: 'Morocco',
+  Algeria: 'North African',
+  Tunisia: 'North African',
+  Libya: 'North African',
+  Egypt: 'North African',
+  Sudan: 'North African',
+  'W. Sahara': 'North African',
+  'Western Sahara': 'North African',
+
+  // ── East Africa ──
+  Ethiopia: 'Ethiopia',
+  Eritrea: 'East African',
+  Djibouti: 'East African',
+  Somalia: 'East African',
+  Somaliland: 'East African',
+  'S. Sudan': 'East African',
+  'South Sudan': 'East African',
+  Kenya: 'East African',
+  Uganda: 'East African',
+  Tanzania: 'East African',
+  Rwanda: 'East African',
+  Burundi: 'East African',
+  Madagascar: 'East African',
+  Comoros: 'East African',
+  Seychelles: 'East African',
+  Mauritius: 'East African',
+  Malawi: 'East African',
+  Mozambique: 'East African',
+  Zambia: 'East African',
+  Zimbabwe: 'East African',
+
+  // ── West / Central Africa ──
+  Nigeria: 'Nigeria',
+  Ghana: 'Ghana',
+  Senegal: 'West African',
+  Gambia: 'West African',
+  'Guinea-Bissau': 'West African',
+  Guinea: 'West African',
+  'Sierra Leone': 'West African',
+  Liberia: 'West African',
+  'Côte d\'Ivoire': 'West African',
+  'Ivory Coast': 'West African',
+  Mali: 'West African',
+  'Burkina Faso': 'West African',
+  Niger: 'West African',
+  Togo: 'West African',
+  Benin: 'West African',
+  Mauritania: 'West African',
+  'Cape Verde': 'West African',
+  Cameroon: 'West African',
+  Chad: 'West African',
+  'Central African Rep.': 'West African',
+  'Central African Republic': 'West African',
+  Gabon: 'West African',
+  'Eq. Guinea': 'West African',
+  'Equatorial Guinea': 'West African',
+  Congo: 'West African',
+  'Dem. Rep. Congo': 'West African',
+  'Democratic Republic of the Congo': 'West African',
+  Angola: 'West African',
+  Namibia: 'West African',
+
+  // ── North America ──
+  'United States of America': 'North American',
+  'United States': 'North American',
+  USA: 'North American',
+  Canada: 'North American',
+  Greenland: 'North American',
+
+  // ── Central America / Caribbean ──
+  Mexico: 'Central American',
+  Guatemala: 'Central American',
+  Belize: 'Central American',
+  Honduras: 'Central American',
+  'El Salvador': 'El Salvador',
+  Nicaragua: 'Central American',
+  'Costa Rica': 'Central American',
+  Panama: 'Central American',
+  Cuba: 'Caribbean',
+  Jamaica: 'Jamaica',
+  Haiti: 'Caribbean',
+  'Dominican Rep.': 'Caribbean',
+  'Dominican Republic': 'Caribbean',
+  'Puerto Rico': 'Caribbean',
+  'Trinidad and Tobago': 'Trinidad and Tobago',
+  Bahamas: 'Caribbean',
+  Dominica: 'Caribbean',
+  Barbados: 'Caribbean',
+
+  // ── South America ──
+  Brazil: 'Brazil',
+  Argentina: 'Argentina',
+  Peru: 'Peru',
+  Chile: 'South American',
+  Colombia: 'South American',
+  Venezuela: 'South American',
+  Ecuador: 'South American',
+  Bolivia: 'South American',
+  Paraguay: 'South American',
+  Uruguay: 'South American',
+  Guyana: 'South American',
+  Suriname: 'South American',
+  'French Guiana': 'South American',
+
+  // ── Oceania ──
+  Australia: 'Australia',
+  'New Zealand': 'Oceanian',
+  'Papua New Guinea': 'Oceanian',
+  Fiji: 'Oceanian',
+  'Solomon Is.': 'Oceanian',
+  'Solomon Islands': 'Oceanian',
+  Vanuatu: 'Oceanian',
+  Samoa: 'Oceanian',
+  Tonga: 'Oceanian',
 };
 
 const LOOKUP = Object.fromEntries(


### PR DESCRIPTION
## Summary

The home page's "Explore by region" world map was tinting only ~10 countries even though `/api/map/regions/` already returns site-wide content counts across 58 seeded culinary regions. The cause was entirely on the frontend: `utils/countryRegions.js` only mapped 20 countries — all Turkey-centric — so every other country fell through to the neutral cream branch with no hover popover and no click target. That made the map read as "this is just my data" even though the data was always global.

This PR keeps the visual identical (same rust gradient, same hover popover, same `/search?region=<name>` click destination) and only expands the country→region lookup so the rest of the world responds to data.

### Changes

- **`utils/countryRegions.js`** — expand `COUNTRY_TO_REGION` to ~140 entries covering every country/alias on the world-atlas map, mapped to the most specific backend `Region.name` from `app/backend/apps/recipes/migrations/0004_seed_regions.py`. Prefer country-level regions (`Russia` → `Russia`, `Spain` → `Spain`, `Brazil` → `Brazil`) over macro-regions (`Sweden` → `Nordic`, `Croatia` → `Balkan`, `Vietnam` → `Vietnam`).
- **Bug fix**: `Iraq` was mapped to `Southeast Anatolia` but the backend seeds `Southeastern Anatolia` (no `-ern` was a typo). Iraq used to silently stay cream even though the backend has data for it.
- **Aliases**: world-atlas / Natural Earth truncates a few long names with `.` (`Bosnia and Herz.`, `Czech Rep.`, `Dem. Rep. Congo`, `S. Sudan`). Both forms now resolve.
- **`__tests__/countryRegions.test.js`** (new) — 9 cases covering case-insensitive lookup, null on unmapped / non-string input, country-specific-over-macro precedence, macro fallback, Iraq regression, world-atlas alias coverage, and a contract test that every value in the mapping exists in the backend seed list.
- **`__tests__/RegionContentMap.test.jsx`** — fixture used `Anatolia` and `Aegean` for Turkey/Greece, but neither is a seeded region (`Anatolian` and `Greece` are). The test passed only because the old mapping had the same typo. Updated the fixture to use real region names so the test now exercises the actual contract.

### No backend changes

`/api/map/regions/` already returns site-wide counts and is `permissions.AllowAny` (no user filter — anyone gets the same answer). The map was always pulling the right data; the frontend just wasn't translating most countries into something the data could be joined against.

## Test plan

- [ ] Open `/` on a wide window — country tints visible across Europe, Asia, the Americas, Africa, and Oceania (not just Turkey + Mediterranean basin).
- [ ] Hover Japan — popover shows `Japanese · N recipes · M stories`. Hover Brazil — popover shows `Brazil · N recipes · M stories`. Hover Iraq — popover shows `Southeastern Anatolia · …` (the previously broken case).
- [ ] Click Japan — navigates to `/search?region=Japanese`.
- [ ] Hover Antarctica (or any country without a culinary-region mapping) — popover says "Not part of a culinary region yet", click does nothing.
- [ ] `cd app/frontend && CI=true npm test -- --watchAll=false --testPathPattern="(countryRegions|RegionContentMap)"` — 15 tests pass.
- [ ] `cd app/frontend && CI=true npm test -- --watchAll=false` — full suite green (93 suites / 806 tests).

## Out of scope

- Backend seed expansion. If a region the frontend lookup references is later renamed or removed, the new contract test (`every mapped region value matches a backend seed Region.name`) fails loudly so the drift is caught at PR time.
- The passport map's `passportCultureRegions.js` — that's a different flow (culture-name → countries) and keeps the engagement-weighted multi-culture-per-country behavior the passport needs.