### PR TITLE
fix(mobile): show recipe/story titles in passport timeline pills (#871)

### DIFF
--- a/app/mobile/__tests__/components/JourneyTimeline.test.tsx
+++ b/app/mobile/__tests__/components/JourneyTimeline.test.tsx
@@ -239,6 +239,34 @@ describe('JourneyTimeline', () => {
     expect(queryByText(/Story #/)).toBeNull();
   });
 
+  it('renders Recipe pill with title from payload when backend provides recipe_title (#871)', async () => {
+    const ev = makeEvent({
+      id: 30,
+      message: 'Saved a recipe',
+      payload: { related_recipe: 99, recipe_title: 'Trabzon Butter Kuymak' },
+    });
+    mockPaginationSync([ev]);
+    const { getByText, queryByText } = render(
+      <JourneyTimeline username="ayse" initialEvents={[ev]} />,
+    );
+    expect(getByText('Trabzon Butter Kuymak →')).toBeTruthy();
+    expect(queryByText('Recipe #99 →')).toBeNull();
+  });
+
+  it('renders Story pill with title from payload when backend provides story_title (#871)', async () => {
+    const ev = makeEvent({
+      id: 31,
+      message: 'Saved a story',
+      payload: { related_story: 12, story_title: 'When Yogurt Connects Continents' },
+    });
+    mockPaginationSync([ev]);
+    const { getByText, queryByText } = render(
+      <JourneyTimeline username="ayse" initialEvents={[ev]} />,
+    );
+    expect(getByText('When Yogurt Connects Continents →')).toBeTruthy();
+    expect(queryByText('Story #12 →')).toBeNull();
+  });
+
   it('skips the Recipe pill when the message already mentions Recipe #', async () => {
     const ev = makeEvent({
       id: 24,

--- a/app/mobile/__tests__/services/passportTimelineService.test.ts
+++ b/app/mobile/__tests__/services/passportTimelineService.test.ts
@@ -51,6 +51,37 @@ describe('normalizeEvent', () => {
   it('returns null when id is missing', () => {
     expect(normalizeEvent({ event_type: 'recipe_tried' } as any)).toBeNull();
   });
+
+  it('folds backend recipe_title and story_title into payload (#871)', () => {
+    const out = normalizeEvent({
+      id: 9,
+      event_type: 'stamp_earned',
+      description: 'Got a stamp',
+      timestamp: 't',
+      related_recipe: 12,
+      related_story: 34,
+      recipe_title: 'Trabzon Butter Kuymak',
+      story_title: 'When Yogurt Connects Continents',
+    });
+    expect(out!.payload).toEqual({
+      related_recipe: 12,
+      related_story: 34,
+      recipe_title: 'Trabzon Butter Kuymak',
+      story_title: 'When Yogurt Connects Continents',
+    });
+  });
+
+  it('skips empty title strings so the ID fallback still kicks in', () => {
+    const out = normalizeEvent({
+      id: 10,
+      event_type: 'recipe_tried',
+      description: 'Tried something',
+      timestamp: 't',
+      related_recipe: 5,
+      recipe_title: '',
+    });
+    expect(out!.payload).toEqual({ related_recipe: 5 });
+  });
 });
 
 describe('fetchTimeline — dedicated endpoint path', () => {

--- a/app/mobile/src/components/passport/JourneyTimeline.tsx
+++ b/app/mobile/src/components/passport/JourneyTimeline.tsx
@@ -182,6 +182,9 @@ function TimelineRow({ event, isFirst, isLast }: RowProps) {
   const { recipeId, storyId } = extractRelatedIds(event);
   const showRecipePill = recipeId !== null && !messageMentions(event.message, 'Recipe');
   const showStoryPill = storyId !== null && !messageMentions(event.message, 'Story');
+  const payload = event.payload ?? {};
+  const recipeTitle = typeof payload.recipe_title === 'string' ? payload.recipe_title : null;
+  const storyTitle = typeof payload.story_title === 'string' ? payload.story_title : null;
   return (
     <View style={styles.row} accessible accessibilityLabel={a11y}>
       <View style={styles.rail}>
@@ -208,9 +211,9 @@ function TimelineRow({ event, isFirst, isLast }: RowProps) {
                   pressed && styles.pillPressed,
                 ]}
                 accessibilityRole="link"
-                accessibilityLabel={`Open Recipe ${recipeId}`}
+                accessibilityLabel={`Open recipe ${recipeTitle ?? `#${recipeId}`}`}
               >
-                <Text style={styles.pillText}>{`Recipe #${recipeId} →`}</Text>
+                <Text style={styles.pillText}>{`${recipeTitle ?? `Recipe #${recipeId}`} →`}</Text>
               </Pressable>
             ) : null}
             {showStoryPill && storyId !== null ? (
@@ -224,9 +227,9 @@ function TimelineRow({ event, isFirst, isLast }: RowProps) {
                   pressed && styles.pillPressed,
                 ]}
                 accessibilityRole="link"
-                accessibilityLabel={`Open Story ${storyId}`}
+                accessibilityLabel={`Open story ${storyTitle ?? `#${storyId}`}`}
               >
-                <Text style={styles.pillText}>{`Story #${storyId} →`}</Text>
+                <Text style={styles.pillText}>{`${storyTitle ?? `Story #${storyId}`} →`}</Text>
               </Pressable>
             ) : null}
           </View>

--- a/app/mobile/src/services/passportTimelineService.ts
+++ b/app/mobile/src/services/passportTimelineService.ts
@@ -44,6 +44,8 @@ type RawTimelineEvent = {
   // backend extras that we fold into payload for the title composer
   related_recipe?: number | string | null;
   related_story?: number | string | null;
+  recipe_title?: string | null;
+  story_title?: string | null;
   stamp_rarity?: string | null;
 };
 
@@ -89,6 +91,12 @@ export function normalizeEvent(raw: RawTimelineEvent | null | undefined): Timeli
   }
   if (raw.related_story !== undefined && raw.related_story !== null) {
     payload.related_story = raw.related_story;
+  }
+  if (typeof raw.recipe_title === 'string' && raw.recipe_title) {
+    payload.recipe_title = raw.recipe_title;
+  }
+  if (typeof raw.story_title === 'string' && raw.story_title) {
+    payload.story_title = raw.story_title;
   }
   if (raw.stamp_rarity !== undefined && raw.stamp_rarity !== null) {
     payload.stamp_rarity = raw.stamp_rarity;


### PR DESCRIPTION
Closes #871

Summary
JourneyTimeline pills used to render the placeholder text \`Recipe #95 →\` / \`Story #12 →\` because the wire payload never carried a human-readable title. Backend #870 added \`recipe_title\` and \`story_title\` as SerializerMethodField on PassportEventSerializer, so the title is now available on every event that has a related recipe or story.

passportTimelineService.ts: Folded the two new backend fields into the event payload alongside \`related_recipe\` / \`related_story\` so the rendering layer keeps a single shape to read from. Empty strings are skipped so the existing ID fallback still kicks in for events the backend can't title (e.g. a recipe that was deleted).

JourneyTimeline.tsx: Pill text is now \`\${payload.recipe_title ?? 'Recipe #' + id} →\` (and the equivalent for stories). The accessibility label also reads the title when available, which is the bigger win for screen reader users — "Open recipe Trabzon Butter Kuymak" is a lot more useful than "Open Recipe 95". The hardcoded ID still ships as a fallback because older event rows in the DB will not have a backfilled title and we don't want to render nothing.

Tests
- 2 new JourneyTimeline tests: pill renders title when payload has recipe_title / story_title, and the old "Recipe #ID" string is no longer present
- 2 new passportTimelineService tests: normalizer folds titles into payload, and skips empty strings so the ID fallback still kicks in
- 35/35 timeline + service tests pass

Test plan
 [ ] Pull #870 backend changes locally, open Cultural Passport → Timeline as a user with recipe_tried / story_saved / stamp_earned events
 [ ] Pills now read the actual recipe/story title (e.g. "Trabzon Butter Kuymak →") instead of "Recipe #95 →"
 [ ] Tap a pill — still navigates to RecipeDetail / StoryDetail by ID, no regression
 [ ] Force an event without a title (e.g. recipe deleted) — pill falls back to "Recipe #ID →" instead of breaking
 [ ] Screen reader announces the title in the pill's accessibility label