### PR TITLE
feat(frontend): compact search forms on /recipes and /stories

### DIFF
--- a/app/frontend/src/__tests__/RecipeListPage.test.jsx
+++ b/app/frontend/src/__tests__/RecipeListPage.test.jsx
@@ -143,3 +143,36 @@ describe('RecipeListPage bookmark icon', () => {
     expect(screen.getByLabelText(/not bookmarked/i)).toBeInTheDocument();
   });
 });
+
+describe('RecipeListPage — search form', () => {
+  beforeEach(() => {
+    recipeService.fetchRecipes.mockResolvedValue([]);
+  });
+
+  function renderWithRoutes() {
+    return render(
+      <MemoryRouter initialEntries={['/recipes']}>
+        <Routes>
+          <Route path="/recipes" element={<RecipeListPage />} />
+          <Route path="/search" element={<div>search-page</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
+  }
+
+  it('renders a search form with a search input and Search button', async () => {
+    renderWithRoutes();
+    await waitFor(() => expect(screen.queryByText(/loading/i)).not.toBeInTheDocument());
+    expect(screen.getByRole('searchbox')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /search/i })).toBeInTheDocument();
+  });
+
+  it('navigates to /search?q=<query> on submit', async () => {
+    const { fireEvent } = require('@testing-library/react');
+    renderWithRoutes();
+    await waitFor(() => expect(screen.queryByText(/loading/i)).not.toBeInTheDocument());
+    fireEvent.change(screen.getByRole('searchbox'), { target: { value: 'baklava' } });
+    fireEvent.submit(screen.getByRole('search', { name: /search recipes/i }));
+    expect(await screen.findByText('search-page')).toBeInTheDocument();
+  });
+});

--- a/app/frontend/src/__tests__/StoryListPage.test.jsx
+++ b/app/frontend/src/__tests__/StoryListPage.test.jsx
@@ -70,3 +70,36 @@ describe('StoryListPage', () => {
     );
   });
 });
+
+describe('StoryListPage — search form', () => {
+  beforeEach(() => {
+    storyService.fetchStories.mockResolvedValue([]);
+  });
+
+  function renderWithRoutes() {
+    return render(
+      <MemoryRouter initialEntries={['/stories']}>
+        <Routes>
+          <Route path="/stories" element={<StoryListPage />} />
+          <Route path="/search" element={<div>search-page</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
+  }
+
+  it('renders a search form with a search input and Search button', async () => {
+    renderWithRoutes();
+    await waitFor(() => expect(screen.queryByText(/loading/i)).not.toBeInTheDocument());
+    expect(screen.getByRole('searchbox')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /search/i })).toBeInTheDocument();
+  });
+
+  it('navigates to /search?q=<query> on submit', async () => {
+    const { fireEvent } = require('@testing-library/react');
+    renderWithRoutes();
+    await waitFor(() => expect(screen.queryByText(/loading/i)).not.toBeInTheDocument());
+    fireEvent.change(screen.getByRole('searchbox'), { target: { value: 'grandma' } });
+    fireEvent.submit(screen.getByRole('search', { name: /search stories/i }));
+    expect(await screen.findByText('search-page')).toBeInTheDocument();
+  });
+});

