### PR TITLE
feat(frontend): cultural batch — onboarding, endangered heritage, cultural story, ingredient routes

### DIFF
--- a/app/frontend/src/App.js
+++ b/app/frontend/src/App.js
@@ -29,6 +29,7 @@ import AccountPage from './pages/AccountPage';
 import ModerationPage from './pages/ModerationPage';
 import HeritagePage from './pages/HeritagePage';
 import HeritageMapPage from './pages/HeritageMapPage';
+import EndangeredListPage from './pages/EndangeredListPage';
 import CalendarPage from './pages/CalendarPage';
 import CulturalHighlightPage from './pages/CulturalHighlightPage';
 import NotFoundPage from './pages/NotFoundPage';
@@ -51,6 +52,7 @@ export default function App() {
           <Route path="/map" element={<MapPage />} />
           <Route path="/explore" element={<ExplorePage />} />
           <Route path="/explore/:eventId" element={<EventDetailPage />} />
+          <Route path="/endangered" element={<EndangeredListPage />} />
 
           <Route
             path="/recipes/new"

--- a/app/frontend/src/App.js
+++ b/app/frontend/src/App.js
@@ -30,6 +30,7 @@ import ModerationPage from './pages/ModerationPage';
 import HeritagePage from './pages/HeritagePage';
 import HeritageMapPage from './pages/HeritageMapPage';
 import EndangeredListPage from './pages/EndangeredListPage';
+import MigrationRoutesPage from './pages/MigrationRoutesPage';
 import CalendarPage from './pages/CalendarPage';
 import CulturalHighlightPage from './pages/CulturalHighlightPage';
 import NotFoundPage from './pages/NotFoundPage';
@@ -53,6 +54,7 @@ export default function App() {
           <Route path="/explore" element={<ExplorePage />} />
           <Route path="/explore/:eventId" element={<EventDetailPage />} />
           <Route path="/endangered" element={<EndangeredListPage />} />
+          <Route path="/migration-routes" element={<MigrationRoutesPage />} />
 
           <Route
             path="/recipes/new"

--- a/app/frontend/src/__tests__/CulturalStoryForm.test.jsx
+++ b/app/frontend/src/__tests__/CulturalStoryForm.test.jsx
@@ -1,0 +1,83 @@
+import { useState } from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import CulturalStoryForm from '../components/CulturalStoryForm';
+import { trimCulturalStoryForPayload } from '../components/culturalStoryFields';
+
+function Harness({ initial = {}, onCommit }) {
+  const [values, setValues] = useState(initial);
+  return (
+    <CulturalStoryForm
+      values={values}
+      onChange={(key, value) => {
+        setValues((prev) => {
+          const next = { ...prev, [key]: value };
+          onCommit?.(next);
+          return next;
+        });
+      }}
+    />
+  );
+}
+
+describe('CulturalStoryForm', () => {
+  it('starts collapsed when no field has content', () => {
+    render(<Harness initial={{}} />);
+    // Toggle button visible
+    expect(
+      screen.getByRole('button', { name: /tell your story/i }),
+    ).toHaveAttribute('aria-expanded', 'false');
+    // Textareas hidden until expanded
+    expect(screen.queryByPlaceholderText(/this dish is how i know/i)).toBeNull();
+  });
+
+  it('starts expanded when any field is pre-filled (edit case)', () => {
+    render(<Harness initial={{ identity_note: 'Already filled' }} />);
+    expect(
+      screen.getByRole('button', { name: /tell your story/i }),
+    ).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByDisplayValue('Already filled')).toBeInTheDocument();
+  });
+
+  it('toggles open and closed when the header is clicked', () => {
+    render(<Harness initial={{}} />);
+    const toggle = screen.getByRole('button', { name: /tell your story/i });
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('writes through onChange (parent owns the state)', () => {
+    const commits = [];
+    render(<Harness onCommit={(v) => commits.push(v)} />);
+    fireEvent.click(screen.getByRole('button', { name: /tell your story/i }));
+    const input = screen.getByPlaceholderText(/this dish is how i know/i);
+    fireEvent.change(input, { target: { value: 'Mine' } });
+    expect(commits[commits.length - 1]).toEqual(
+      expect.objectContaining({ identity_note: 'Mine' }),
+    );
+  });
+});
+
+describe('trimCulturalStoryForPayload', () => {
+  it('drops blank and whitespace-only fields and trims surviving ones', () => {
+    expect(
+      trimCulturalStoryForPayload({
+        identity_note: '  Heritage matters.  ',
+        memory_note: '',
+        ritual_note: '   ',
+        craft_note: 'Knead with hands.',
+        bogus_extra: 'ignored',
+      }),
+    ).toEqual({
+      identity_note: 'Heritage matters.',
+      craft_note: 'Knead with hands.',
+    });
+  });
+
+  it('returns an empty object when nothing is filled', () => {
+    expect(trimCulturalStoryForPayload({})).toEqual({});
+    expect(trimCulturalStoryForPayload(null)).toEqual({});
+    expect(trimCulturalStoryForPayload(undefined)).toEqual({});
+  });
+});

--- a/app/frontend/src/__tests__/CulturalStorySection.test.jsx
+++ b/app/frontend/src/__tests__/CulturalStorySection.test.jsx
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react';
+import CulturalStorySection from '../components/CulturalStorySection';
+
+describe('CulturalStorySection', () => {
+  it('renders only the filled fields', () => {
+    render(
+      <CulturalStorySection
+        culturalContext={{
+          identity_note: 'This dish is how I know home.',
+          memory_note: '',
+          migration_note: 'Brought from the Black Sea in the 1920s.',
+          ritual_note: '',
+          commensality_note: '',
+          terroir_note: '',
+          craft_note: '',
+        }}
+      />,
+    );
+    expect(screen.getByRole('heading', { name: /beyond the recipe/i })).toBeInTheDocument();
+    expect(screen.getByText(/this dish is how i know home/i)).toBeInTheDocument();
+    expect(screen.getByText(/brought from the black sea/i)).toBeInTheDocument();
+    // Empty fields don't render labels.
+    expect(screen.queryByText(/a personal memory/i)).toBeNull();
+    expect(screen.queryByText(/the craft/i)).toBeNull();
+  });
+
+  it('renders nothing when every field is blank or whitespace-only', () => {
+    const { container } = render(
+      <CulturalStorySection
+        culturalContext={{
+          identity_note: '   ',
+          memory_note: '',
+          migration_note: '',
+        }}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing for null / undefined cultural context', () => {
+    expect(render(<CulturalStorySection culturalContext={null} />).container.firstChild).toBeNull();
+    expect(render(<CulturalStorySection culturalContext={undefined} />).container.firstChild).toBeNull();
+  });
+
+  it('preserves embedded newlines inside a single field', () => {
+    render(
+      <CulturalStorySection
+        culturalContext={{
+          memory_note: 'Line one.\nLine two.',
+        }}
+      />,
+    );
+    expect(screen.getByText(/line one\.\s+line two\./i)).toBeInTheDocument();
+  });
+});

--- a/app/frontend/src/__tests__/EndangeredHeritageSection.test.jsx
+++ b/app/frontend/src/__tests__/EndangeredHeritageSection.test.jsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+import EndangeredHeritageSection from '../components/EndangeredHeritageSection';
+
+describe('EndangeredHeritageSection', () => {
+  it('renders the status info box with blurb for an endangered recipe', () => {
+    render(<EndangeredHeritageSection status="endangered" notes={[]} />);
+    expect(screen.getByText(/endangered/i)).toBeInTheDocument();
+    expect(screen.getByText(/at risk of being lost/i)).toBeInTheDocument();
+  });
+
+  it('renders sourced notes as a list with source links', () => {
+    const notes = [
+      { id: 1, text: 'Recipe almost lost after 1923.', source_url: 'https://example.com/ref' },
+      { id: 2, text: 'Recovered through oral history.', source_url: '' },
+    ];
+    render(<EndangeredHeritageSection status="endangered" notes={notes} />);
+    expect(screen.getByText(/recipe almost lost after 1923/i)).toBeInTheDocument();
+    expect(screen.getByText(/recovered through oral history/i)).toBeInTheDocument();
+    const sourceLink = screen.getByRole('link', { name: /source ↗/i });
+    expect(sourceLink).toHaveAttribute('href', 'https://example.com/ref');
+    expect(sourceLink).toHaveAttribute('target', '_blank');
+  });
+
+  it('renders nothing when status is "none" and no notes', () => {
+    const { container } = render(<EndangeredHeritageSection status="none" notes={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing for missing status and missing notes', () => {
+    const { container } = render(<EndangeredHeritageSection status={null} notes={null} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('still renders notes when status is "none"', () => {
+    const notes = [{ id: 3, text: 'A standalone heritage note.', source_url: '' }];
+    render(<EndangeredHeritageSection status="none" notes={notes} />);
+    expect(screen.getByText(/standalone heritage note/i)).toBeInTheDocument();
+  });
+});

--- a/app/frontend/src/__tests__/EndangeredListPage.test.jsx
+++ b/app/frontend/src/__tests__/EndangeredListPage.test.jsx
@@ -1,0 +1,58 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import EndangeredListPage from '../pages/EndangeredListPage';
+import * as recipeService from '../services/recipeService';
+
+jest.mock('../services/recipeService');
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <EndangeredListPage />
+    </MemoryRouter>,
+  );
+}
+
+describe('EndangeredListPage', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('renders endangered recipes by default', async () => {
+    recipeService.fetchRecipesByHeritageStatus.mockResolvedValue([
+      { id: 1, title: 'Pinhead Pilaf',  heritage_status: 'endangered', author_username: 'ayse', region_name: 'Aegean', image: null },
+      { id: 2, title: 'Tarhana Ekşili', heritage_status: 'endangered', author_username: 'demo_chef', region_name: 'Anatolian', image: null },
+    ]);
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Pinhead Pilaf')).toBeInTheDocument());
+    expect(screen.getByText('Tarhana Ekşili')).toBeInTheDocument();
+    expect(recipeService.fetchRecipesByHeritageStatus).toHaveBeenCalledWith('endangered');
+  });
+
+  it('switches to the revived filter when the tab is selected', async () => {
+    recipeService.fetchRecipesByHeritageStatus.mockResolvedValueOnce([]);
+    renderPage();
+    await waitFor(() => screen.getByText(/no recipes flagged as endangered/i));
+
+    recipeService.fetchRecipesByHeritageStatus.mockResolvedValueOnce([
+      { id: 9, title: 'Revived Bread', heritage_status: 'revived', author_username: 'baker', region_name: 'Marmara', image: null },
+    ]);
+    fireEvent.click(screen.getByRole('tab', { name: /revived/i }));
+    await waitFor(() => expect(screen.getByText('Revived Bread')).toBeInTheDocument());
+    expect(recipeService.fetchRecipesByHeritageStatus).toHaveBeenLastCalledWith('revived');
+  });
+
+  it('shows an error state when the API fails', async () => {
+    recipeService.fetchRecipesByHeritageStatus.mockRejectedValue(new Error('boom'));
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(/could not load/i);
+    });
+  });
+
+  it('shows an empty state when no recipes match', async () => {
+    recipeService.fetchRecipesByHeritageStatus.mockResolvedValue([]);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText(/no recipes flagged as endangered/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/app/frontend/src/__tests__/HeritageStatusBadge.test.jsx
+++ b/app/frontend/src/__tests__/HeritageStatusBadge.test.jsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react';
+import HeritageStatusBadge from '../components/HeritageStatusBadge';
+
+describe('HeritageStatusBadge', () => {
+  it.each([
+    ['endangered', /endangered/i, /heritage-status-endangered/],
+    ['preserved', /preserved/i, /heritage-status-preserved/],
+    ['revived', /revived/i, /heritage-status-revived/],
+  ])('renders the %s pill', (status, labelMatcher, classMatcher) => {
+    const { container } = render(<HeritageStatusBadge status={status} />);
+    expect(screen.getByText(labelMatcher)).toBeInTheDocument();
+    expect(container.querySelector('.heritage-status-badge').className).toMatch(classMatcher);
+  });
+
+  it('renders nothing for "none"', () => {
+    const { container } = render(<HeritageStatusBadge status="none" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing for null/undefined/unknown values', () => {
+    expect(render(<HeritageStatusBadge status={null} />).container.firstChild).toBeNull();
+    expect(render(<HeritageStatusBadge status={undefined} />).container.firstChild).toBeNull();
+    expect(render(<HeritageStatusBadge status="something-else" />).container.firstChild).toBeNull();
+  });
+
+  it('applies the size variant class', () => {
+    const { container } = render(<HeritageStatusBadge status="endangered" size="md" />);
+    expect(container.querySelector('.heritage-status-md')).not.toBeNull();
+  });
+});

--- a/app/frontend/src/__tests__/MigrationRoutesPage.test.jsx
+++ b/app/frontend/src/__tests__/MigrationRoutesPage.test.jsx
@@ -1,0 +1,146 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import MigrationRoutesPage from '../pages/MigrationRoutesPage';
+import * as ingredientRouteService from '../services/ingredientRouteService';
+
+jest.mock('../services/ingredientRouteService');
+
+// react-leaflet pulls in DOM-only globals (window.L etc) that aren't relevant
+// to the component's data wiring; stub the parts the page uses with simple
+// passthrough wrappers so the test focuses on state + waypoint plumbing.
+jest.mock('react-leaflet', () => ({
+  MapContainer: ({ children }) => <div data-testid="map">{children}</div>,
+  TileLayer: () => null,
+  Polyline: ({ positions }) => (
+    <div data-testid="polyline" data-points={JSON.stringify(positions)} />
+  ),
+  CircleMarker: ({ children, center }) => (
+    <div data-testid="marker" data-center={JSON.stringify(center)}>{children}</div>
+  ),
+  Popup: ({ children }) => <div data-testid="popup">{children}</div>,
+}));
+
+const ROUTES = [
+  {
+    id: 1,
+    ingredient: 11,
+    ingredient_name: 'Tomato',
+    waypoints: [
+      { lat: -9.19, lng: -75.01, era: 'Ancestral',  label: 'Andes (Peru)' },
+      { lat: 19.43, lng: -99.13, era: 'Pre-Columbian', label: 'Mexico (Aztecs)' },
+      { lat: 40.41, lng:  -3.70, era: '1540s',     label: 'Spain' },
+    ],
+  },
+  {
+    id: 2,
+    ingredient: 22,
+    ingredient_name: 'Lentils',
+    waypoints: [
+      { lat: 37.0, lng: 38.0, era: 'Neolithic',   label: 'Fertile Crescent' },
+      { lat: 30.0, lng: 31.0, era: '3000 BC',     label: 'Ancient Egypt' },
+      { lat: 41.0, lng: 29.0, era: 'Ottoman',     label: 'Anatolia / Istanbul' },
+    ],
+  },
+];
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <MigrationRoutesPage />
+    </MemoryRouter>,
+  );
+}
+
+describe('MigrationRoutesPage', () => {
+  beforeEach(() => jest.clearAllMocks());
+  afterEach(() => jest.useRealTimers());
+
+  it('renders an empty state when no routes are returned', async () => {
+    ingredientRouteService.fetchIngredientRoutes.mockResolvedValue([]);
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByText(/no ingredient migration routes/i)).toBeInTheDocument(),
+    );
+  });
+
+  it('renders an error state when the API fails', async () => {
+    ingredientRouteService.fetchIngredientRoutes.mockRejectedValue(new Error('boom'));
+    renderPage();
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(/could not load/i),
+    );
+  });
+
+  it('renders the picker, full polyline and one marker per waypoint by default', async () => {
+    ingredientRouteService.fetchIngredientRoutes.mockResolvedValue(ROUTES);
+    const { container } = renderPage();
+    await waitFor(() =>
+      expect(screen.getByLabelText('Ingredient')).toBeInTheDocument(),
+    );
+    expect(screen.getByRole('combobox')).toHaveValue('1'); // first route
+    expect(screen.getAllByTestId('marker')).toHaveLength(3);
+    const line = screen.getByTestId('polyline');
+    expect(JSON.parse(line.getAttribute('data-points'))).toEqual([
+      [-9.19, -75.01],
+      [19.43, -99.13],
+      [40.41, -3.7],
+    ]);
+    // Each waypoint shows up in the side list, fully visible (no pending state).
+    const labelTexts = Array.from(
+      container.querySelectorAll('.migration-routes-waypoint-label'),
+    ).map((el) => el.textContent);
+    expect(labelTexts).toEqual(['Andes (Peru)', 'Mexico (Aztecs)', 'Spain']);
+  });
+
+  it('switches routes when a different ingredient is picked', async () => {
+    ingredientRouteService.fetchIngredientRoutes.mockResolvedValue(ROUTES);
+    const { container } = renderPage();
+    await waitFor(() => screen.getByLabelText('Ingredient'));
+    const readLabels = () =>
+      Array.from(container.querySelectorAll('.migration-routes-waypoint-label')).map(
+        (el) => el.textContent,
+      );
+    expect(readLabels()).toEqual(['Andes (Peru)', 'Mexico (Aztecs)', 'Spain']);
+
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: '2' } });
+    expect(readLabels()).toEqual([
+      'Fertile Crescent',
+      'Ancient Egypt',
+      'Anatolia / Istanbul',
+    ]);
+    expect(screen.getAllByTestId('marker')).toHaveLength(3);
+  });
+
+  it('reveals waypoints sequentially when Animate is clicked, then completes', async () => {
+    jest.useFakeTimers();
+    ingredientRouteService.fetchIngredientRoutes.mockResolvedValue(ROUTES);
+    renderPage();
+    // Wait for the picker to mount.
+    await waitFor(() => screen.getByLabelText('Ingredient'));
+
+    fireEvent.click(screen.getByRole('button', { name: /animate route/i }));
+    // First tick — only the origin should be drawn (no polyline because we
+    // need ≥ 2 points).
+    expect(screen.getAllByTestId('marker')).toHaveLength(1);
+    expect(screen.queryByTestId('polyline')).toBeNull();
+
+    act(() => { jest.advanceTimersByTime(650); });
+    expect(screen.getAllByTestId('marker')).toHaveLength(2);
+    expect(screen.getByTestId('polyline')).toBeInTheDocument();
+
+    act(() => { jest.advanceTimersByTime(650); });
+    expect(screen.getAllByTestId('marker')).toHaveLength(3);
+  });
+
+  it('skips routes whose payload has fewer than two valid waypoints', async () => {
+    ingredientRouteService.fetchIngredientRoutes.mockResolvedValue([
+      ...ROUTES,
+      { id: 3, ingredient_name: 'Bogus', waypoints: [{ lat: 'NaN', lng: null }] },
+      { id: 4, ingredient_name: 'OnePointOnly', waypoints: [{ lat: 0, lng: 0, label: 'X' }] },
+    ]);
+    renderPage();
+    await waitFor(() => screen.getByLabelText('Ingredient'));
+    const options = screen.getAllByRole('option').map((o) => o.textContent);
+    expect(options).toEqual(['Tomato', 'Lentils']);
+  });
+});

--- a/app/frontend/src/__tests__/OnboardingPage.test.jsx
+++ b/app/frontend/src/__tests__/OnboardingPage.test.jsx
@@ -38,10 +38,10 @@ describe('OnboardingPage', () => {
     authService.updateMe.mockResolvedValue({
       id: 1,
       username: 'alice',
-      cultural_interests: ['Ottoman'],
+      cultural_interests: ['Turkish cuisine'],
       regional_ties: ['Aegean'],
       religious_preferences: ['Halal'],
-      event_interests: ['Ramadan'],
+      event_interests: ['Wedding'],
     });
   });
 
@@ -60,20 +60,20 @@ describe('OnboardingPage', () => {
   it('submits all preference fields on finish', async () => {
     renderPage();
 
-    fireEvent.click(screen.getByLabelText(/ottoman/i));
+    fireEvent.click(screen.getByLabelText(/turkish cuisine/i));
     fireEvent.click(screen.getByRole('button', { name: /next/i }));
-    fireEvent.click(screen.getByLabelText(/aegean/i));
+    fireEvent.click(screen.getByLabelText(/^aegean$/i));
     fireEvent.click(screen.getByRole('button', { name: /next/i }));
-    fireEvent.click(screen.getByLabelText(/halal/i));
+    fireEvent.click(screen.getByLabelText(/^halal$/i));
     fireEvent.click(screen.getByRole('button', { name: /next/i }));
-    fireEvent.click(screen.getByLabelText(/ramadan/i));
+    fireEvent.click(screen.getByLabelText(/^wedding$/i));
     fireEvent.click(screen.getByRole('button', { name: /finish/i }));
 
     await waitFor(() => expect(authService.updateMe).toHaveBeenCalledWith({
-      cultural_interests: ['Ottoman'],
+      cultural_interests: ['Turkish cuisine'],
       regional_ties: ['Aegean'],
       religious_preferences: ['Halal'],
-      event_interests: ['Ramadan'],
+      event_interests: ['Wedding'],
     }));
     expect(mockUpdateUser).toHaveBeenCalled();
     expect(mockNavigate).toHaveBeenCalledWith('/');

--- a/app/frontend/src/__tests__/ingredientRouteService.test.js
+++ b/app/frontend/src/__tests__/ingredientRouteService.test.js
@@ -1,0 +1,48 @@
+import { apiClient } from '../services/api';
+import {
+  fetchIngredientRoutes,
+  fetchIngredientRoutesByIngredient,
+} from '../services/ingredientRouteService';
+
+jest.mock('../services/api', () => ({
+  apiClient: { get: jest.fn() },
+}));
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('fetchIngredientRoutes', () => {
+  it('unwraps a DRF-paginated response', async () => {
+    apiClient.get.mockResolvedValue({
+      data: { results: [{ id: 1, ingredient_name: 'Tomato', waypoints: [] }] },
+    });
+    const routes = await fetchIngredientRoutes();
+    expect(apiClient.get).toHaveBeenCalledWith('/api/ingredient-routes/', {
+      params: { page_size: 50 },
+    });
+    expect(routes).toEqual([{ id: 1, ingredient_name: 'Tomato', waypoints: [] }]);
+  });
+
+  it('returns a bare array as-is when pagination is off', async () => {
+    apiClient.get.mockResolvedValue({
+      data: [{ id: 5, ingredient_name: 'Lentils', waypoints: [] }],
+    });
+    expect(await fetchIngredientRoutes()).toEqual([
+      { id: 5, ingredient_name: 'Lentils', waypoints: [] },
+    ]);
+  });
+
+  it('returns [] for an empty payload', async () => {
+    apiClient.get.mockResolvedValue({ data: null });
+    expect(await fetchIngredientRoutes()).toEqual([]);
+  });
+});
+
+describe('fetchIngredientRoutesByIngredient', () => {
+  it('passes the ingredient id as a query param', async () => {
+    apiClient.get.mockResolvedValue({ data: { results: [] } });
+    await fetchIngredientRoutesByIngredient(42);
+    expect(apiClient.get).toHaveBeenCalledWith('/api/ingredient-routes/', {
+      params: { ingredient: 42, page_size: 50 },
+    });
+  });
+});

--- a/app/frontend/src/components/CulturalStoryForm.css
+++ b/app/frontend/src/components/CulturalStoryForm.css
@@ -1,0 +1,79 @@
+.cultural-story-form {
+  border: 1.5px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface);
+  margin: 1rem 0 1.5rem;
+  padding: 0;
+}
+
+.cultural-story-form.is-open {
+  border-color: var(--color-primary);
+}
+
+.cultural-story-form-toggle {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  background: transparent;
+  border: none;
+  padding: 0.85rem 1rem;
+  cursor: pointer;
+  color: var(--color-text);
+  font-family: inherit;
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
+.cultural-story-form-toggle-chev {
+  color: var(--color-primary);
+  font-weight: 900;
+}
+
+.cultural-story-form-body {
+  padding: 0 1rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.cultural-story-form-intro {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: 0.85rem;
+}
+
+.cultural-story-form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.cultural-story-form-field-label {
+  font-weight: 700;
+  font-size: 0.9rem;
+  color: var(--color-text);
+}
+
+.cultural-story-form-field-hint {
+  font-size: 0.78rem;
+  color: var(--color-text-muted);
+}
+
+.cultural-story-form-field-input {
+  margin-top: 0.25rem;
+  padding: 0.6rem 0.75rem;
+  border-radius: var(--radius-md);
+  border: 1.5px solid var(--color-border);
+  font-family: inherit;
+  font-size: 0.95rem;
+  resize: vertical;
+  background: var(--color-surface-input);
+  color: var(--color-text);
+}
+
+.cultural-story-form-field-input:focus {
+  outline: none;
+  border-color: var(--color-primary);
+}

--- a/app/frontend/src/components/CulturalStoryForm.jsx
+++ b/app/frontend/src/components/CulturalStoryForm.jsx
@@ -1,0 +1,61 @@
+import { useState } from 'react';
+import { CULTURAL_STORY_FIELDS } from './culturalStoryFields';
+import './CulturalStoryForm.css';
+
+/**
+ * Optional "Tell Your Story" section for the recipe create/edit form (#516).
+ * Renders a collapsible panel containing the seven narrative textareas from
+ * `CULTURAL_STORY_FIELDS`. All fields are optional and free-form. The parent
+ * owns the `values` object and the `onChange(key, value)` handler so the
+ * payload is built once at submit time (`trimCulturalStoryForPayload`).
+ *
+ * Initial expansion: open by default if any field already has content
+ * (typical on the edit page when the recipe already carries a cultural
+ * context), collapsed otherwise (typical on first-time create).
+ */
+export default function CulturalStoryForm({ values, onChange }) {
+  const [open, setOpen] = useState(() =>
+    CULTURAL_STORY_FIELDS.some((f) => {
+      const v = values?.[f.key];
+      return typeof v === 'string' && v.trim().length > 0;
+    }),
+  );
+
+  return (
+    <fieldset className={`cultural-story-form${open ? ' is-open' : ''}`}>
+      <button
+        type="button"
+        className="cultural-story-form-toggle"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+      >
+        <span className="cultural-story-form-toggle-label">
+          Tell Your Story — Beyond the Recipe (optional)
+        </span>
+        <span className="cultural-story-form-toggle-chev" aria-hidden="true">
+          {open ? '▴' : '▾'}
+        </span>
+      </button>
+      {open && (
+        <div className="cultural-story-form-body">
+          <p className="cultural-story-form-intro">
+            Any of these you'd like to share — leave the rest blank.
+          </p>
+          {CULTURAL_STORY_FIELDS.map((field) => (
+            <label key={field.key} className="cultural-story-form-field">
+              <span className="cultural-story-form-field-label">{field.label}</span>
+              <span className="cultural-story-form-field-hint">{field.hint}</span>
+              <textarea
+                className="cultural-story-form-field-input"
+                value={values?.[field.key] ?? ''}
+                onChange={(e) => onChange(field.key, e.target.value)}
+                placeholder={field.placeholder}
+                rows={3}
+              />
+            </label>
+          ))}
+        </div>
+      )}
+    </fieldset>
+  );
+}

--- a/app/frontend/src/components/CulturalStorySection.css
+++ b/app/frontend/src/components/CulturalStorySection.css
@@ -1,0 +1,57 @@
+.cultural-story {
+  margin: 1.75rem 0;
+  padding: 1.25rem 1.4rem;
+  border-radius: var(--radius-lg);
+  border: 1.5px solid var(--color-border);
+  background: var(--color-surface);
+}
+
+.cultural-story-header {
+  margin-bottom: 1rem;
+}
+
+.cultural-story-heading {
+  font-family: var(--font-display);
+  font-size: 1.4rem;
+  margin: 0;
+  color: var(--color-text);
+}
+
+.cultural-story-subheading {
+  margin: 0.25rem 0 0;
+  color: var(--color-text-muted);
+  font-size: 0.9rem;
+}
+
+.cultural-story-cards {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 0.85rem;
+}
+
+.cultural-story-card {
+  padding: 0.85rem 1rem;
+  border-radius: var(--radius-md);
+  background: var(--color-primary-tint);
+  border: 1px solid var(--color-primary-subtle);
+}
+
+.cultural-story-card-label {
+  margin: 0 0 0.35rem;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-primary);
+}
+
+.cultural-story-card-body {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  color: var(--color-text);
+  white-space: pre-wrap;
+}

--- a/app/frontend/src/components/CulturalStorySection.jsx
+++ b/app/frontend/src/components/CulturalStorySection.jsx
@@ -1,0 +1,37 @@
+import { CULTURAL_STORY_FIELDS, hasAnyCulturalStory } from './culturalStoryFields';
+import './CulturalStorySection.css';
+
+/**
+ * Read-only "Beyond the Recipe" cultural story (#516) on the recipe detail
+ * page. Renders only the narrative notes that the author actually filled in,
+ * each as its own card. Returns null when none of the seven fields carry a
+ * non-blank value, so a recipe with no story stays silent.
+ */
+export default function CulturalStorySection({ culturalContext }) {
+  if (!hasAnyCulturalStory(culturalContext)) return null;
+
+  return (
+    <section className="cultural-story" aria-label="Cultural story">
+      <header className="cultural-story-header">
+        <h2 className="cultural-story-heading">Beyond the Recipe</h2>
+        <p className="cultural-story-subheading">
+          The cultural story of this dish, in the cook's own words.
+        </p>
+      </header>
+      <ul className="cultural-story-cards">
+        {CULTURAL_STORY_FIELDS.map((field) => {
+          const value = typeof culturalContext[field.key] === 'string'
+            ? culturalContext[field.key].trim()
+            : '';
+          if (!value) return null;
+          return (
+            <li key={field.key} className="cultural-story-card">
+              <h3 className="cultural-story-card-label">{field.label}</h3>
+              <p className="cultural-story-card-body">{value}</p>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}

--- a/app/frontend/src/components/EndangeredHeritageSection.css
+++ b/app/frontend/src/components/EndangeredHeritageSection.css
@@ -1,0 +1,78 @@
+.endangered-heritage {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin: 1.5rem 0;
+}
+
+.endangered-heritage-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  padding: 1rem 1.1rem;
+  border-radius: var(--radius-lg);
+  border: 1.5px solid;
+}
+
+.endangered-heritage-endangered {
+  background: #FFFBEB;
+  border-color: #D97706;
+}
+
+.endangered-heritage-preserved {
+  background: var(--color-accent-green-tint);
+  border-color: var(--color-accent-green-border);
+}
+
+.endangered-heritage-revived {
+  background: #EFF6FF;
+  border-color: #2563EB;
+}
+
+.endangered-heritage-blurb {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  color: var(--color-text);
+}
+
+.endangered-heritage-notes-heading {
+  font-size: 1rem;
+  font-weight: 700;
+  margin: 0 0 0.5rem;
+  color: var(--color-text);
+}
+
+.endangered-heritage-note-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.endangered-heritage-note {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 0.75rem 0.9rem;
+}
+
+.endangered-heritage-note-text {
+  margin: 0 0 0.4rem;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: var(--color-text);
+}
+
+.endangered-heritage-note-source {
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: var(--color-primary);
+  text-decoration: none;
+}
+
+.endangered-heritage-note-source:hover {
+  text-decoration: underline;
+}

--- a/app/frontend/src/components/EndangeredHeritageSection.jsx
+++ b/app/frontend/src/components/EndangeredHeritageSection.jsx
@@ -1,0 +1,53 @@
+import HeritageStatusBadge from './HeritageStatusBadge';
+import './EndangeredHeritageSection.css';
+
+const BLURB = {
+  endangered: 'This recipe is at risk of being lost. Cooks, source it, share it, keep it on the table.',
+  preserved:  'A heritage recipe actively kept alive by its community.',
+  revived:    'Once nearly lost — now coming back through deliberate revival.',
+};
+
+/**
+ * Status info box + sourced notes for the recipe detail page (#520 web,
+ * mirrors mobile #720). Renders nothing when the recipe has neither a
+ * meaningful heritage status nor any endangered notes.
+ */
+export default function EndangeredHeritageSection({ status, notes }) {
+  const hasStatus = status && status !== 'none' && BLURB[status];
+  const safeNotes = Array.isArray(notes) ? notes.filter(Boolean) : [];
+  const hasNotes = safeNotes.length > 0;
+  if (!hasStatus && !hasNotes) return null;
+
+  return (
+    <section className="endangered-heritage" aria-label="Endangered heritage status">
+      {hasStatus && (
+        <div className={`endangered-heritage-card endangered-heritage-${status}`}>
+          <HeritageStatusBadge status={status} size="md" />
+          <p className="endangered-heritage-blurb">{BLURB[status]}</p>
+        </div>
+      )}
+      {hasNotes && (
+        <div className="endangered-heritage-notes">
+          <h3 className="endangered-heritage-notes-heading">Sourced notes</h3>
+          <ul className="endangered-heritage-note-list">
+            {safeNotes.map((note) => (
+              <li key={note.id} className="endangered-heritage-note">
+                <p className="endangered-heritage-note-text">{note.text}</p>
+                {note.source_url && (
+                  <a
+                    href={note.source_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="endangered-heritage-note-source"
+                  >
+                    Source ↗
+                  </a>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/app/frontend/src/components/HeritageStatusBadge.css
+++ b/app/frontend/src/components/HeritageStatusBadge.css
@@ -1,0 +1,47 @@
+.heritage-status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  border-radius: var(--radius-pill);
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  border: 1.5px solid;
+  white-space: nowrap;
+  line-height: 1;
+}
+
+.heritage-status-sm {
+  font-size: 0.72rem;
+  padding: 0.2rem 0.55rem;
+}
+
+.heritage-status-md {
+  font-size: 0.85rem;
+  padding: 0.3rem 0.7rem;
+}
+
+.heritage-status-emoji {
+  font-size: 0.95em;
+  line-height: 1;
+}
+
+/* Amber — endangered */
+.heritage-status-endangered {
+  background: #FEF3C7;
+  color: #92400E;
+  border-color: #D97706;
+}
+
+/* Green — preserved */
+.heritage-status-preserved {
+  background: var(--color-accent-green-tint);
+  color: var(--color-accent-green-text);
+  border-color: var(--color-accent-green-border);
+}
+
+/* Blue — revived */
+.heritage-status-revived {
+  background: #DBEAFE;
+  color: #1E40AF;
+  border-color: #2563EB;
+}

--- a/app/frontend/src/components/HeritageStatusBadge.jsx
+++ b/app/frontend/src/components/HeritageStatusBadge.jsx
@@ -1,0 +1,30 @@
+import './HeritageStatusBadge.css';
+
+const TREATMENT = {
+  endangered: { emoji: '⚠️', label: 'Endangered', cls: 'heritage-status-endangered' },
+  preserved:  { emoji: '🛡',  label: 'Preserved',  cls: 'heritage-status-preserved' },
+  revived:    { emoji: '🌱',  label: 'Revived',    cls: 'heritage-status-revived' },
+};
+
+/**
+ * Small chip rendering `Recipe.heritage_status` (#520). Renders nothing for
+ * `none` / null / unknown values so callers can safely drop it inline.
+ *
+ * Colours: amber for endangered, green for preserved, blue for revived
+ * (issue #520 spec).
+ */
+export default function HeritageStatusBadge({ status, size = 'sm' }) {
+  if (!status || status === 'none') return null;
+  const t = TREATMENT[status];
+  if (!t) return null;
+  return (
+    <span
+      className={`heritage-status-badge ${t.cls} heritage-status-${size}`}
+      aria-label={`Heritage status: ${t.label}`}
+      title={`Heritage status: ${t.label}`}
+    >
+      <span className="heritage-status-emoji" aria-hidden="true">{t.emoji}</span>
+      <span className="heritage-status-label">{t.label}</span>
+    </span>
+  );
+}

--- a/app/frontend/src/components/SearchResultCard.jsx
+++ b/app/frontend/src/components/SearchResultCard.jsx
@@ -1,8 +1,9 @@
 import { Link } from 'react-router-dom';
+import HeritageStatusBadge from './HeritageStatusBadge';
 import './SearchResultCard.css';
 
 export default function SearchResultCard({ result }) {
-  const { type, id, title, region, thumbnail, rankScore } = result;
+  const { type, id, title, region, thumbnail, rankScore, heritage_status } = result;
   const href = type === 'recipe' ? `/recipes/${id}` : `/stories/${id}`;
   const accentClass = type === 'recipe' ? 'card-accent-green' : 'card-accent-mustard';
 
@@ -19,6 +20,7 @@ export default function SearchResultCard({ result }) {
           <div className="result-meta-row">
             <span className="result-type">{type}</span>
             {rankScore > 0 && <span className="result-personalized">For you</span>}
+            {type === 'recipe' && <HeritageStatusBadge status={heritage_status} />}
           </div>
           <h3 className="result-card-title">{title}</h3>
           {region && <span className="result-region">{region}</span>}

--- a/app/frontend/src/components/culturalStoryFields.js
+++ b/app/frontend/src/components/culturalStoryFields.js
@@ -1,0 +1,76 @@
+/**
+ * Shared schema for the seven "Beyond the Recipe" narrative notes (#516).
+ *
+ * Field keys mirror `apps.recipes.serializers.CulturalContextSerializer`
+ * (`identity_note`, `memory_note`, `migration_note`, `ritual_note`,
+ * `commensality_note`, `terroir_note`, `craft_note`). Label / hint /
+ * placeholder are the only user-facing strings; rename here to update both
+ * the recipe-detail read view and the create/edit form in one place.
+ */
+export const CULTURAL_STORY_FIELDS = [
+  {
+    key: 'identity_note',
+    label: 'Why this dish matters',
+    hint: 'What this recipe means to you or your community.',
+    placeholder: "e.g. This dish is how I know I'm from Trabzon.",
+  },
+  {
+    key: 'memory_note',
+    label: 'A personal memory',
+    hint: 'A moment, a person, a place this dish brings back.',
+    placeholder: 'e.g. My grandmother stirred this every Sunday morning.',
+  },
+  {
+    key: 'migration_note',
+    label: 'Where it came from',
+    hint: 'How the dish travelled — across families, regions, or continents.',
+    placeholder: 'e.g. Originally a Caucasus recipe, brought to the Aegean in the 1920s.',
+  },
+  {
+    key: 'ritual_note',
+    label: "When it's made",
+    hint: 'The occasions, seasons, or rituals tied to this dish.',
+    placeholder: 'e.g. Only cooked on the first Friday of Ramadan.',
+  },
+  {
+    key: 'commensality_note',
+    label: "How it's shared",
+    hint: 'The serving rituals, who eats it together, the order it appears.',
+    placeholder: 'e.g. Always served at the centre of the table, family-style.',
+  },
+  {
+    key: 'terroir_note',
+    label: 'Taste of place',
+    hint: 'The land, water, climate, ingredients that make it taste right.',
+    placeholder: 'e.g. The corn flour has to come from the Black Sea hills.',
+  },
+  {
+    key: 'craft_note',
+    label: 'The craft',
+    hint: 'The techniques, tools, or knowledge passed down with this recipe.',
+    placeholder: 'e.g. The dough must be slapped — never rolled — by hand.',
+  },
+];
+
+/** Convert a full cultural-context object (any/none of the 7 keys filled) into
+ *  an object that only contains the fields that have a non-blank trimmed
+ *  value. Used at submit time so we never send a payload of empty strings
+ *  that would create an empty `RecipeCulturalContext` row server-side. */
+export function trimCulturalStoryForPayload(values) {
+  const out = {};
+  for (const { key } of CULTURAL_STORY_FIELDS) {
+    const v = typeof values?.[key] === 'string' ? values[key].trim() : '';
+    if (v) out[key] = v;
+  }
+  return out;
+}
+
+/** True if at least one of the seven fields is non-blank. Drives whether the
+ *  read-only section renders at all. */
+export function hasAnyCulturalStory(values) {
+  if (!values || typeof values !== 'object') return false;
+  return CULTURAL_STORY_FIELDS.some((f) => {
+    const v = values[f.key];
+    return typeof v === 'string' && v.trim().length > 0;
+  });
+}

--- a/app/frontend/src/pages/EndangeredListPage.css
+++ b/app/frontend/src/pages/EndangeredListPage.css
@@ -1,0 +1,150 @@
+.endangered-page-header {
+  margin-bottom: 1.5rem;
+}
+
+.endangered-page-header h1 {
+  font-family: var(--font-display);
+  font-size: clamp(1.75rem, 4vw, 2.5rem);
+  margin: 0;
+  color: var(--color-text);
+}
+
+.endangered-page-subtitle {
+  color: var(--color-text-muted);
+  margin: 0.4rem 0 1rem;
+  max-width: 560px;
+  line-height: 1.5;
+}
+
+.endangered-page-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.endangered-page-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.85rem;
+  border-radius: var(--radius-pill);
+  border: 1.5px solid var(--color-border);
+  background: var(--color-surface);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--color-text);
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.endangered-page-tab:hover {
+  border-color: var(--color-primary);
+}
+
+.endangered-page-tab.is-active {
+  background: var(--color-primary-tint);
+  border-color: var(--color-primary);
+}
+
+.endangered-page-tab-label {
+  font-weight: 600;
+}
+
+.endangered-page-status {
+  margin: 2rem 0;
+  color: var(--color-text-muted);
+  text-align: center;
+}
+
+.endangered-page-error {
+  color: var(--color-error, #b91c1c);
+}
+
+.endangered-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.endangered-list-row {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface);
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.endangered-list-row:hover {
+  border-color: var(--color-primary);
+  box-shadow: 0 2px 10px rgba(196, 82, 30, 0.08);
+}
+
+.endangered-list-link {
+  display: flex;
+  align-items: stretch;
+  gap: 1rem;
+  padding: 0.85rem;
+  text-decoration: none;
+  color: inherit;
+}
+
+.endangered-list-thumb {
+  width: 88px;
+  height: 88px;
+  flex-shrink: 0;
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  background: var(--color-surface-dark);
+}
+
+.endangered-list-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.endangered-list-placeholder {
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(135deg, var(--color-accent-green-tint), var(--color-primary-subtle));
+}
+
+.endangered-list-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  flex: 1;
+  min-width: 0;
+}
+
+.endangered-list-meta-top {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.endangered-list-region {
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  font-weight: 600;
+}
+
+.endangered-list-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--color-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.endangered-list-author {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+}

--- a/app/frontend/src/pages/EndangeredListPage.jsx
+++ b/app/frontend/src/pages/EndangeredListPage.jsx
@@ -1,0 +1,101 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { fetchRecipesByHeritageStatus } from '../services/recipeService';
+import HeritageStatusBadge from '../components/HeritageStatusBadge';
+import './EndangeredListPage.css';
+
+const STATUS_FILTERS = [
+  { key: 'endangered', label: 'Endangered' },
+  { key: 'revived',    label: 'Revived' },
+  { key: 'preserved',  label: 'Preserved' },
+];
+
+function RecipeRow({ recipe }) {
+  return (
+    <li className="endangered-list-row">
+      <Link to={`/recipes/${recipe.id}`} className="endangered-list-link">
+        <div className="endangered-list-thumb">
+          {recipe.image ? (
+            <img src={recipe.image} alt="" className="endangered-list-image" />
+          ) : (
+            <div className="endangered-list-placeholder" aria-hidden="true" />
+          )}
+        </div>
+        <div className="endangered-list-meta">
+          <div className="endangered-list-meta-top">
+            <HeritageStatusBadge status={recipe.heritage_status} />
+            {recipe.region_name && (
+              <span className="endangered-list-region">📍 {recipe.region_name}</span>
+            )}
+          </div>
+          <h3 className="endangered-list-title">{recipe.title}</h3>
+          {recipe.author_username && (
+            <p className="endangered-list-author">@{recipe.author_username}</p>
+          )}
+        </div>
+      </Link>
+    </li>
+  );
+}
+
+export default function EndangeredListPage() {
+  const [status, setStatus] = useState('endangered');
+  const [recipes, setRecipes] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError('');
+    fetchRecipesByHeritageStatus(status)
+      .then((data) => { if (!cancelled) setRecipes(Array.isArray(data) ? data : []); })
+      .catch(() => { if (!cancelled) setError('Could not load endangered recipes.'); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [status]);
+
+  return (
+    <main className="page-card endangered-page">
+      <header className="endangered-page-header">
+        <h1>Endangered &amp; heritage recipes</h1>
+        <p className="endangered-page-subtitle">
+          Dishes flagged at risk, actively preserved, or revived by their
+          communities. Cook them, share them, keep them on the table.
+        </p>
+        <div className="endangered-page-tabs" role="tablist" aria-label="Heritage status">
+          {STATUS_FILTERS.map((f) => (
+            <button
+              key={f.key}
+              type="button"
+              role="tab"
+              aria-selected={status === f.key}
+              className={`endangered-page-tab${status === f.key ? ' is-active' : ''}`}
+              onClick={() => setStatus(f.key)}
+            >
+              <HeritageStatusBadge status={f.key} />
+              <span className="endangered-page-tab-label">{f.label}</span>
+            </button>
+          ))}
+        </div>
+      </header>
+
+      {loading && <p className="endangered-page-status">Loading…</p>}
+      {error && (
+        <p className="endangered-page-status endangered-page-error" role="alert">
+          {error}
+        </p>
+      )}
+      {!loading && !error && recipes.length === 0 && (
+        <p className="endangered-page-status">
+          No recipes flagged as {STATUS_FILTERS.find((f) => f.key === status)?.label.toLowerCase()} yet.
+        </p>
+      )}
+      {!loading && !error && recipes.length > 0 && (
+        <ul className="endangered-list">
+          {recipes.map((r) => <RecipeRow key={r.id} recipe={r} />)}
+        </ul>
+      )}
+    </main>
+  );
+}

--- a/app/frontend/src/pages/MigrationRoutesPage.css
+++ b/app/frontend/src/pages/MigrationRoutesPage.css
@@ -1,0 +1,153 @@
+.migration-routes-page {
+  max-width: none;
+}
+
+.migration-routes-header {
+  margin-bottom: 1rem;
+}
+
+.migration-routes-header h1 {
+  font-family: var(--font-display);
+  font-size: clamp(1.75rem, 4vw, 2.5rem);
+  margin: 0;
+  color: var(--color-text);
+}
+
+.migration-routes-subtitle {
+  color: var(--color-text-muted);
+  margin: 0.4rem 0 0;
+  max-width: 600px;
+  line-height: 1.5;
+}
+
+.migration-routes-status {
+  margin: 2.5rem 0;
+  text-align: center;
+  color: var(--color-text-muted);
+}
+
+.migration-routes-error {
+  color: var(--color-error, #b91c1c);
+}
+
+.migration-routes-layout {
+  display: grid;
+  grid-template-columns: minmax(220px, 280px) 1fr;
+  gap: 1.25rem;
+  margin-top: 1rem;
+}
+
+@media (max-width: 720px) {
+  .migration-routes-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+.migration-routes-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  padding: 1rem;
+  background: var(--color-surface);
+  border: 1.5px solid var(--color-border);
+  border-radius: var(--radius-lg);
+}
+
+.migration-routes-picker-label {
+  font-size: 0.78rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-muted);
+}
+
+.migration-routes-picker-select {
+  padding: 0.55rem 0.7rem;
+  border: 1.5px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface-input);
+  font-family: inherit;
+  font-size: 0.95rem;
+  color: var(--color-text);
+}
+
+.migration-routes-picker-select:focus {
+  outline: none;
+  border-color: var(--color-primary);
+}
+
+.migration-routes-anim-controls {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.migration-routes-waypoint-list-heading {
+  font-size: 0.85rem;
+  margin: 0 0 0.35rem;
+  color: var(--color-text);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  font-weight: 700;
+}
+
+.migration-routes-waypoint-list ol {
+  list-style: decimal;
+  padding-left: 1.2rem;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.migration-routes-waypoint {
+  display: flex;
+  flex-direction: column;
+  gap: 0.05rem;
+  font-size: 0.85rem;
+  color: var(--color-text);
+  transition: opacity 0.2s ease;
+}
+
+.migration-routes-waypoint.is-pending {
+  opacity: 0.35;
+}
+
+.migration-routes-waypoint-era {
+  font-size: 0.7rem;
+  color: var(--color-text-muted);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.migration-routes-waypoint-label {
+  font-weight: 600;
+}
+
+.migration-routes-map-wrap {
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  border: 1.5px solid var(--color-border);
+  background: var(--color-surface);
+}
+
+.migration-routes-leaflet {
+  height: 520px;
+  width: 100%;
+}
+
+.migration-routes-popup {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.migration-routes-popup-label {
+  color: var(--color-text);
+}
+
+.migration-routes-popup-era {
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+}

--- a/app/frontend/src/pages/MigrationRoutesPage.jsx
+++ b/app/frontend/src/pages/MigrationRoutesPage.jsx
@@ -1,0 +1,253 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { MapContainer, TileLayer, CircleMarker, Polyline, Popup } from 'react-leaflet';
+import 'leaflet/dist/leaflet.css';
+import { fetchIngredientRoutes } from '../services/ingredientRouteService';
+import './MigrationRoutesPage.css';
+
+const DEFAULT_CENTER = [25, 15];
+const DEFAULT_ZOOM = 2;
+const ANIMATION_STEP_MS = 650;
+
+/**
+ * Coerce a waypoint shape into `{ lat, lng, era, label }` with numeric coords
+ * or null when the payload is broken. Backend ships a JSONField, so we never
+ * fully trust the structure.
+ */
+function normaliseWaypoint(raw) {
+  const lat = Number(raw?.lat);
+  const lng = Number(raw?.lng);
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null;
+  return {
+    lat,
+    lng,
+    era: typeof raw?.era === 'string' ? raw.era : '',
+    label: typeof raw?.label === 'string' ? raw.label : '',
+  };
+}
+
+function normaliseRoute(route) {
+  const waypoints = Array.isArray(route?.waypoints)
+    ? route.waypoints.map(normaliseWaypoint).filter(Boolean)
+    : [];
+  return {
+    id: route?.id,
+    ingredient: route?.ingredient,
+    ingredient_name: route?.ingredient_name || `Ingredient #${route?.ingredient ?? '?'}`,
+    waypoints,
+  };
+}
+
+export default function MigrationRoutesPage() {
+  const [routes, setRoutes] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [selectedId, setSelectedId] = useState(null);
+  const [animatedCount, setAnimatedCount] = useState(null); // null => static
+  const animationTimerRef = useRef(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchIngredientRoutes()
+      .then((data) => {
+        if (cancelled) return;
+        const cleaned = (data || []).map(normaliseRoute).filter((r) => r.waypoints.length >= 2);
+        setRoutes(cleaned);
+        if (cleaned.length > 0) setSelectedId(cleaned[0].id);
+      })
+      .catch(() => { if (!cancelled) setError('Could not load migration routes.'); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, []);
+
+  // Clear any pending animation timer when the page unmounts or the route
+  // selection flips — we never want a stale tick advancing into a different
+  // ingredient's waypoints.
+  useEffect(() => {
+    return () => {
+      if (animationTimerRef.current) {
+        clearInterval(animationTimerRef.current);
+        animationTimerRef.current = null;
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (animationTimerRef.current) {
+      clearInterval(animationTimerRef.current);
+      animationTimerRef.current = null;
+    }
+    setAnimatedCount(null);
+  }, [selectedId]);
+
+  const selected = useMemo(
+    () => routes.find((r) => r.id === selectedId) || null,
+    [routes, selectedId],
+  );
+
+  const visibleWaypoints = useMemo(() => {
+    if (!selected) return [];
+    if (animatedCount === null) return selected.waypoints;
+    return selected.waypoints.slice(0, animatedCount);
+  }, [selected, animatedCount]);
+
+  function startAnimation() {
+    if (!selected || selected.waypoints.length < 2) return;
+    if (animationTimerRef.current) clearInterval(animationTimerRef.current);
+    setAnimatedCount(1);
+    animationTimerRef.current = setInterval(() => {
+      setAnimatedCount((current) => {
+        const next = (current ?? 0) + 1;
+        if (next >= selected.waypoints.length) {
+          if (animationTimerRef.current) {
+            clearInterval(animationTimerRef.current);
+            animationTimerRef.current = null;
+          }
+          return selected.waypoints.length;
+        }
+        return next;
+      });
+    }, ANIMATION_STEP_MS);
+  }
+
+  function resetAnimation() {
+    if (animationTimerRef.current) {
+      clearInterval(animationTimerRef.current);
+      animationTimerRef.current = null;
+    }
+    setAnimatedCount(null);
+  }
+
+  const polylinePositions = visibleWaypoints.map((w) => [w.lat, w.lng]);
+  const mapCenter = selected?.waypoints?.[0]
+    ? [selected.waypoints[0].lat, selected.waypoints[0].lng]
+    : DEFAULT_CENTER;
+
+  return (
+    <main className="page-card migration-routes-page">
+      <header className="migration-routes-header">
+        <h1>Ingredient migration routes</h1>
+        <p className="migration-routes-subtitle">
+          How everyday ingredients travelled across the world, from their
+          earliest known origins to the kitchens we cook in today.
+        </p>
+      </header>
+
+      {loading && <p className="migration-routes-status">Loading routes…</p>}
+      {error && (
+        <p className="migration-routes-status migration-routes-error" role="alert">
+          {error}
+        </p>
+      )}
+
+      {!loading && !error && routes.length === 0 && (
+        <p className="migration-routes-status">
+          No ingredient migration routes have been curated yet.
+        </p>
+      )}
+
+      {!loading && !error && routes.length > 0 && (
+        <div className="migration-routes-layout">
+          <aside className="migration-routes-picker" aria-label="Pick an ingredient">
+            <label htmlFor="ingredient-picker" className="migration-routes-picker-label">
+              Ingredient
+            </label>
+            <select
+              id="ingredient-picker"
+              className="migration-routes-picker-select"
+              value={selectedId ?? ''}
+              onChange={(e) => setSelectedId(Number(e.target.value))}
+            >
+              {routes.map((r) => (
+                <option key={r.id} value={r.id}>{r.ingredient_name}</option>
+              ))}
+            </select>
+
+            <div className="migration-routes-anim-controls">
+              <button
+                type="button"
+                className="btn btn-outline btn-sm"
+                onClick={startAnimation}
+                disabled={!selected || selected.waypoints.length < 2}
+              >
+                ▶ Animate route
+              </button>
+              <button
+                type="button"
+                className="btn btn-outline btn-sm"
+                onClick={resetAnimation}
+                disabled={animatedCount === null}
+              >
+                Reset
+              </button>
+            </div>
+
+            {selected && (
+              <div className="migration-routes-waypoint-list">
+                <h2 className="migration-routes-waypoint-list-heading">Waypoints</h2>
+                <ol>
+                  {selected.waypoints.map((wp, i) => {
+                    const isReached =
+                      animatedCount === null || i < animatedCount;
+                    return (
+                      <li
+                        key={`${wp.label}-${i}`}
+                        className={`migration-routes-waypoint${isReached ? '' : ' is-pending'}`}
+                      >
+                        <span className="migration-routes-waypoint-era">{wp.era || '—'}</span>
+                        <span className="migration-routes-waypoint-label">{wp.label || `${wp.lat.toFixed(1)}, ${wp.lng.toFixed(1)}`}</span>
+                      </li>
+                    );
+                  })}
+                </ol>
+              </div>
+            )}
+          </aside>
+
+          <div className="migration-routes-map-wrap">
+            <MapContainer
+              center={mapCenter}
+              zoom={DEFAULT_ZOOM}
+              className="migration-routes-leaflet"
+              scrollWheelZoom={false}
+            >
+              <TileLayer
+                url="https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png"
+                attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>'
+              />
+              {polylinePositions.length >= 2 && (
+                <Polyline
+                  positions={polylinePositions}
+                  pathOptions={{ color: '#C4521E', weight: 3, opacity: 0.85 }}
+                />
+              )}
+              {visibleWaypoints.map((wp, i) => (
+                <CircleMarker
+                  key={`wp-${selected?.id}-${i}`}
+                  center={[wp.lat, wp.lng]}
+                  radius={i === 0 ? 9 : 7}
+                  pathOptions={{
+                    color: '#A3401A',
+                    fillColor: i === 0 ? '#C4521E' : '#FAF7EF',
+                    fillOpacity: 0.9,
+                    weight: 2,
+                  }}
+                >
+                  <Popup>
+                    <div className="migration-routes-popup">
+                      <strong className="migration-routes-popup-label">
+                        {wp.label || `${wp.lat.toFixed(2)}, ${wp.lng.toFixed(2)}`}
+                      </strong>
+                      {wp.era && (
+                        <span className="migration-routes-popup-era">{wp.era}</span>
+                      )}
+                    </div>
+                  </Popup>
+                </CircleMarker>
+              ))}
+            </MapContainer>
+          </div>
+        </div>
+      )}
+    </main>
+  );
+}

--- a/app/frontend/src/pages/OnboardingPage.jsx
+++ b/app/frontend/src/pages/OnboardingPage.jsx
@@ -5,30 +5,74 @@ import { extractApiError } from '../services/api';
 import { updateMe } from '../services/authService';
 import './OnboardingPage.css';
 
+// Option strings are sourced from the canonical seed in
+// `app/backend/fixtures/seed_canonical.json` (#883). Casing and wording must
+// match exactly — the recommendations engine joins user preferences against
+// recipe/story tags by string equality, so a "ghost" tag here silently
+// breaks personalisation.
 const STEPS = [
   {
     key: 'cultural_interests',
     title: 'Cultural Interests',
     description: 'Choose cuisines and traditions you want to explore.',
-    options: ['Ottoman', 'Anatolian', 'Balkan', 'Levantine', 'Mediterranean', 'Central Asian'],
+    // Matches `users[].cultural_interests` values used in the seed.
+    options: [
+      'Turkish cuisine',
+      'Mediterranean diet',
+      'Levantine cuisine',
+      'Aegean cuisine',
+      'Black Sea traditions',
+      'street food',
+      'food history',
+      'fermentation',
+    ],
   },
   {
     key: 'regional_ties',
     title: 'Regional Ties',
     description: 'Select regions connected to your family or roots.',
-    options: ['Aegean', 'Marmara', 'Central Anatolia', 'Black Sea', 'Mediterranean', 'Southeastern Anatolia'],
+    // Matches canonical `Region.name` values (see
+    // `app/backend/apps/recipes/migrations/0004_seed_regions.py`).
+    options: [
+      'Aegean',
+      'Marmara',
+      'Black Sea',
+      'Anatolian',
+      'Mediterranean',
+      'Levantine',
+      'North African',
+      'Southeastern Anatolia',
+    ],
   },
   {
     key: 'religious_preferences',
     title: 'Dietary / Religious Preferences',
     description: 'Pick preferences to personalize recommendations.',
-    options: ['Halal', 'Kosher', 'Vegetarian', 'Vegan', 'Pescetarian', 'No Preference'],
+    // Mix of canonical `dietary_tags` and `religions` values used in the seed.
+    options: [
+      'Halal',
+      'Vegan',
+      'Vegetarian',
+      'Gluten-Free',
+      'Dairy-Free',
+      'Kosher',
+      'Islam',
+      'Christianity',
+    ],
   },
   {
     key: 'event_interests',
     title: 'Event Interests',
     description: 'Choose occasions you cook for most often.',
-    options: ['Ramadan', 'Eid', 'Weddings', 'Family Gatherings', 'Religious Holidays', 'Weeknight Meals'],
+    // Matches canonical `event_tags` values used in the seed.
+    options: [
+      'Religious Holiday',
+      'Wedding',
+      'Birthday',
+      'Anniversary',
+      'Funeral',
+      'Graduation',
+    ],
   },
 ];
 

--- a/app/frontend/src/pages/RecipeCreatePage.jsx
+++ b/app/frontend/src/pages/RecipeCreatePage.jsx
@@ -4,6 +4,8 @@ import IngredientRow from '../components/IngredientRow';
 import StepsEditor from '../components/StepsEditor';
 import Toast from '../components/Toast';
 import DraftRestoreBanner from '../components/DraftRestoreBanner';
+import CulturalStoryForm from '../components/CulturalStoryForm';
+import { trimCulturalStoryForPayload } from '../components/culturalStoryFields';
 import useDraftAutosave from '../hooks/useDraftAutosave';
 import {
   createRecipe,
@@ -53,6 +55,7 @@ export default function RecipeCreatePage() {
   const [qaEnabled, setQaEnabled] = useState(true);
   const [rows, setRows] = useState([makeRow()]);
   const [steps, setSteps] = useState([]);
+  const [culturalStory, setCulturalStory] = useState({});
 
   const [ingredients, setIngredients] = useState([]);
   const [units, setUnits] = useState([]);
@@ -168,6 +171,7 @@ export default function RecipeCreatePage() {
     const cleanedSteps = steps
       .map((s) => (typeof s === 'string' ? s.trim() : ''))
       .filter((s) => s.length > 0);
+    const culturalPayload = trimCulturalStoryForPayload(culturalStory);
     const payload = {
       title,
       description,
@@ -180,6 +184,9 @@ export default function RecipeCreatePage() {
         amount: r.amount,
         unit: r.unitId,
       })),
+      ...(Object.keys(culturalPayload).length > 0
+        ? { cultural_context: culturalPayload }
+        : {}),
     };
 
     setSubmitting(true);
@@ -354,6 +361,14 @@ export default function RecipeCreatePage() {
             hint="Walk readers through the recipe one step at a time. Order matters — use the arrows to reorder. Empty steps are skipped on save."
           />
           <StepsEditor value={steps} onChange={handleStepsChange} />
+
+          <CulturalStoryForm
+            values={culturalStory}
+            onChange={(key, value) => {
+              markDirty();
+              setCulturalStory((prev) => ({ ...prev, [key]: value }));
+            }}
+          />
         </section>
 
         {/* ── Step 4: Media & options ── */}

--- a/app/frontend/src/pages/RecipeDetailPage.jsx
+++ b/app/frontend/src/pages/RecipeDetailPage.jsx
@@ -7,6 +7,7 @@ import { fetchSubstitutes } from '../services/ingredientService';
 import { fetchCheckedIngredients, toggleCheckedIngredient } from '../services/checkOffService';
 import RecipeCommentsSection from '../components/RecipeCommentsSection';
 import HeritageBadge from '../components/HeritageBadge';
+import EndangeredHeritageSection from '../components/EndangeredHeritageSection';
 import CulturalFactCard from '../components/CulturalFactCard';
 import StarRating from '../components/StarRating';
 import { fetchCulturalFacts } from '../services/culturalFactService';
@@ -507,6 +508,11 @@ export default function RecipeDetailPage() {
           <HeritageBadge group={recipe.heritage_group} />
         </section>
       )}
+
+      <EndangeredHeritageSection
+        status={recipe.heritage_status}
+        notes={recipe.endangered_notes}
+      />
 
       {recipeFacts.length > 0 && (
         <section className="recipe-cultural-facts">

--- a/app/frontend/src/pages/RecipeDetailPage.jsx
+++ b/app/frontend/src/pages/RecipeDetailPage.jsx
@@ -8,6 +8,7 @@ import { fetchCheckedIngredients, toggleCheckedIngredient } from '../services/ch
 import RecipeCommentsSection from '../components/RecipeCommentsSection';
 import HeritageBadge from '../components/HeritageBadge';
 import EndangeredHeritageSection from '../components/EndangeredHeritageSection';
+import CulturalStorySection from '../components/CulturalStorySection';
 import CulturalFactCard from '../components/CulturalFactCard';
 import StarRating from '../components/StarRating';
 import { fetchCulturalFacts } from '../services/culturalFactService';
@@ -513,6 +514,8 @@ export default function RecipeDetailPage() {
         status={recipe.heritage_status}
         notes={recipe.endangered_notes}
       />
+
+      <CulturalStorySection culturalContext={recipe.cultural_context} />
 
       {recipeFacts.length > 0 && (
         <section className="recipe-cultural-facts">

--- a/app/frontend/src/pages/RecipeEditPage.jsx
+++ b/app/frontend/src/pages/RecipeEditPage.jsx
@@ -3,6 +3,8 @@ import { useParams, useNavigate, Navigate } from 'react-router-dom';
 import { AuthContext } from '../context/AuthContext';
 import IngredientRow from '../components/IngredientRow';
 import StepsEditor from '../components/StepsEditor';
+import CulturalStoryForm from '../components/CulturalStoryForm';
+import { CULTURAL_STORY_FIELDS, trimCulturalStoryForPayload } from '../components/culturalStoryFields';
 import Toast from '../components/Toast';
 import DraftRestoreBanner from '../components/DraftRestoreBanner';
 import useDraftAutosave from '../hooks/useDraftAutosave';
@@ -53,6 +55,7 @@ export default function RecipeEditPage() {
   const [qaEnabled, setQaEnabled] = useState(false);
   const [rows, setRows] = useState([]);
   const [steps, setSteps] = useState([]);
+  const [culturalStory, setCulturalStory] = useState({});
   const [ingredients, setIngredients] = useState([]);
   const [units, setUnits] = useState([]);
   const [regions, setRegions] = useState([]);
@@ -84,6 +87,15 @@ export default function RecipeEditPage() {
             : [makeEmptyRow()]
         );
         setSteps(Array.isArray(recipeData.steps) ? recipeData.steps : []);
+        // Pre-fill cultural story when the recipe already carries one (#516).
+        if (recipeData.cultural_context && typeof recipeData.cultural_context === 'object') {
+          const next = {};
+          for (const { key } of CULTURAL_STORY_FIELDS) {
+            const v = recipeData.cultural_context[key];
+            next[key] = typeof v === 'string' ? v : '';
+          }
+          setCulturalStory(next);
+        }
         setIngredients(ings);
         setUnits(uns);
       })
@@ -164,6 +176,7 @@ export default function RecipeEditPage() {
     const cleanedSteps = steps
       .map((s) => (typeof s === 'string' ? s.trim() : ''))
       .filter((s) => s.length > 0);
+    const culturalPayload = trimCulturalStoryForPayload(culturalStory);
     const payload = {
       title,
       description,
@@ -171,6 +184,9 @@ export default function RecipeEditPage() {
       qa_enabled: qaEnabled,
       is_published: publish,
       steps: cleanedSteps,
+      // Always send cultural_context on edit so emptied fields persist back
+      // as blanks (the serializer keys default to '' on the model side).
+      cultural_context: culturalPayload,
       ingredients_write: validRows.map((r) => ({
         ingredient: r.ingredientId,
         amount: r.amount,
@@ -309,6 +325,13 @@ export default function RecipeEditPage() {
             Walk readers through the recipe one step at a time. Order matters — use the arrows to reorder. Empty steps are skipped on save.
           </p>
           <StepsEditor value={steps} onChange={setSteps} />
+
+          <CulturalStoryForm
+            values={culturalStory}
+            onChange={(key, value) =>
+              setCulturalStory((prev) => ({ ...prev, [key]: value }))
+            }
+          />
         </section>
 
         <div className="recipe-form-actions">

--- a/app/frontend/src/services/ingredientRouteService.js
+++ b/app/frontend/src/services/ingredientRouteService.js
@@ -1,0 +1,35 @@
+import { apiClient } from './api';
+
+const USE_MOCK = process.env.REACT_APP_USE_MOCK === 'true';
+
+/**
+ * Fetch every published ingredient migration route (#514). Backend may return
+ * either a DRF-paginated `{ results: [...] }` envelope or a bare array
+ * (depending on whether default pagination is on for `IngredientRouteViewSet`)
+ * — normalise to a plain array here so callers stay simple.
+ *
+ * `USE_MOCK=true` returns an empty list rather than a stub fixture: the
+ * page renders an empty-state CTA instead of pretending we have routes.
+ */
+function unwrap(payload) {
+  if (Array.isArray(payload)) return payload;
+  if (payload && Array.isArray(payload.results)) return payload.results;
+  return [];
+}
+
+export async function fetchIngredientRoutes() {
+  if (USE_MOCK) return [];
+  const response = await apiClient.get('/api/ingredient-routes/', {
+    params: { page_size: 50 },
+  });
+  return unwrap(response.data);
+}
+
+/** Fetch routes for one ingredient (server-side `?ingredient=<id>` filter). */
+export async function fetchIngredientRoutesByIngredient(ingredientId) {
+  if (USE_MOCK) return [];
+  const response = await apiClient.get('/api/ingredient-routes/', {
+    params: { ingredient: ingredientId, page_size: 50 },
+  });
+  return unwrap(response.data);
+}

--- a/app/frontend/src/services/recipeService.js
+++ b/app/frontend/src/services/recipeService.js
@@ -73,6 +73,19 @@ export async function fetchRecipes() {
   return response.data.results ?? response.data;
 }
 
+/**
+ * Fetch recipes filtered by `heritage_status` (#520). Backend accepts a
+ * comma-separated list (e.g. `endangered,revived`); we send a single value
+ * for the `/endangered` listing page.
+ */
+export async function fetchRecipesByHeritageStatus(status) {
+  if (USE_MOCK) return [];
+  const response = await apiClient.get('/api/recipes/', {
+    params: { heritage_status: status, page_size: 100 },
+  });
+  return response.data.results ?? response.data;
+}
+
 export async function fetchDietaryTags() {
   if (USE_MOCK) return [];
   const response = await apiClient.get('/api/dietary-tags/');


### PR DESCRIPTION
## Summary

Closes the remaining web-frontend QA issues in the cultural-personalisation batch. Each issue lands as its own commit so reviewers can read (or revert) one at a time.

* **#883 (commit 1)** — Onboarding `STEPS` options now mirror `seed_canonical.json` strings exactly (`Turkish cuisine`, `Aegean`, `Halal`, `Wedding`, …). Onboarding selections now actually surface matching content from the recommendations engine. Web only; the mobile counterpart in `OnboardingScreen.tsx` is being handled in a separate PR by the mobile owner.
* **#520 (commit 2)** — New `HeritageStatusBadge` (amber / green / blue per the issue spec), `EndangeredHeritageSection` on `RecipeDetailPage` (status info card + sourced notes), and a new `/endangered` listing page with Endangered / Revived / Preserved tabs. `SearchResultCard` also picks up the badge when `heritage_status` is in its payload, so existing rails will light up the moment search starts surfacing the field.
* **#516 (commit 3)** — `CulturalStorySection` on `RecipeDetailPage` (renders only the filled notes), plus a collapsible "Tell Your Story" panel on `RecipeCreatePage` and `RecipeEditPage`. Seven optional narrative notes round-trip through `cultural_context` on the recipe JSON payload; edit page sends `cultural_context` even when emptied so previously-filled notes can be cleared back to blank.
* **#514 (commit 4)** — New `/migration-routes` page. Ingredient picker (native `<select>`) plus a Leaflet map with a chronological polyline + waypoint markers + popups (location, era). Optional sequential reveal via a plain `setInterval`/`animatedCount` index — no SVG `stroke-dasharray` trickery or animation library, so the polyline always renders correctly. Animation is off by default; the static map is the safe baseline.

Closes #883
Closes #520
Closes #516
Closes #514

## Out of scope

- Mobile portion of #883 (`app/mobile/src/screens/OnboardingScreen.tsx`).
- #398 umbrella will be closed manually once this PR ships.
- Adding `heritage_status` to the unified `/api/search/` payload (the badge on `SearchResultCard` no-ops there today).

## Test plan

- [ ] `cd app/frontend && CI=true npm test -- --watchAll=false` — 100 suites / 846 tests pass.
- [ ] Visit `/onboarding`, pick "Turkish cuisine" → "Aegean" → "Halal" → "Wedding", finish; home feed surfaces matching seed recipes/stories.
- [ ] Open a seed recipe with `heritage_status: endangered` — amber badge on detail, full info card with sourced notes list (each note's "Source ↗" opens in a new tab).
- [ ] Open `/endangered` — flip between Endangered / Revived / Preserved tabs; list refetches each time. Empty / error / loading states all render.
- [ ] On a recipe with a populated `cultural_context`, the "Beyond the Recipe" section renders one card per filled note.
- [ ] Open `/recipes/new` → expand "Tell Your Story" → fill any subset → publish. Reopen edit and confirm the fields round-trip; clear one and save and confirm the cleared note disappears on detail.
- [ ] Visit `/migration-routes` — pick Tomato; static polyline + markers render. Click "Animate route"; waypoints reveal sequentially (~650 ms steps). Click "Reset" — clears back to static.