--- a/app/frontend/src/pages/RecipeListPage.css
+++ b/app/frontend/src/pages/RecipeListPage.css
@@ -1,7 +1,35 @@
 .recipe-list-heading {
   font-size: 2rem;
-  margin-bottom: 1.75rem;
+  margin-bottom: 1rem;
   color: var(--color-text);
+}
+
+.list-search-form {
+  display: flex;
+  gap: 0.5rem;
+  align-items: stretch;
+  margin: 0 0 1.5rem;
+  max-width: 560px;
+}
+
+.list-search-input {
+  flex: 1;
+  font: inherit;
+  padding: 0.55rem 0.9rem;
+  border: 1.5px solid var(--color-border, #e0d8c8);
+  border-radius: var(--radius-md, 8px);
+  background: var(--color-surface-input, var(--color-surface, #FAF7EF));
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+.list-search-input:focus {
+  outline: none;
+  border-color: var(--color-primary, #C4521E);
+  box-shadow: 0 0 0 3px rgba(196, 82, 30, 0.12);
+}
+
+.list-search-btn {
+  flex-shrink: 0;
 }
 
 .recipe-list-empty {

--- a/app/frontend/src/pages/RecipeListPage.jsx
+++ b/app/frontend/src/pages/RecipeListPage.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { fetchRecipes } from '../services/recipeService';
 import StarRating from '../components/StarRating';
 import './RecipeListPage.css';
@@ -8,6 +8,8 @@ export default function RecipeListPage() {
   const [recipes, setRecipes] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
+  const [q, setQ] = useState('');
+  const navigate = useNavigate();
 
   useEffect(() => {
     let cancelled = false;
@@ -18,12 +20,29 @@ export default function RecipeListPage() {
     return () => { cancelled = true; };
   }, []);
 
+  function handleSubmit(e) {
+    e.preventDefault();
+    navigate(`/search?q=${encodeURIComponent(q)}`);
+  }
+
   if (loading) return <p className="page-status">Loading…</p>;
   if (error) return <p className="page-status page-error">{error}</p>;
 
   return (
     <main className="page-card recipe-list">
       <h1 className="recipe-list-heading">Recipes</h1>
+      <form className="list-search-form" onSubmit={handleSubmit} role="search" aria-label="Search recipes">
+        <label htmlFor="recipe-list-search" className="sr-only">Search recipes</label>
+        <input
+          id="recipe-list-search"
+          type="search"
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+          placeholder="Search recipes…"
+          className="list-search-input"
+        />
+        <button type="submit" className="btn btn-primary list-search-btn">Search</button>
+      </form>
       {recipes.length === 0 && (
         <p className="recipe-list-empty">No recipes yet. Share the first one!</p>
       )}

--- a/app/frontend/src/pages/StoryListPage.css
+++ b/app/frontend/src/pages/StoryListPage.css
@@ -1,7 +1,35 @@
 .story-list-heading {
   font-size: 2rem;
-  margin-bottom: 1.75rem;
+  margin-bottom: 1rem;
   color: var(--color-text);
+}
+
+.list-search-form {
+  display: flex;
+  gap: 0.5rem;
+  align-items: stretch;
+  margin: 0 0 1.5rem;
+  max-width: 560px;
+}
+
+.list-search-input {
+  flex: 1;
+  font: inherit;
+  padding: 0.55rem 0.9rem;
+  border: 1.5px solid var(--color-border, #e0d8c8);
+  border-radius: var(--radius-md, 8px);
+  background: var(--color-surface-input, var(--color-surface, #FAF7EF));
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+.list-search-input:focus {
+  outline: none;
+  border-color: var(--color-primary, #C4521E);
+  box-shadow: 0 0 0 3px rgba(196, 82, 30, 0.12);
+}
+
+.list-search-btn {
+  flex-shrink: 0;
 }
 
 .story-list-empty {

--- a/app/frontend/src/pages/StoryListPage.jsx
+++ b/app/frontend/src/pages/StoryListPage.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { fetchStories } from '../services/storyService';
 import './StoryListPage.css';
 
@@ -7,6 +7,8 @@ export default function StoryListPage() {
   const [stories, setStories] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
+  const [q, setQ] = useState('');
+  const navigate = useNavigate();
 
   useEffect(() => {
     let cancelled = false;
@@ -17,12 +19,29 @@ export default function StoryListPage() {
     return () => { cancelled = true; };
   }, []);
 
+  function handleSubmit(e) {
+    e.preventDefault();
+    navigate(`/search?q=${encodeURIComponent(q)}`);
+  }
+
   if (loading) return <p className="page-status">Loading…</p>;
   if (error) return <p className="page-status page-error">{error}</p>;
 
   return (
     <main className="page-card story-list">
       <h1 className="story-list-heading">Stories</h1>
+      <form className="list-search-form" onSubmit={handleSubmit} role="search" aria-label="Search stories">
+        <label htmlFor="story-list-search" className="sr-only">Search stories</label>
+        <input
+          id="story-list-search"
+          type="search"
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+          placeholder="Search stories…"
+          className="list-search-input"
+        />
+        <button type="submit" className="btn btn-primary list-search-btn">Search</button>
+      </form>
       {stories.length === 0 && (
         <p className="story-list-empty">No stories yet. Be the first to share one!</p>
       )}


### PR DESCRIPTION
\`/recipes\` and \`/stories\` had no way to search from inside themselves — the user had to jump to the explicit search page first. Added a small inline form above the grid on both pages. Submitting routes to \`/search?q=<query>\` which already handles cross-type results.

## Changes
- **RecipeListPage**: \`role=\"search\"\` form with input + Search button at the top of the page; aria-label \"Search recipes\".
- **StoryListPage**: same shape, aria-label \"Search stories\".
- Per-page CSS (\`.list-search-form\` / \`.list-search-input\` / \`.list-search-btn\`), capped at 560px so the form sits comfortably without dominating the grid.

## Note on the second ask (single-toggle pills)
The original request also included consolidating SearchPage's \`+ / -\` chip pairs into a single toggle pill. Implementation was started but rolled back during the session — that piece will land separately so this PR stays narrow.

## Test plan
- [x] +4 tests (2 per page): form renders, submit navigates
- [x] Full Jest suite green locally
- [ ] Manual QA: open \`/recipes\` → type in the search box → submit → land on \`/search?q=…\`. Repeat on \`/stories\`.